### PR TITLE
feat: add support for `begin` expression

### DIFF
--- a/tests/contracts/begin.clar
+++ b/tests/contracts/begin.clar
@@ -1,0 +1,8 @@
+(define-public (simple)
+    (ok
+        (begin
+            (+ 1 2)
+            (+ 3 4)
+        )
+    )
+)

--- a/tests/tests/lib_tests.rs
+++ b/tests/tests/lib_tests.rs
@@ -175,3 +175,8 @@ test_contract!(test_fold, "fold", "fold-sub", |response: ResponseData| {
     assert!(response.committed);
     assert_eq!(*response.data, Value::Int(2));
 });
+
+test_contract!(test_begin, "begin", "simple", |response: ResponseData| {
+    assert!(response.committed);
+    assert_eq!(*response.data, Value::Int(7));
+});


### PR DESCRIPTION
The non-obvious feature here is to throw away unused return values for the statements in the list, except for the last one, whose return value becomes the return value for the `begin` expression.