### PR TITLE
Create property tests for standard.wat functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 **/*.wasm
+**/proptest-regressions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +463,7 @@ dependencies = [
  "clarity-vm",
  "criterion",
  "lazy_static",
+ "proptest",
  "regex",
  "walrus",
  "wasmtime",
@@ -1670,6 +1686,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
+name = "libm"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1820,6 +1842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2050,6 +2073,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
+dependencies = [
+ "bit-set",
+ "bitflags 1.3.2",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_xorshift",
+ "regex-syntax 0.6.29",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2068,6 +2111,12 @@ dependencies = [
  "memchr",
  "unicase",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -2160,6 +2209,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rayon"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2232,7 +2290,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -2243,8 +2301,14 @@ checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.4",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -2457,6 +2521,18 @@ name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rustyline"
@@ -3215,6 +3291,12 @@ name = "ucd-trie"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"

--- a/clar2wasm/Cargo.toml
+++ b/clar2wasm/Cargo.toml
@@ -17,6 +17,7 @@ wat = "1.0.69"
 [dev-dependencies]
 wasmtime = "11.0.1"
 criterion = "0.5.1"
+proptest = "1.2.0"
 
 [lib]
 path = "src/lib.rs"

--- a/clar2wasm/src/lib.rs
+++ b/clar2wasm/src/lib.rs
@@ -13,7 +13,6 @@ use walrus::Module;
 use wasm_generator::WasmGenerator;
 
 mod ast_visitor;
-mod standard;
 mod wasm_generator;
 
 // FIXME: This is copied from stacks-blockchain

--- a/clar2wasm/src/standard/mod.rs
+++ b/clar2wasm/src/standard/mod.rs
@@ -1,2 +1,0 @@
-#[cfg(test)]
-pub mod tests;

--- a/clar2wasm/src/standard/tests.rs
+++ b/clar2wasm/src/standard/tests.rs
@@ -1,3 +1,5 @@
+use proptest::prelude::*;
+
 use std::borrow::BorrowMut;
 use wasmtime::{Caller, Engine, Instance, Linker, Module, Store, Val};
 
@@ -58,11 +60,16 @@ fn load_stdlib() -> Result<(Instance, Store<()>), wasmtime::Error> {
     Ok((instance, store))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 struct PropInt(u128);
 
 impl PropInt {
     const fn new(n: u128) -> Self {
         Self(n)
+    }
+
+    const fn from_wasm(high: i64, low: i64) -> Self {
+        Self(((high as u64) as u128) << 64 | ((low as u64) as u128))
     }
 
     const fn signed(&self) -> i128 {
@@ -79,6 +86,34 @@ impl PropInt {
 
     const fn low(&self) -> i64 {
         self.0 as i64
+    }
+}
+
+prop_compose! {
+    fn int128()(n in any::<u128>()) -> PropInt {
+        PropInt::new(n)
+    }
+}
+
+proptest! {
+    #[test]
+    fn prop_add_uint(n in int128(), m in int128()) {
+        let (instance, mut store) = load_stdlib().unwrap();
+        let add = instance.get_func(store.borrow_mut(), "add-uint").unwrap();
+        let mut sum = [Val::I64(0), Val::I64(0)];
+        let res = add.call(
+            store.borrow_mut(),
+            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &mut sum,
+        );
+        match n.unsigned().checked_add(m.unsigned()) {
+            Some(rust_result) => {
+                res.expect("call to add-uint failed");
+                let wasm_result = PropInt::from_wasm(sum[0].i64().unwrap(), sum[1].i64().unwrap());
+                prop_assert_eq!(rust_result, wasm_result.unsigned());
+            }
+            None => {res.expect_err("expected overflow");}
+        }
     }
 }
 

--- a/clar2wasm/src/standard/tests.rs
+++ b/clar2wasm/src/standard/tests.rs
@@ -1,5 +1,3 @@
-use proptest::prelude::*;
-
 use std::borrow::BorrowMut;
 use wasmtime::{Caller, Engine, Instance, Linker, Module, Store, Val};
 
@@ -58,63 +56,6 @@ fn load_stdlib() -> Result<(Instance, Store<()>), wasmtime::Error> {
     let module = Module::new(&engine, standard_lib).unwrap();
     let instance = linker.instantiate(store.borrow_mut(), &module)?;
     Ok((instance, store))
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-struct PropInt(u128);
-
-impl PropInt {
-    const fn new(n: u128) -> Self {
-        Self(n)
-    }
-
-    const fn from_wasm(high: i64, low: i64) -> Self {
-        Self(((high as u64) as u128) << 64 | ((low as u64) as u128))
-    }
-
-    const fn signed(&self) -> i128 {
-        self.0 as i128
-    }
-
-    const fn unsigned(&self) -> u128 {
-        self.0
-    }
-
-    const fn high(&self) -> i64 {
-        (self.0 >> 64) as i64
-    }
-
-    const fn low(&self) -> i64 {
-        self.0 as i64
-    }
-}
-
-prop_compose! {
-    fn int128()(n in any::<u128>()) -> PropInt {
-        PropInt::new(n)
-    }
-}
-
-proptest! {
-    #[test]
-    fn prop_add_uint(n in int128(), m in int128()) {
-        let (instance, mut store) = load_stdlib().unwrap();
-        let add = instance.get_func(store.borrow_mut(), "add-uint").unwrap();
-        let mut sum = [Val::I64(0), Val::I64(0)];
-        let res = add.call(
-            store.borrow_mut(),
-            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
-            &mut sum,
-        );
-        match n.unsigned().checked_add(m.unsigned()) {
-            Some(rust_result) => {
-                res.expect("call to add-uint failed");
-                let wasm_result = PropInt::from_wasm(sum[0].i64().unwrap(), sum[1].i64().unwrap());
-                prop_assert_eq!(rust_result, wasm_result.unsigned());
-            }
-            None => {res.expect_err("expected overflow");}
-        }
-    }
 }
 
 #[test]

--- a/clar2wasm/src/standard/tests.rs
+++ b/clar2wasm/src/standard/tests.rs
@@ -58,6 +58,30 @@ fn load_stdlib() -> Result<(Instance, Store<()>), wasmtime::Error> {
     Ok((instance, store))
 }
 
+struct PropInt(u128);
+
+impl PropInt {
+    const fn new(n: u128) -> Self {
+        Self(n)
+    }
+
+    const fn signed(&self) -> i128 {
+        self.0 as i128
+    }
+
+    const fn unsigned(&self) -> u128 {
+        self.0
+    }
+
+    const fn high(&self) -> i64 {
+        (self.0 >> 64) as i64
+    }
+
+    const fn low(&self) -> i64 {
+        self.0 as i64
+    }
+}
+
 #[test]
 fn test_add_uint() {
     let (instance, mut store) = load_stdlib().unwrap();

--- a/clar2wasm/tests/standard/main.rs
+++ b/clar2wasm/tests/standard/main.rs
@@ -1,2 +1,3 @@
 mod property_tests;
+mod unit_tests;
 mod utils;

--- a/clar2wasm/tests/standard/main.rs
+++ b/clar2wasm/tests/standard/main.rs
@@ -1,0 +1,2 @@
+mod property_tests;
+mod utils;

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -376,3 +376,41 @@ fn prop_gt_int() {
         prop_assert_eq!(n.signed() > m.signed(), res[0].i32().unwrap() == 1);
     })
 }
+
+#[test]
+fn prop_le_uint() {
+    let (instance, store) = load_stdlib().unwrap();
+    let store = RefCell::new(store);
+    let le = instance
+        .get_func(store.borrow_mut().deref_mut(), "le-uint")
+        .unwrap();
+
+    proptest!(|(n in int128(), m in int128())| {
+        let mut res = [Val::I32(0)];
+        le.call(
+            store.borrow_mut().deref_mut(),
+            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &mut res,
+        ).expect("call to le-uint failed");
+        prop_assert_eq!(n.unsigned() <= m.unsigned(), res[0].i32().unwrap() == 1);
+    })
+}
+
+#[test]
+fn prop_le_int() {
+    let (instance, store) = load_stdlib().unwrap();
+    let store = RefCell::new(store);
+    let le = instance
+        .get_func(store.borrow_mut().deref_mut(), "le-int")
+        .unwrap();
+
+    proptest!(|(n in int128(), m in int128())| {
+        let mut res = [Val::I32(0)];
+        le.call(
+            store.borrow_mut().deref_mut(),
+            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &mut res,
+        ).expect("call to le-int failed");
+        prop_assert_eq!(n.signed() <= m.signed(), res[0].i32().unwrap() == 1);
+    })
+}

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -83,7 +83,7 @@ fn prop_add_int() {
         );
         match n.signed().checked_add(m.signed()) {
             Some(rust_result) => {
-                call.expect("call to add-uint failed");
+                call.expect("call to add-int failed");
                 let wasm_result = PropInt::from_wasm(res[0].i64().unwrap(), res[1].i64().unwrap());
                 prop_assert_eq!(rust_result, wasm_result.signed());
             }
@@ -109,7 +109,7 @@ fn prop_sub_uint() {
         );
         match n.unsigned().checked_sub(m.unsigned()) {
             Some(rust_result) => {
-                call.expect("call to add-uint failed");
+                call.expect("call to sub-uint failed");
                 let wasm_result = PropInt::from_wasm(res[0].i64().unwrap(), res[1].i64().unwrap());
                 prop_assert_eq!(rust_result, wasm_result.unsigned());
             }
@@ -135,11 +135,63 @@ fn prop_sub_int() {
         );
         match n.signed().checked_sub(m.signed()) {
             Some(rust_result) => {
-                call.expect("call to add-uint failed");
+                call.expect("call to sub-int failed");
                 let wasm_result = PropInt::from_wasm(res[0].i64().unwrap(), res[1].i64().unwrap());
                 prop_assert_eq!(rust_result, wasm_result.signed());
             }
             None => { call.expect_err("expected underflow"); }
+        }
+    })
+}
+
+#[test]
+fn prop_mul_uint() {
+    let (instance, store) = load_stdlib().unwrap();
+    let store = RefCell::new(store);
+    let mul = instance
+        .get_func(store.borrow_mut().deref_mut(), "mul-uint")
+        .unwrap();
+
+    proptest!(|(n in int128(), m in int128())| {
+        let mut res = [Val::I64(0), Val::I64(0)];
+        let call = mul.call(
+            store.borrow_mut().deref_mut(),
+            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &mut res,
+        );
+        match n.unsigned().checked_mul(m.unsigned()) {
+            Some(rust_result) => {
+                call.expect("call to mul-int failed");
+                let wasm_result = PropInt::from_wasm(res[0].i64().unwrap(), res[1].i64().unwrap());
+                prop_assert_eq!(rust_result, wasm_result.unsigned());
+            }
+            None => { call.expect_err("expected overrflow"); }
+        }
+    })
+}
+
+#[test]
+fn prop_mul_int() {
+    let (instance, store) = load_stdlib().unwrap();
+    let store = RefCell::new(store);
+    let mul = instance
+        .get_func(store.borrow_mut().deref_mut(), "mul-int")
+        .unwrap();
+
+    proptest!(|(n in int128(), m in int128())| {
+        let mut res = [Val::I64(0), Val::I64(0)];
+        let call = mul.call(
+            store.borrow_mut().deref_mut(),
+            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &mut res,
+        );
+        match n.signed().checked_mul(m.signed()) {
+            Some(rust_result) => {
+                call.expect("call to mul-int failed");
+                let wasm_result = PropInt::from_wasm(res[0].i64().unwrap(), res[1].i64().unwrap());
+                prop_assert_eq!(rust_result, wasm_result.signed());
+            }
+            None => { call.expect_err("expected overflow"); }
         }
     })
 }

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -1,0 +1,61 @@
+use crate::utils::load_stdlib;
+
+use proptest::prelude::*;
+use wasmtime::Val;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct PropInt(u128);
+
+impl PropInt {
+    const fn new(n: u128) -> Self {
+        Self(n)
+    }
+
+    const fn from_wasm(high: i64, low: i64) -> Self {
+        Self(((high as u64) as u128) << 64 | ((low as u64) as u128))
+    }
+
+    const fn signed(&self) -> i128 {
+        self.0 as i128
+    }
+
+    const fn unsigned(&self) -> u128 {
+        self.0
+    }
+
+    const fn high(&self) -> i64 {
+        (self.0 >> 64) as i64
+    }
+
+    const fn low(&self) -> i64 {
+        self.0 as i64
+    }
+}
+
+prop_compose! {
+    fn int128()(n in any::<u128>()) -> PropInt {
+        PropInt::new(n)
+    }
+}
+
+proptest! {
+    #[test]
+    fn prop_add_uint(n in int128(), m in int128()) {
+        let (instance, mut store) = load_stdlib().unwrap();
+        let add = instance.get_func(&mut store, "add-uint").unwrap();
+        let mut sum = [Val::I64(0), Val::I64(0)];
+        let res = add.call(
+            &mut store,
+            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &mut sum,
+        );
+        match n.unsigned().checked_add(m.unsigned()) {
+            Some(rust_result) => {
+                res.expect("call to add-uint failed");
+                let wasm_result = PropInt::from_wasm(sum[0].i64().unwrap(), sum[1].i64().unwrap());
+                prop_assert_eq!(rust_result, wasm_result.unsigned());
+            }
+            None => {res.expect_err("expected overflow");}
+        }
+    }
+}

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -300,3 +300,41 @@ fn prop_mod_int() {
         }
     })
 }
+
+#[test]
+fn prop_lt_uint() {
+    let (instance, store) = load_stdlib().unwrap();
+    let store = RefCell::new(store);
+    let lt = instance
+        .get_func(store.borrow_mut().deref_mut(), "lt-uint")
+        .unwrap();
+
+    proptest!(|(n in int128(), m in int128())| {
+        let mut res = [Val::I32(0)];
+        lt.call(
+            store.borrow_mut().deref_mut(),
+            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &mut res,
+        ).expect("call to lt-uint failed");
+        prop_assert_eq!(n.unsigned() < m.unsigned(), res[0].i32().unwrap() == 1);
+    })
+}
+
+#[test]
+fn prop_lt_int() {
+    let (instance, store) = load_stdlib().unwrap();
+    let store = RefCell::new(store);
+    let lt = instance
+        .get_func(store.borrow_mut().deref_mut(), "lt-int")
+        .unwrap();
+
+    proptest!(|(n in int128(), m in int128())| {
+        let mut res = [Val::I32(0)];
+        lt.call(
+            store.borrow_mut().deref_mut(),
+            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &mut res,
+        ).expect("call to lt-uint failed");
+        prop_assert_eq!(n.signed() < m.signed(), res[0].i32().unwrap() == 1);
+    })
+}

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -161,11 +161,11 @@ fn prop_mul_uint() {
         );
         match n.unsigned().checked_mul(m.unsigned()) {
             Some(rust_result) => {
-                call.expect("call to mul-int failed");
+                call.expect("call to mul-uint failed");
                 let wasm_result = PropInt::from_wasm(res[0].i64().unwrap(), res[1].i64().unwrap());
                 prop_assert_eq!(rust_result, wasm_result.unsigned());
             }
-            None => { call.expect_err("expected overrflow"); }
+            None => { call.expect_err("expected overflow"); }
         }
     })
 }
@@ -192,6 +192,58 @@ fn prop_mul_int() {
                 prop_assert_eq!(rust_result, wasm_result.signed());
             }
             None => { call.expect_err("expected overflow"); }
+        }
+    })
+}
+
+#[test]
+fn prop_div_uint() {
+    let (instance, store) = load_stdlib().unwrap();
+    let store = RefCell::new(store);
+    let div = instance
+        .get_func(store.borrow_mut().deref_mut(), "div-uint")
+        .unwrap();
+
+    proptest!(|(n in int128(), m in int128())| {
+        let mut res = [Val::I64(0), Val::I64(0)];
+        let call = div.call(
+            store.borrow_mut().deref_mut(),
+            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &mut res,
+        );
+        match n.unsigned().checked_div(m.unsigned()) {
+            Some(rust_result) => {
+                call.expect("call to div-uint failed");
+                let wasm_result = PropInt::from_wasm(res[0].i64().unwrap(), res[1].i64().unwrap());
+                prop_assert_eq!(rust_result, wasm_result.unsigned());
+            }
+            None => { call.expect_err("expected divide by zero"); }
+        }
+    })
+}
+
+#[test]
+fn prop_div_int() {
+    let (instance, store) = load_stdlib().unwrap();
+    let store = RefCell::new(store);
+    let div = instance
+        .get_func(store.borrow_mut().deref_mut(), "div-int")
+        .unwrap();
+
+    proptest!(|(n in int128(), m in int128())| {
+        let mut res = [Val::I64(0), Val::I64(0)];
+        let call = div.call(
+            store.borrow_mut().deref_mut(),
+            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &mut res,
+        );
+        match n.signed().checked_div(m.signed()) {
+            Some(rust_result) => {
+                call.expect("call to div-int failed");
+                let wasm_result = PropInt::from_wasm(res[0].i64().unwrap(), res[1].i64().unwrap());
+                prop_assert_eq!(rust_result, wasm_result.signed());
+            }
+            None => { call.expect_err("expected divide by zero"); }
         }
     })
 }

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -414,3 +414,41 @@ fn prop_le_int() {
         prop_assert_eq!(n.signed() <= m.signed(), res[0].i32().unwrap() == 1);
     })
 }
+
+#[test]
+fn prop_ge_uint() {
+    let (instance, store) = load_stdlib().unwrap();
+    let store = RefCell::new(store);
+    let ge = instance
+        .get_func(store.borrow_mut().deref_mut(), "ge-uint")
+        .unwrap();
+
+    proptest!(|(n in int128(), m in int128())| {
+        let mut res = [Val::I32(0)];
+        ge.call(
+            store.borrow_mut().deref_mut(),
+            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &mut res,
+        ).expect("call to ge-uint failed");
+        prop_assert_eq!(n.unsigned() >= m.unsigned(), res[0].i32().unwrap() == 1);
+    })
+}
+
+#[test]
+fn prop_ge_int() {
+    let (instance, store) = load_stdlib().unwrap();
+    let store = RefCell::new(store);
+    let ge = instance
+        .get_func(store.borrow_mut().deref_mut(), "ge-int")
+        .unwrap();
+
+    proptest!(|(n in int128(), m in int128())| {
+        let mut res = [Val::I32(0)];
+        ge.call(
+            store.borrow_mut().deref_mut(),
+            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &mut res,
+        ).expect("call to ge-int failed");
+        prop_assert_eq!(n.signed() >= m.signed(), res[0].i32().unwrap() == 1);
+    })
+}

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -334,7 +334,45 @@ fn prop_lt_int() {
             store.borrow_mut().deref_mut(),
             &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
             &mut res,
-        ).expect("call to lt-uint failed");
+        ).expect("call to lt-int failed");
         prop_assert_eq!(n.signed() < m.signed(), res[0].i32().unwrap() == 1);
+    })
+}
+
+#[test]
+fn prop_gt_uint() {
+    let (instance, store) = load_stdlib().unwrap();
+    let store = RefCell::new(store);
+    let gt = instance
+        .get_func(store.borrow_mut().deref_mut(), "gt-uint")
+        .unwrap();
+
+    proptest!(|(n in int128(), m in int128())| {
+        let mut res = [Val::I32(0)];
+        gt.call(
+            store.borrow_mut().deref_mut(),
+            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &mut res,
+        ).expect("call to gt-uint failed");
+        prop_assert_eq!(n.unsigned() > m.unsigned(), res[0].i32().unwrap() == 1);
+    })
+}
+
+#[test]
+fn prop_gt_int() {
+    let (instance, store) = load_stdlib().unwrap();
+    let store = RefCell::new(store);
+    let gt = instance
+        .get_func(store.borrow_mut().deref_mut(), "gt-int")
+        .unwrap();
+
+    proptest!(|(n in int128(), m in int128())| {
+        let mut res = [Val::I32(0)];
+        gt.call(
+            store.borrow_mut().deref_mut(),
+            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &mut res,
+        ).expect("call to gt-int failed");
+        prop_assert_eq!(n.signed() > m.signed(), res[0].i32().unwrap() == 1);
     })
 }

--- a/clar2wasm/tests/standard/utils.rs
+++ b/clar2wasm/tests/standard/utils.rs
@@ -1,0 +1,58 @@
+use wasmtime::{Caller, Engine, Instance, Linker, Module, Store};
+
+/// Load the standard library into a Wasmtime instance. This is used to load in
+/// the standard.wat file and link in all of the host interface functions.
+pub(crate) fn load_stdlib() -> Result<(Instance, Store<()>), wasmtime::Error> {
+    let standard_lib = include_str!("../../src/standard/standard.wat");
+    let engine = Engine::default();
+    let mut store = Store::new(&engine, ());
+
+    let mut linker = Linker::new(&engine);
+
+    // Link in the host interface functions.
+    linker
+        .func_wrap(
+            "clarity",
+            "define_variable",
+            |_: Caller<'_, ()>,
+             identifier: i32,
+             _name_offset: i32,
+             _name_length: i32,
+             _value_offset: i32,
+             _value_length: i32| {
+                println!("define-data-var: {identifier}");
+            },
+        )
+        .unwrap();
+
+    linker
+        .func_wrap(
+            "clarity",
+            "get_variable",
+            |_: Caller<'_, ()>, identifier: i32, _return_offset: i32, _return_length: i32| {
+                println!("var-get: {identifier}");
+            },
+        )
+        .unwrap();
+
+    linker
+        .func_wrap(
+            "clarity",
+            "set_variable",
+            |_: Caller<'_, ()>, identifier: i32, _return_offset: i32, _return_length: i32| {
+                println!("var-set: {identifier}");
+            },
+        )
+        .unwrap();
+
+    // Create a log function for debugging.
+    linker
+        .func_wrap("", "log", |_: Caller<'_, ()>, param: i64| {
+            println!("log: {param}");
+        })
+        .unwrap();
+
+    let module = Module::new(&engine, standard_lib).unwrap();
+    let instance = linker.instantiate(&mut store, &module)?;
+    Ok((instance, store))
+}


### PR DESCRIPTION
This PR adds property tests for the standard.wat functions. For that, we pulled the new dependency _Proptest_.
The basic idea of those tests is to generate hundreds of inputs for any wasm functions, and check if the result of the function applied  to those input would be the same as the result of an existing rust function with the same input.

At the same time, I reorganized the tests from the standard folder. It didn't make much sense to not put them on a dedicated place.