### PR TITLE
Chore: invert low and high in litteral values int and uint

### DIFF
--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -2,11 +2,11 @@
 ;; builtins, to be called from the generated Wasm code.
 (module
     (type (;0;) (func (param i32)))
-    (type (;1;) (func (param $a_hi i64) (param $a_lo i64) (param $b_hi i64) (param $b_lo i64) (result i64 i64)))
-    (type (;2;) (func (param $a_hi i64) (param $a_lo i64) (param $b_hi i64) (param $b_lo i64) (result i64 i64 i64 i64)))
+    (type (;1;) (func (param $a_lo i64) (param $a_hi i64) (param $b_lo i64) (param $b_hi i64) (result i64 i64)))
+    (type (;2;) (func (param $a_lo i64) (param $a_hi i64) (param $b_lo i64) (param $b_hi i64) (result i64 i64 i64 i64)))
     (type (;3;) (func (param i64 i64) (result i64 i64)))
     (type (;4;) (func (param i32 i32 i32) (result i32)))
-    (type (;5;) (func (param $a_hi i64) (param $a_lo i64) (param $b_hi i64) (param $b_lo i64) (result i32)))
+    (type (;5;) (func (param $a_lo i64) (param $a_hi i64) (param $b_lo i64) (param $b_hi i64) (result i32)))
 
     ;; Functions imported for host interface
     ;; define_variable(var_id: i32, name: string (offset: i32, length: i32), initial_value: (offset: i32, length: i32))
@@ -65,7 +65,7 @@
 
 
     ;; This function can be used to add either signed or unsigned integers
-    (func $add-int128 (type 1) (param $a_hi i64) (param $a_lo i64) (param $b_hi i64) (param $b_lo i64) (result i64 i64)
+    (func $add-int128 (type 1) (param $a_lo i64) (param $a_hi i64) (param $b_lo i64) (param $b_hi i64) (result i64 i64)
         (local $sum_lo i64)
         (local $sum_hi i64)
         (local $carry i64)
@@ -80,21 +80,21 @@
         (local.set $sum_hi (i64.add (i64.add (local.get $a_hi) (local.get $b_hi)) (local.get $carry)))
 
         ;; Return the result
-        (return (local.get $sum_hi) (local.get $sum_lo))
+        (return (local.get $sum_lo) (local.get $sum_hi))
     )
 
-    (func $add-int (type 1) (param $a_hi i64) (param $a_lo i64) (param $b_hi i64) (param $b_lo i64) (result i64 i64)
+    (func $add-int (type 1) (param $a_lo i64) (param $a_hi i64) (param $b_lo i64) (param $b_hi i64) (result i64 i64)
         (local $sum_hi i64)
         (local $sum_lo i64)
 
-        (local.get $a_hi)
         (local.get $a_lo)
-        (local.get $b_hi)
+        (local.get $a_hi)
         (local.get $b_lo)
+        (local.get $b_hi)
         (call $add-int128)
 
-        (local.set $sum_lo)
         (local.set $sum_hi)
+        (local.set $sum_lo)
 
         ;; Check for overflow and underflow
         (if (i64.eq (i64.shr_s (local.get $a_hi) (i64.const 63)) (i64.shr_s (local.get $b_hi) (i64.const 63))) ;; if a and b have the same sign
@@ -104,21 +104,21 @@
         )
 
         ;; Return the result
-        (return (local.get $sum_hi) (local.get $sum_lo))
+        (return (local.get $sum_lo) (local.get $sum_hi))
     )
 
-    (func $add-uint (type 1) (param $a_hi i64) (param $a_lo i64) (param $b_hi i64) (param $b_lo i64) (result i64 i64)
+    (func $add-uint (type 1) (param $a_lo i64) (param $a_hi i64) (param $b_lo i64) (param $b_hi i64) (result i64 i64)
         (local $sum_hi i64)
         (local $sum_lo i64)
 
-        (local.get $a_hi)
         (local.get $a_lo)
-        (local.get $b_hi)
+        (local.get $a_hi)
         (local.get $b_lo)
+        (local.get $b_hi)
         (call $add-int128)
 
-        (local.set $sum_lo)
         (local.set $sum_hi)
+        (local.set $sum_lo)
 
         ;; Check for overflow
         (if (i64.lt_u (local.get $sum_hi) (local.get $a_hi))
@@ -126,11 +126,11 @@
         )
 
         ;; Return the result
-        (return (local.get $sum_hi) (local.get $sum_lo))
+        (return (local.get $sum_lo) (local.get $sum_hi))
     )
 
     ;; This function can be used to subtract either signed or unsigned integers
-    (func $sub-int128 (type 1) (param $a_hi i64) (param $a_lo i64) (param $b_hi i64) (param $b_lo i64) (result i64 i64)
+    (func $sub-int128 (type 1) (param $a_lo i64) (param $a_hi i64) (param $b_lo i64) (param $b_hi i64) (result i64 i64)
         (local $borrow i64)
         (local $diff_lo i64)
         (local $diff_hi i64)
@@ -145,21 +145,21 @@
         (local.set $diff_hi (i64.sub (i64.sub (local.get $a_hi) (local.get $b_hi)) (local.get $borrow)))
 
         ;; Return the result
-        (return (local.get $diff_hi) (local.get $diff_lo))
+        (return (local.get $diff_lo) (local.get $diff_hi))
     )
 
-    (func $sub-int (type 1) (param $a_hi i64) (param $a_lo i64) (param $b_hi i64) (param $b_lo i64) (result i64 i64)
+    (func $sub-int (type 1) (param $a_lo i64) (param $a_hi i64) (param $b_lo i64) (param $b_hi i64) (result i64 i64)
         (local $diff_hi i64)
         (local $diff_lo i64)
 
-        (local.get $a_hi)
         (local.get $a_lo)
-        (local.get $b_hi)
+        (local.get $a_hi)
         (local.get $b_lo)
+        (local.get $b_hi)
         (call $sub-int128)
 
-        (local.set $diff_lo)
         (local.set $diff_hi)
+        (local.set $diff_lo)
 
         ;; Check for overflow and underflow
         (if (i64.ne (i64.shr_s (local.get $a_hi) (i64.const 63)) (i64.shr_s (local.get $b_hi) (i64.const 63))) ;; if a and b have different signs
@@ -169,21 +169,21 @@
         )
 
         ;; Return the result
-        (return (local.get $diff_hi) (local.get $diff_lo))
+        (return (local.get $diff_lo) (local.get $diff_hi))
     )
 
-    (func $sub-uint (type 1) (param $a_hi i64) (param $a_lo i64) (param $b_hi i64) (param $b_lo i64) (result i64 i64)
+    (func $sub-uint (type 1) (param $a_lo i64) (param $a_hi i64) (param $b_lo i64) (param $b_hi i64) (result i64 i64)
         (local $diff_hi i64)
         (local $diff_lo i64)
 
-        (local.get $a_hi)
         (local.get $a_lo)
-        (local.get $b_hi)
+        (local.get $a_hi)
         (local.get $b_lo)
+        (local.get $b_hi)
         (call $sub-int128)
 
-        (local.set $diff_lo)
         (local.set $diff_hi)
+        (local.set $diff_lo)
 
         ;; Check for underflow
         (if (i64.gt_u (local.get $diff_hi) (local.get $a_hi))
@@ -191,10 +191,10 @@
         )
 
         ;; Return the result
-        (return (local.get $diff_hi) (local.get $diff_lo))
+        (return (local.get $diff_lo) (local.get $diff_hi))
     )
 
-    (func $mul-uint (type 1) (param $a_hi i64) (param $a_lo i64) (param $b_hi i64) (param $b_lo i64) (result i64 i64)
+    (func $mul-uint (type 1) (param $a_lo i64) (param $a_hi i64) (param $b_lo i64) (param $b_hi i64) (result i64 i64)
         (local $a0 i32)
         (local $a1 i32)
         (local $a2 i32)
@@ -334,10 +334,10 @@
         )
 
         ;; Return the result
-        (return (local.get $res_hi) (local.get $res_lo))
+        (return (local.get $res_lo) (local.get $res_hi))
     )
 
-    (func $mul-int (type 1) (param $a_hi i64) (param $a_lo i64) (param $b_hi i64) (param $b_lo i64) (result i64 i64)
+    (func $mul-int (type 1) (param $a_lo i64) (param $a_hi i64) (param $b_lo i64) (param $b_hi i64) (result i64 i64)
         (local $res_hi i64)
         (local $res_lo i64)
         (local $sign_a i64)
@@ -351,14 +351,14 @@
             (return (i64.const 0) (i64.const 0))
         )
 
-        (local.get $a_hi)
         (local.get $a_lo)
-        (local.get $b_hi)
+        (local.get $a_hi)
         (local.get $b_lo)
+        (local.get $b_hi)
         (call $mul-uint)
 
-        (local.set $res_lo)
         (local.set $res_hi)
+        (local.set $res_lo)
 
         ;; Check for overflow into sign bit
         (local.set $sign_a (i64.shr_s (local.get $a_hi) (i64.const 63)))
@@ -369,10 +369,10 @@
         )
 
         ;; Return the result
-        (return (local.get $res_hi) (local.get $res_lo))
+        (return (local.get $res_lo) (local.get $res_hi))
     )
 
-    (func $div-int128 (type 2) (param $dividend_hi i64) (param $dividend_lo i64) (param $divisor_hi i64) (param $divisor_lo i64) (result i64 i64 i64 i64)
+    (func $div-int128 (type 2) (param $dividend_lo i64) (param $dividend_hi i64) (param $divisor_lo i64) (param $divisor_hi i64) (result i64 i64 i64 i64)
         (local $quotient_hi i64)
         (local $quotient_lo i64)
         (local $remainder_hi i64)
@@ -418,9 +418,9 @@
                                  (i64.ge_u (local.get $remainder_lo) (local.get $divisor_lo))))
                 (then
                     ;; Subtract the divisor from the remainder
-                    (call $sub-int128 (local.get $remainder_hi) (local.get $remainder_lo) (local.get $divisor_hi) (local.get $divisor_lo))
-                    (local.set $remainder_lo)
+                    (call $sub-int128 (local.get $remainder_lo) (local.get $remainder_hi) (local.get $divisor_lo) (local.get $divisor_hi))
                     (local.set $remainder_hi)
+                    (local.set $remainder_lo)
 
                     ;; and set the current bit of the quotient to 1
                     (if (i64.lt_u (local.get $current_bit) (i64.const 64))
@@ -442,25 +442,25 @@
         )
 
         ;; Return the quotient and the remainder
-        (return (local.get $quotient_hi) (local.get $quotient_lo) (local.get $remainder_hi) (local.get $remainder_lo))
+        (return (local.get $quotient_lo) (local.get $quotient_hi) (local.get $remainder_lo) (local.get $remainder_hi))
     )
 
-    (func $div-uint (type 1) (param $dividend_hi i64) (param $dividend_lo i64) (param $divisor_hi i64) (param $divisor_lo i64) (result i64 i64)
+    (func $div-uint (type 1) (param $dividend_lo i64) (param $dividend_hi i64) (param $divisor_lo i64) (param $divisor_hi i64) (result i64 i64)
         (local $quotient_hi i64)
         (local $quotient_lo i64)
         (local $remainder_hi i64)
         (local $remainder_lo i64)
 
-        (call $div-int128 (local.get $dividend_hi) (local.get $dividend_lo) (local.get $divisor_hi) (local.get $divisor_lo))
-        (local.set $remainder_lo)
+        (call $div-int128 (local.get $dividend_lo) (local.get $dividend_hi) (local.get $divisor_lo) (local.get $divisor_hi))
         (local.set $remainder_hi)
-        (local.set $quotient_lo)
+        (local.set $remainder_lo)
         (local.set $quotient_hi)
+        (local.set $quotient_lo)
 
-        (return (local.get $quotient_hi) (local.get $quotient_lo))
+        (return (local.get $quotient_lo) (local.get $quotient_hi))
     )
 
-    (func $div-int (type 1) (param $dividend_hi i64) (param $dividend_lo i64) (param $divisor_hi i64) (param $divisor_lo i64) (result i64 i64)
+    (func $div-int (type 1) (param $dividend_lo i64) (param $dividend_hi i64) (param $divisor_lo i64) (param $divisor_hi i64) (result i64 i64)
         (local $quotient_hi i64)
         (local $quotient_lo i64)
         (local $remainder_hi i64)
@@ -477,53 +477,53 @@
         ;; Perform the division using the absolute values of the operands
         (if (i32.wrap_i64 (local.get $sign_dividend))
             (then
-                (call $sub-int128 (i64.const 0) (i64.const 0) (local.get $dividend_hi) (local.get $dividend_lo))
-                (local.set $dividend_lo)
+                (call $sub-int128 (i64.const 0) (i64.const 0) (local.get $dividend_lo) (local.get $dividend_hi))
                 (local.set $dividend_hi)
+                (local.set $dividend_lo)
             )
         )
         (if (i32.wrap_i64 (local.get $sign_divisor))
             (then
-                (call $sub-int128 (i64.const 0) (i64.const 0) (local.get $divisor_hi) (local.get $divisor_lo))
-                (local.set $divisor_lo)
+                (call $sub-int128 (i64.const 0) (i64.const 0) (local.get $divisor_lo) (local.get $divisor_hi))
                 (local.set $divisor_hi)
+                (local.set $divisor_lo)
             )
         )
 
-        (call $div-int128 (local.get $dividend_hi) (local.get $dividend_lo) (local.get $divisor_hi) (local.get $divisor_lo))
-        (local.set $remainder_lo)
+        (call $div-int128 (local.get $dividend_lo) (local.get $dividend_hi) (local.get $divisor_lo) (local.get $divisor_hi))
         (local.set $remainder_hi)
-        (local.set $quotient_lo)
+        (local.set $remainder_lo)
         (local.set $quotient_hi)
+        (local.set $quotient_lo)
 
         ;; If the result should be negative, negate it
         (if (i32.wrap_i64 (local.get $expected_sign))
             (then
-                (call $sub-int128 (i64.const 0) (i64.const 0) (local.get $quotient_hi) (local.get $quotient_lo))
-                (local.set $quotient_lo)
+                (call $sub-int128 (i64.const 0) (i64.const 0) (local.get $quotient_lo) (local.get $quotient_hi))
                 (local.set $quotient_hi)
+                (local.set $quotient_lo)
             )
         )
 
-        (return (local.get $quotient_hi) (local.get $quotient_lo))
+        (return (local.get $quotient_lo) (local.get $quotient_hi))
     )
 
-    (func $mod-uint (type 1) (param $dividend_hi i64) (param $dividend_lo i64) (param $divisor_hi i64) (param $divisor_lo i64) (result i64 i64)
+    (func $mod-uint (type 1) (param $dividend_lo i64) (param $dividend_hi i64) (param $divisor_lo i64) (param $divisor_hi i64) (result i64 i64)
         (local $quotient_hi i64)
         (local $quotient_lo i64)
         (local $remainder_hi i64)
         (local $remainder_lo i64)
 
-        (call $div-int128 (local.get $dividend_hi) (local.get $dividend_lo) (local.get $divisor_hi) (local.get $divisor_lo))
-        (local.set $remainder_lo)
+        (call $div-int128 (local.get $dividend_lo) (local.get $dividend_hi) (local.get $divisor_lo) (local.get $divisor_hi))
         (local.set $remainder_hi)
-        (local.set $quotient_lo)
+        (local.set $remainder_lo)
         (local.set $quotient_hi)
+        (local.set $quotient_lo)
 
-        (return (local.get $remainder_hi) (local.get $remainder_lo))
+        (return (local.get $remainder_lo) (local.get $remainder_hi))
     )
 
-    (func $mod-int (type 1) (param $dividend_hi i64) (param $dividend_lo i64) (param $divisor_hi i64) (param $divisor_lo i64) (result i64 i64)
+    (func $mod-int (type 1) (param $dividend_lo i64) (param $dividend_hi i64) (param $divisor_lo i64) (param $divisor_hi i64) (result i64 i64)
         (local $quotient_hi i64)
         (local $quotient_lo i64)
         (local $remainder_hi i64)
@@ -540,24 +540,24 @@
         ;; Perform the division using the absolute values of the operands
         (if (i32.wrap_i64 (local.get $sign_dividend))
             (then
-                (call $sub-int128 (i64.const 0) (i64.const 0) (local.get $dividend_hi) (local.get $dividend_lo))
-                (local.set $dividend_lo)
+                (call $sub-int128 (i64.const 0) (i64.const 0) (local.get $dividend_lo) (local.get $dividend_hi))
                 (local.set $dividend_hi)
+                (local.set $dividend_lo)
             )
         )
         (if (i32.wrap_i64 (local.get $sign_divisor))
             (then
-                (call $sub-int128 (i64.const 0) (i64.const 0) (local.get $divisor_hi) (local.get $divisor_lo))
-                (local.set $divisor_lo)
+                (call $sub-int128 (i64.const 0) (i64.const 0) (local.get $divisor_lo) (local.get $divisor_hi))
                 (local.set $divisor_hi)
+                (local.set $divisor_lo)
             )
         )
 
-        (call $div-int128 (local.get $dividend_hi) (local.get $dividend_lo) (local.get $divisor_hi) (local.get $divisor_lo))
-        (local.set $remainder_lo)
+        (call $div-int128 (local.get $dividend_lo) (local.get $dividend_hi) (local.get $divisor_lo) (local.get $divisor_hi))
         (local.set $remainder_hi)
-        (local.set $quotient_lo)
+        (local.set $remainder_lo)
         (local.set $quotient_hi)
+        (local.set $quotient_lo)
 
         ;; If the result should be negative, negate it
         (if (i32.wrap_i64 (local.get $sign_dividend))
@@ -568,10 +568,10 @@
             )
         )
 
-        (return (local.get $remainder_hi) (local.get $remainder_lo))
+        (return (local.get $remainder_lo) (local.get $remainder_hi))
     )
 
-    (func $lt-uint (type 5) (param $a_hi i64) (param $a_lo i64) (param $b_hi i64) (param $b_lo i64) (result i32)
+    (func $lt-uint (type 5) (param $a_lo i64) (param $a_hi i64) (param $b_lo i64) (param $b_hi i64) (result i32)
         (select
             (i64.lt_u (local.get $a_lo) (local.get $b_lo))
             (i64.lt_u (local.get $a_hi) (local.get $b_hi))
@@ -579,7 +579,7 @@
         )
     )
 
-    (func $gt-uint (type 5) (param $a_hi i64) (param $a_lo i64) (param $b_hi i64) (param $b_lo i64) (result i32)
+    (func $gt-uint (type 5) (param $a_lo i64) (param $a_hi i64) (param $b_lo i64) (param $b_hi i64) (result i32)
         (select
             (i64.gt_u (local.get $a_lo) (local.get $b_lo))
             (i64.gt_u (local.get $a_hi) (local.get $b_hi))
@@ -587,7 +587,7 @@
         )
     )
 
-    (func $le-uint (type 5) (param $a_hi i64) (param $a_lo i64) (param $b_hi i64) (param $b_lo i64) (result i32)
+    (func $le-uint (type 5) (param $a_lo i64) (param $a_hi i64) (param $b_lo i64) (param $b_hi i64) (result i32)
         (select
             (i64.le_u (local.get $a_lo) (local.get $b_lo))
             (i64.le_u (local.get $a_hi) (local.get $b_hi))
@@ -595,7 +595,7 @@
         )
     )
 
-    (func $ge-uint (type 5) (param $a_hi i64) (param $a_lo i64) (param $b_hi i64) (param $b_lo i64) (result i32)
+    (func $ge-uint (type 5) (param $a_lo i64) (param $a_hi i64) (param $b_lo i64) (param $b_hi i64) (result i32)
         (select
             (i64.ge_u (local.get $a_lo) (local.get $b_lo))
             (i64.ge_u (local.get $a_hi) (local.get $b_hi))
@@ -603,7 +603,7 @@
         )
     )
 
-    (func $lt-int (type 5) (param $a_hi i64) (param $a_lo i64) (param $b_hi i64) (param $b_lo i64) (result i32)
+    (func $lt-int (type 5) (param $a_lo i64) (param $a_hi i64) (param $b_lo i64) (param $b_hi i64) (result i32)
         (select
             (i64.lt_u (local.get $a_lo) (local.get $b_lo))
             (i64.lt_s (local.get $a_hi) (local.get $b_hi))
@@ -611,7 +611,7 @@
         )
     )
 
-    (func $gt-int (type 5) (param $a_hi i64) (param $a_lo i64) (param $b_hi i64) (param $b_lo i64) (result i32)
+    (func $gt-int (type 5) (param $a_lo i64) (param $a_hi i64) (param $b_lo i64) (param $b_hi i64) (result i32)
         (select
             (i64.gt_u (local.get $a_lo) (local.get $b_lo))
             (i64.gt_s (local.get $a_hi) (local.get $b_hi))
@@ -619,7 +619,7 @@
         )
     )
 
-    (func $le-int (type 5) (param $a_hi i64) (param $a_lo i64) (param $b_hi i64) (param $b_lo i64) (result i32)
+    (func $le-int (type 5) (param $a_lo i64) (param $a_hi i64) (param $b_lo i64) (param $b_hi i64) (result i32)
         (select
             (i64.le_u (local.get $a_lo) (local.get $b_lo))
             (i64.le_s (local.get $a_hi) (local.get $b_hi))
@@ -627,7 +627,7 @@
         )
     )
 
-    (func $ge-int (type 5) (param $a_hi i64) (param $a_lo i64) (param $b_hi i64) (param $b_lo i64) (result i32)
+    (func $ge-int (type 5) (param $a_lo i64) (param $a_hi i64) (param $b_lo i64) (param $b_hi i64) (result i32)
         (select
             (i64.ge_u (local.get $a_lo) (local.get $b_lo))
             (i64.ge_s (local.get $a_hi) (local.get $b_hi))
@@ -635,7 +635,7 @@
         )
     )
 
-    (func $log2 (param $hi i64) (param $lo i64) (result i64)
+    (func $log2 (param $lo i64) (param $hi i64) (result i64)
         (select
             (i64.xor (i64.clz (local.get $lo)) (i64.const 63))
             (i64.xor (i64.clz (local.get $hi)) (i64.const 127))
@@ -643,18 +643,18 @@
         )
     )
 
-    (func $log2-uint (type 3) (param $hi i64) (param $lo i64) (result i64 i64)
+    (func $log2-uint (type 3) (param $lo i64) (param $hi i64) (result i64 i64)
         (if (i64.eqz (i64.or (local.get $hi) (local.get $lo)))
             (call $runtime-error (i32.const 3)))
+        (call $log2 (local.get $lo) (local.get $hi))
         (i64.const 0)
-        (call $log2 (local.get $hi) (local.get $lo))
     )
 
-    (func $log2-int (type 3) (param $hi i64) (param $lo i64) (result i64 i64)
+    (func $log2-int (type 3) (param $lo i64) (param $hi i64) (result i64 i64)
         (if (call $le-int (local.get $hi) (local.get $lo) (i64.const 0) (i64.const 0))
             (call $runtime-error (i32.const 3)))
+        (call $log2 (local.get $lo) (local.get $hi))
         (i64.const 0)
-        (call $log2 (local.get $hi) (local.get $lo))
     )
 
     (export "memcpy" (func $memcpy))

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -562,9 +562,9 @@
         ;; If the result should be negative, negate it
         (if (i32.wrap_i64 (local.get $sign_dividend))
             (then
-                (call $sub-int128 (i64.const 0) (i64.const 0) (local.get $remainder_hi) (local.get $remainder_lo))
-                (local.set $remainder_lo)
+                (call $sub-int128 (i64.const 0) (i64.const 0) (local.get $remainder_lo) (local.get $remainder_hi))
                 (local.set $remainder_hi)
+                (local.set $remainder_lo)
             )
         )
 
@@ -651,7 +651,7 @@
     )
 
     (func $log2-int (type 3) (param $lo i64) (param $hi i64) (result i64 i64)
-        (if (call $le-int (local.get $hi) (local.get $lo) (i64.const 0) (i64.const 0))
+        (if (call $le-int (local.get $lo) (local.get $hi) (i64.const 0) (i64.const 0))
             (call $runtime-error (i32.const 3)))
         (call $log2 (local.get $lo) (local.get $hi))
         (i64.const 0)

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -569,13 +569,13 @@ impl<'a> ASTVisitor<'a> for WasmGenerator {
     ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
         match value {
             clarity::vm::Value::Int(i) => {
-                builder.i64_const(((i >> 64) & 0xFFFFFFFFFFFFFFFF) as i64);
                 builder.i64_const((i & 0xFFFFFFFFFFFFFFFF) as i64);
+                builder.i64_const(((i >> 64) & 0xFFFFFFFFFFFFFFFF) as i64);
                 Ok(builder)
             }
             clarity::vm::Value::UInt(u) => {
-                builder.i64_const(((u >> 64) & 0xFFFFFFFFFFFFFFFF) as i64);
                 builder.i64_const((u & 0xFFFFFFFFFFFFFFFF) as i64);
+                builder.i64_const(((u >> 64) & 0xFFFFFFFFFFFFFFFF) as i64);
                 Ok(builder)
             }
             clarity::vm::Value::Sequence(SequenceData::String(s)) => {

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -13,7 +13,7 @@ impl PropInt {
         Self(n)
     }
 
-    const fn from_wasm(high: i64, low: i64) -> Self {
+    const fn from_wasm(low: i64, high: i64) -> Self {
         Self(((high as u64) as u128) << 64 | ((low as u64) as u128))
     }
 
@@ -52,7 +52,7 @@ fn prop_add_uint() {
         let mut res = [Val::I64(0), Val::I64(0)];
         let call = add.call(
             store.borrow_mut().deref_mut(),
-            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
             &mut res,
         );
         match n.unsigned().checked_add(m.unsigned()) {
@@ -78,7 +78,7 @@ fn prop_add_int() {
         let mut res = [Val::I64(0), Val::I64(0)];
         let call = add.call(
             store.borrow_mut().deref_mut(),
-            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
             &mut res,
         );
         match n.signed().checked_add(m.signed()) {
@@ -104,7 +104,7 @@ fn prop_sub_uint() {
         let mut res = [Val::I64(0), Val::I64(0)];
         let call = sub.call(
             store.borrow_mut().deref_mut(),
-            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
             &mut res,
         );
         match n.unsigned().checked_sub(m.unsigned()) {
@@ -130,7 +130,7 @@ fn prop_sub_int() {
         let mut res = [Val::I64(0), Val::I64(0)];
         let call = sub.call(
             store.borrow_mut().deref_mut(),
-            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
             &mut res,
         );
         match n.signed().checked_sub(m.signed()) {
@@ -156,7 +156,7 @@ fn prop_mul_uint() {
         let mut res = [Val::I64(0), Val::I64(0)];
         let call = mul.call(
             store.borrow_mut().deref_mut(),
-            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
             &mut res,
         );
         match n.unsigned().checked_mul(m.unsigned()) {
@@ -182,7 +182,7 @@ fn prop_mul_int() {
         let mut res = [Val::I64(0), Val::I64(0)];
         let call = mul.call(
             store.borrow_mut().deref_mut(),
-            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
             &mut res,
         );
         match n.signed().checked_mul(m.signed()) {
@@ -208,7 +208,7 @@ fn prop_div_uint() {
         let mut res = [Val::I64(0), Val::I64(0)];
         let call = div.call(
             store.borrow_mut().deref_mut(),
-            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
             &mut res,
         );
         match n.unsigned().checked_div(m.unsigned()) {
@@ -234,7 +234,7 @@ fn prop_div_int() {
         let mut res = [Val::I64(0), Val::I64(0)];
         let call = div.call(
             store.borrow_mut().deref_mut(),
-            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
             &mut res,
         );
         match n.signed().checked_div(m.signed()) {
@@ -260,7 +260,7 @@ fn prop_mod_uint() {
         let mut res = [Val::I64(0), Val::I64(0)];
         let call = modulo.call(
             store.borrow_mut().deref_mut(),
-            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
             &mut res,
         );
         match n.unsigned().checked_rem(m.unsigned()) {
@@ -286,7 +286,7 @@ fn prop_mod_int() {
         let mut res = [Val::I64(0), Val::I64(0)];
         let call = modulo.call(
             store.borrow_mut().deref_mut(),
-            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
             &mut res,
         );
         match n.signed().checked_rem(m.signed()) {
@@ -313,7 +313,7 @@ fn prop_lt_uint() {
         let mut res = [Val::I32(0)];
         lt.call(
             store.borrow_mut().deref_mut(),
-            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
             &mut res,
         ).expect("call to lt-uint failed");
         prop_assert_eq!(n.unsigned() < m.unsigned(), res[0].i32().unwrap() == 1);
@@ -332,7 +332,7 @@ fn prop_lt_int() {
         let mut res = [Val::I32(0)];
         lt.call(
             store.borrow_mut().deref_mut(),
-            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
             &mut res,
         ).expect("call to lt-int failed");
         prop_assert_eq!(n.signed() < m.signed(), res[0].i32().unwrap() == 1);
@@ -351,7 +351,7 @@ fn prop_gt_uint() {
         let mut res = [Val::I32(0)];
         gt.call(
             store.borrow_mut().deref_mut(),
-            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
             &mut res,
         ).expect("call to gt-uint failed");
         prop_assert_eq!(n.unsigned() > m.unsigned(), res[0].i32().unwrap() == 1);
@@ -370,7 +370,7 @@ fn prop_gt_int() {
         let mut res = [Val::I32(0)];
         gt.call(
             store.borrow_mut().deref_mut(),
-            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
             &mut res,
         ).expect("call to gt-int failed");
         prop_assert_eq!(n.signed() > m.signed(), res[0].i32().unwrap() == 1);
@@ -389,7 +389,7 @@ fn prop_le_uint() {
         let mut res = [Val::I32(0)];
         le.call(
             store.borrow_mut().deref_mut(),
-            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
             &mut res,
         ).expect("call to le-uint failed");
         prop_assert_eq!(n.unsigned() <= m.unsigned(), res[0].i32().unwrap() == 1);
@@ -408,7 +408,7 @@ fn prop_le_int() {
         let mut res = [Val::I32(0)];
         le.call(
             store.borrow_mut().deref_mut(),
-            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
             &mut res,
         ).expect("call to le-int failed");
         prop_assert_eq!(n.signed() <= m.signed(), res[0].i32().unwrap() == 1);
@@ -427,7 +427,7 @@ fn prop_ge_uint() {
         let mut res = [Val::I32(0)];
         ge.call(
             store.borrow_mut().deref_mut(),
-            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
             &mut res,
         ).expect("call to ge-uint failed");
         prop_assert_eq!(n.unsigned() >= m.unsigned(), res[0].i32().unwrap() == 1);
@@ -446,7 +446,7 @@ fn prop_ge_int() {
         let mut res = [Val::I32(0)];
         ge.call(
             store.borrow_mut().deref_mut(),
-            &[n.high().into(), n.low().into(), m.high().into(), m.low().into()],
+            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
             &mut res,
         ).expect("call to ge-int failed");
         prop_assert_eq!(n.signed() >= m.signed(), res[0].i32().unwrap() == 1);
@@ -465,7 +465,7 @@ fn prop_log2_uint() {
         let mut res = [Val::I64(0), Val::I64(0)];
         let call = log2.call(
             store.borrow_mut().deref_mut(),
-            &[n.high().into(), n.low().into()],
+            &[n.low().into(), n.high().into()],
             &mut res,
         );
         match n.unsigned().checked_ilog2() {
@@ -491,7 +491,7 @@ fn prop_log2_int() {
         let mut res = [Val::I64(0), Val::I64(0)];
         let call = log2.call(
             store.borrow_mut().deref_mut(),
-            &[n.high().into(), n.low().into()],
+            &[n.low().into(), n.high().into()],
             &mut res,
         );
         match n.signed().checked_ilog2() {

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -799,7 +799,7 @@ fn test_lt_uint() {
     .expect("call to lt-uint failed");
     assert_eq!(result[0].i32(), Some(0));
 
-    // 1 < 4294967296 is true
+    // 1 < 0x1_0000_0000_0000_0000 is true
     lt.call(
         &mut store,
         &[Val::I64(1), Val::I64(0), Val::I64(0), Val::I64(1)],
@@ -808,7 +808,7 @@ fn test_lt_uint() {
     .expect("call to lt-uint failed");
     assert_eq!(result[0].i32(), Some(1));
 
-    // 1 < 4294967297 is true
+    // 1 < 0x1_0000_0000_0000_0001 is true
     lt.call(
         &mut store,
         &[Val::I64(1), Val::I64(0), Val::I64(1), Val::I64(1)],
@@ -817,7 +817,7 @@ fn test_lt_uint() {
     .expect("call to lt-uint failed");
     assert_eq!(result[0].i32(), Some(1));
 
-    // 4294967296 < 1 is false
+    // 0x1_0000_0000_0000_0000 < 1 is false
     lt.call(
         &mut store,
         &[Val::I64(0), Val::I64(1), Val::I64(1), Val::I64(0)],
@@ -826,7 +826,7 @@ fn test_lt_uint() {
     .expect("call to lt-uint failed");
     assert_eq!(result[0].i32(), Some(0));
 
-    // 4294967297 < 1 is false
+    // 0x1_0000_0000_0000_0001 < 1 is false
     lt.call(
         &mut store,
         &[Val::I64(1), Val::I64(1), Val::I64(1), Val::I64(0)],
@@ -835,7 +835,7 @@ fn test_lt_uint() {
     .expect("call to lt-uint failed");
     assert_eq!(result[0].i32(), Some(0));
 
-    // 4294967296 < 4294967297 is true
+    // 0x1_0000_0000_0000_0000 < 0x1_0000_0000_0000_0001 is true
     lt.call(
         &mut store,
         &[Val::I64(0), Val::I64(1), Val::I64(1), Val::I64(1)],
@@ -844,7 +844,7 @@ fn test_lt_uint() {
     .expect("call to lt-uint failed");
     assert_eq!(result[0].i32(), Some(1));
 
-    // 4294967297 < 4294967296 is false
+    // 0x1_0000_0000_0000_0001 < 0x1_0000_0000_0000_0000 is false
     lt.call(
         &mut store,
         &[Val::I64(1), Val::I64(1), Val::I64(0), Val::I64(1)],
@@ -853,7 +853,7 @@ fn test_lt_uint() {
     .expect("call to lt-uint failed");
     assert_eq!(result[0].i32(), Some(0));
 
-    // 4294967297 < 4294967297 is false
+    // 0x1_0000_0000_0000_0001 < 0x1_0000_0000_0000_0001 is false
     lt.call(
         &mut store,
         &[Val::I64(1), Val::I64(1), Val::I64(1), Val::I64(1)],
@@ -914,7 +914,7 @@ fn test_gt_uint() {
     .expect("call to gt-uint failed");
     assert_eq!(result[0].i32(), Some(0));
 
-    // 1 > 4294967296 is false
+    // 1 > 0x1_0000_0000_0000_0000 is false
     gt.call(
         &mut store,
         &[Val::I64(1), Val::I64(0), Val::I64(0), Val::I64(1)],
@@ -923,7 +923,7 @@ fn test_gt_uint() {
     .expect("call to gt-uint failed");
     assert_eq!(result[0].i32(), Some(0));
 
-    // 1 > 4294967297 is false
+    // 1 > 0x1_0000_0000_0000_0001 is false
     gt.call(
         &mut store,
         &[Val::I64(1), Val::I64(0), Val::I64(1), Val::I64(1)],
@@ -932,7 +932,7 @@ fn test_gt_uint() {
     .expect("call to gt-uint failed");
     assert_eq!(result[0].i32(), Some(0));
 
-    // 4294967296 > 1 is true
+    // 0x1_0000_0000_0000_0000 > 1 is true
     gt.call(
         &mut store,
         &[Val::I64(0), Val::I64(1), Val::I64(1), Val::I64(0)],
@@ -941,7 +941,7 @@ fn test_gt_uint() {
     .expect("call to gt-uint failed");
     assert_eq!(result[0].i32(), Some(1));
 
-    // 4294967297 > 1 is true
+    // 0x1_0000_0000_0000_0001 > 1 is true
     gt.call(
         &mut store,
         &[Val::I64(1), Val::I64(1), Val::I64(1), Val::I64(0)],
@@ -950,7 +950,7 @@ fn test_gt_uint() {
     .expect("call to gt-uint failed");
     assert_eq!(result[0].i32(), Some(1));
 
-    // 4294967296 > 4294967297 is false
+    // 0x1_0000_0000_0000_0000 > 0x1_0000_0000_0000_0001 is false
     gt.call(
         &mut store,
         &[Val::I64(0), Val::I64(1), Val::I64(1), Val::I64(1)],
@@ -959,7 +959,7 @@ fn test_gt_uint() {
     .expect("call to gt-uint failed");
     assert_eq!(result[0].i32(), Some(0));
 
-    // 4294967297 > 4294967296 is true
+    // 0x1_0000_0000_0000_0001 > 0x1_0000_0000_0000_0000 is true
     gt.call(
         &mut store,
         &[Val::I64(1), Val::I64(1), Val::I64(0), Val::I64(1)],
@@ -968,7 +968,7 @@ fn test_gt_uint() {
     .expect("call to gt-uint failed");
     assert_eq!(result[0].i32(), Some(1));
 
-    // 4294967297 > 4294967297 is false
+    // 0x1_0000_0000_0000_0001 > 0x1_0000_0000_0000_0001 is false
     gt.call(
         &mut store,
         &[Val::I64(1), Val::I64(1), Val::I64(1), Val::I64(1)],
@@ -1029,7 +1029,7 @@ fn test_le_uint() {
     .expect("call to le-uint failed");
     assert_eq!(result[0].i32(), Some(1));
 
-    // 1 <= 4294967296 is true
+    // 1 <= 0x1_0000_0000_0000_0000 is true
     le.call(
         &mut store,
         &[Val::I64(1), Val::I64(0), Val::I64(0), Val::I64(1)],
@@ -1038,7 +1038,7 @@ fn test_le_uint() {
     .expect("call to le-uint failed");
     assert_eq!(result[0].i32(), Some(1));
 
-    // 1 <= 4294967297 is true
+    // 1 <= 0x1_0000_0000_0000_0001 is true
     le.call(
         &mut store,
         &[Val::I64(1), Val::I64(0), Val::I64(1), Val::I64(1)],
@@ -1047,7 +1047,7 @@ fn test_le_uint() {
     .expect("call to le-uint failed");
     assert_eq!(result[0].i32(), Some(1));
 
-    // 4294967296 <= 1 is false
+    // 0x1_0000_0000_0000_0000 <= 1 is false
     le.call(
         &mut store,
         &[Val::I64(0), Val::I64(1), Val::I64(1), Val::I64(0)],
@@ -1056,7 +1056,7 @@ fn test_le_uint() {
     .expect("call to le-uint failed");
     assert_eq!(result[0].i32(), Some(0));
 
-    // 4294967297 <= 1 is false
+    // 0x1_0000_0000_0000_0001 <= 1 is false
     le.call(
         &mut store,
         &[Val::I64(1), Val::I64(1), Val::I64(1), Val::I64(0)],
@@ -1065,7 +1065,7 @@ fn test_le_uint() {
     .expect("call to le-uint failed");
     assert_eq!(result[0].i32(), Some(0));
 
-    // 4294967296 <= 4294967297 is true
+    // 0x1_0000_0000_0000_0000 <= 0x1_0000_0000_0000_0001 is true
     le.call(
         &mut store,
         &[Val::I64(0), Val::I64(1), Val::I64(1), Val::I64(1)],
@@ -1074,7 +1074,7 @@ fn test_le_uint() {
     .expect("call to le-uint failed");
     assert_eq!(result[0].i32(), Some(1));
 
-    // 4294967297 <= 4294967296 is false
+    // 0x1_0000_0000_0000_0001 <= 0x1_0000_0000_0000_0000 is false
     le.call(
         &mut store,
         &[Val::I64(1), Val::I64(1), Val::I64(0), Val::I64(1)],
@@ -1083,7 +1083,7 @@ fn test_le_uint() {
     .expect("call to le-uint failed");
     assert_eq!(result[0].i32(), Some(0));
 
-    // 4294967297 <= 4294967297 is true
+    // 0x1_0000_0000_0000_0001 <= 0x1_0000_0000_0000_0001 is true
     le.call(
         &mut store,
         &[Val::I64(1), Val::I64(1), Val::I64(1), Val::I64(1)],
@@ -1144,7 +1144,7 @@ fn test_ge_uint() {
     .expect("call to ge-uint failed");
     assert_eq!(result[0].i32(), Some(1));
 
-    // 1 >= 4294967296 is false
+    // 1 >= 0x1_0000_0000_0000_0000 is false
     ge.call(
         &mut store,
         &[Val::I64(1), Val::I64(0), Val::I64(0), Val::I64(1)],
@@ -1153,7 +1153,7 @@ fn test_ge_uint() {
     .expect("call to ge-uint failed");
     assert_eq!(result[0].i32(), Some(0));
 
-    // 1 >= 4294967297 is false
+    // 1 >= 0x1_0000_0000_0000_0001 is false
     ge.call(
         &mut store,
         &[Val::I64(1), Val::I64(0), Val::I64(1), Val::I64(1)],
@@ -1162,7 +1162,7 @@ fn test_ge_uint() {
     .expect("call to ge-uint failed");
     assert_eq!(result[0].i32(), Some(0));
 
-    // 4294967296 >= 1 is true
+    // 0x1_0000_0000_0000_0000 >= 1 is true
     ge.call(
         &mut store,
         &[Val::I64(0), Val::I64(1), Val::I64(1), Val::I64(0)],
@@ -1171,7 +1171,7 @@ fn test_ge_uint() {
     .expect("call to ge-uint failed");
     assert_eq!(result[0].i32(), Some(1));
 
-    // 4294967297 >= 1 is true
+    // 0x1_0000_0000_0000_0001 >= 1 is true
     ge.call(
         &mut store,
         &[Val::I64(1), Val::I64(1), Val::I64(1), Val::I64(0)],
@@ -1180,7 +1180,7 @@ fn test_ge_uint() {
     .expect("call to ge-uint failed");
     assert_eq!(result[0].i32(), Some(1));
 
-    // 4294967296 >= 4294967297 is false
+    // 0x1_0000_0000_0000_0000 >= 0x1_0000_0000_0000_0001 is false
     ge.call(
         &mut store,
         &[Val::I64(0), Val::I64(1), Val::I64(1), Val::I64(1)],
@@ -1189,7 +1189,7 @@ fn test_ge_uint() {
     .expect("call to ge-uint failed");
     assert_eq!(result[0].i32(), Some(0));
 
-    // 4294967297 >= 4294967296 is true
+    // 0x1_0000_0000_0000_0001 >= 0x1_0000_0000_0000_0000 is true
     ge.call(
         &mut store,
         &[Val::I64(1), Val::I64(1), Val::I64(0), Val::I64(1)],
@@ -1198,7 +1198,7 @@ fn test_ge_uint() {
     .expect("call to ge-uint failed");
     assert_eq!(result[0].i32(), Some(1));
 
-    // 4294967297 >= 4294967297 is true
+    // 0x1_0000_0000_0000_0001 >= 0x1_0000_0000_0000_0001 is true
     ge.call(
         &mut store,
         &[Val::I64(1), Val::I64(1), Val::I64(1), Val::I64(1)],

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -52,7 +52,7 @@ fn test_add_uint() {
     // 1 + 0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff = Overflow
     add.call(
         &mut store,
-        &[Val::I64(-1), Val::I64(-1), Val::I64(1), Val::I64(0)],
+        &[Val::I64(1), Val::I64(0), Val::I64(-1), Val::I64(-1)],
         &mut sum,
     )
     .expect_err("expected overflow");

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -15,35 +15,35 @@ fn test_add_uint() {
         &mut sum,
     )
     .expect("call to add-uint failed");
-    assert_eq!(sum[0].i64(), Some(0));
     assert_eq!(sum[1].i64(), Some(0));
+    assert_eq!(sum[0].i64(), Some(0));
 
     // 1 + 2 = 3
     add.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(0), Val::I64(2)],
+        &[Val::I64(1), Val::I64(0), Val::I64(2), Val::I64(0)],
         &mut sum,
     )
     .expect("call to add-uint failed");
-    assert_eq!(sum[0].i64(), Some(0));
-    assert_eq!(sum[1].i64(), Some(3));
+    assert_eq!(sum[0].i64(), Some(3));
+    assert_eq!(sum[1].i64(), Some(0));
 
     // Carry
     // 0xffff_ffff_ffff_ffff + 1 = 0x1_0000_0000_0000_0000
     add.call(
         &mut store,
-        &[Val::I64(0), Val::I64(-1), Val::I64(0), Val::I64(1)],
+        &[Val::I64(-1), Val::I64(0), Val::I64(1), Val::I64(0)],
         &mut sum,
     )
     .expect("call to add-uint failed");
-    assert_eq!(sum[0].i64(), Some(1));
-    assert_eq!(sum[1].i64(), Some(0));
+    assert_eq!(sum[0].i64(), Some(0));
+    assert_eq!(sum[1].i64(), Some(1));
 
     // Overflow
     // 0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff + 1 = Overflow
     add.call(
         &mut store,
-        &[Val::I64(-1), Val::I64(-1), Val::I64(0), Val::I64(1)],
+        &[Val::I64(-1), Val::I64(-1), Val::I64(1), Val::I64(0)],
         &mut sum,
     )
     .expect_err("expected overflow");
@@ -52,7 +52,7 @@ fn test_add_uint() {
     // 1 + 0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff = Overflow
     add.call(
         &mut store,
-        &[Val::I64(-1), Val::I64(-1), Val::I64(0), Val::I64(1)],
+        &[Val::I64(-1), Val::I64(-1), Val::I64(1), Val::I64(0)],
         &mut sum,
     )
     .expect_err("expected overflow");
@@ -77,49 +77,49 @@ fn test_add_int() {
     // 1 + 2 = 3
     add.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(0), Val::I64(2)],
+        &[Val::I64(1), Val::I64(0), Val::I64(2), Val::I64(0)],
         &mut sum,
     )
     .expect("call to add-int failed");
-    assert_eq!(sum[0].i64(), Some(0));
-    assert_eq!(sum[1].i64(), Some(3));
+    assert_eq!(sum[0].i64(), Some(3));
+    assert_eq!(sum[1].i64(), Some(0));
 
     // Carry
     // 0xffff_ffff_ffff_ffff + 1 = 0x1_0000_0000_0000_0000
     add.call(
         &mut store,
-        &[Val::I64(0), Val::I64(-1), Val::I64(0), Val::I64(1)],
+        &[Val::I64(-1), Val::I64(0), Val::I64(1), Val::I64(0)],
         &mut sum,
     )
     .expect("call to add-int failed");
-    assert_eq!(sum[0].i64(), Some(1));
-    assert_eq!(sum[1].i64(), Some(0));
+    assert_eq!(sum[0].i64(), Some(0));
+    assert_eq!(sum[1].i64(), Some(1));
 
     // Overflow in signed 64-bit, but fine in 128-bit
     // 0x7fff_ffff_ffff_ffff + 0x7fff_ffff_ffff_ffff = 0xffff_ffff_ffff_fffe
     add.call(
         &mut store,
         &[
-            Val::I64(0),
             Val::I64(0x7fff_ffff_ffff_ffff),
             Val::I64(0),
             Val::I64(0x7fff_ffff_ffff_ffff),
+            Val::I64(0),
         ],
         &mut sum,
     )
     .expect("call to add-int failed");
-    assert_eq!(sum[0].i64(), Some(0));
-    assert_eq!(sum[1].i64(), Some(-2));
+    assert_eq!(sum[0].i64(), Some(-2));
+    assert_eq!(sum[1].i64(), Some(0));
 
     // Overflow
     // 0x7fff_ffff_ffff_ffff_ffff_ffff_ffff_ffff + 1 = Overflow
     add.call(
         &mut store,
         &[
-            Val::I64(0x7fff_ffff_ffff_ffff),
             Val::I64(-1),
-            Val::I64(0),
+            Val::I64(0x7fff_ffff_ffff_ffff),
             Val::I64(1),
+            Val::I64(0),
         ],
         &mut sum,
     )
@@ -130,10 +130,10 @@ fn test_add_int() {
     add.call(
         &mut store,
         &[
-            Val::I64(0),
             Val::I64(1),
-            Val::I64(0x7fff_ffff_ffff_ffff),
+            Val::I64(0),
             Val::I64(-1),
+            Val::I64(0x7fff_ffff_ffff_ffff),
         ],
         &mut sum,
     )
@@ -144,8 +144,8 @@ fn test_add_int() {
     add.call(
         &mut store,
         &[
-            Val::I64(-9223372036854775808),
             Val::I64(0),
+            Val::I64(-9223372036854775808),
             Val::I64(-1),
             Val::I64(-1),
         ],
@@ -173,45 +173,45 @@ fn test_sub_uint() {
     // 3 - 2 = 1
     sub.call(
         &mut store,
-        &[Val::I64(0), Val::I64(3), Val::I64(0), Val::I64(2)],
+        &[Val::I64(3), Val::I64(0), Val::I64(2), Val::I64(0)],
         &mut sum,
     )
     .expect("call to sub-uint failed");
-    assert_eq!(sum[0].i64(), Some(0));
-    assert_eq!(sum[1].i64(), Some(1));
+    assert_eq!(sum[0].i64(), Some(1));
+    assert_eq!(sum[1].i64(), Some(0));
 
     // Borrow
     // 0x1_0000_0000_0000_0000 - 1 = 0xffff_ffff_ffff_ffff
     sub.call(
         &mut store,
-        &[Val::I64(1), Val::I64(0), Val::I64(0), Val::I64(1)],
+        &[Val::I64(0), Val::I64(1), Val::I64(1), Val::I64(0)],
         &mut sum,
     )
     .expect("call to sub-uint failed");
-    assert_eq!(sum[0].i64(), Some(0));
-    assert_eq!(sum[1].i64(), Some(-1));
+    assert_eq!(sum[0].i64(), Some(-1));
+    assert_eq!(sum[1].i64(), Some(0));
 
     // Signed underflow, but fine for unsigned
     // 0x8000_0000_0000_0000_0000_0000_0000_0000 - 1 = 0x7fff_ffff_ffff_ffff_ffff_ffff_ffff_ffff
     sub.call(
         &mut store,
         &[
+            Val::I64(0),
             Val::I64(-9223372036854775808),
-            Val::I64(0),
-            Val::I64(0),
             Val::I64(1),
+            Val::I64(0),
         ],
         &mut sum,
     )
     .expect("call to sub-uint failed");
-    assert_eq!(sum[0].i64(), Some(0x7fff_ffff_ffff_ffff));
-    assert_eq!(sum[1].i64(), Some(-1));
+    assert_eq!(sum[0].i64(), Some(-1));
+    assert_eq!(sum[1].i64(), Some(0x7fff_ffff_ffff_ffff));
 
     // Underflow
     // 1 - 2 = Underflow
     sub.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(0), Val::I64(2)],
+        &[Val::I64(1), Val::I64(0), Val::I64(2), Val::I64(0)],
         &mut sum,
     )
     .expect_err("expected underflow");
@@ -236,17 +236,17 @@ fn test_sub_int() {
     // 3 - 2 = 1
     sub.call(
         &mut store,
-        &[Val::I64(0), Val::I64(3), Val::I64(0), Val::I64(2)],
+        &[Val::I64(3), Val::I64(0), Val::I64(2), Val::I64(0)],
         &mut sum,
     )
     .expect("call to sub-int failed");
-    assert_eq!(sum[0].i64(), Some(0));
-    assert_eq!(sum[1].i64(), Some(1));
+    assert_eq!(sum[0].i64(), Some(1));
+    assert_eq!(sum[1].i64(), Some(0));
 
     // 1 - 2 = -1
     sub.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(0), Val::I64(2)],
+        &[Val::I64(1), Val::I64(0), Val::I64(2), Val::I64(0)],
         &mut sum,
     )
     .expect("call to sub-int failed");
@@ -257,22 +257,22 @@ fn test_sub_int() {
     // 0x1_0000_0000_0000_0000 - 1 = 0xffff_ffff_ffff_ffff
     sub.call(
         &mut store,
-        &[Val::I64(1), Val::I64(0), Val::I64(0), Val::I64(1)],
+        &[Val::I64(0), Val::I64(1), Val::I64(1), Val::I64(0)],
         &mut sum,
     )
     .expect("call to sub-int failed");
-    assert_eq!(sum[0].i64(), Some(0));
-    assert_eq!(sum[1].i64(), Some(-1));
+    assert_eq!(sum[0].i64(), Some(-1));
+    assert_eq!(sum[1].i64(), Some(0));
 
     // Underflow
     // 0x8000_0000_0000_0000_0000_0000_0000_0000 - 1 = Underflow
     sub.call(
         &mut store,
         &[
+            Val::I64(0),
             Val::I64(-9223372036854775808),
-            Val::I64(0),
-            Val::I64(0),
             Val::I64(1),
+            Val::I64(0),
         ],
         &mut sum,
     )
@@ -301,8 +301,8 @@ fn test_mul_uint() {
         &[
             Val::I64(0),
             Val::I64(0),
-            Val::I64(0x0123_4567_89ab_cdef),
             Val::I64(-81985529216486896),
+            Val::I64(0x0123_4567_89ab_cdef),
         ],
         &mut result,
     )
@@ -314,8 +314,8 @@ fn test_mul_uint() {
     mul.call(
         &mut store,
         &[
-            Val::I64(0x0123_4567_89ab_cdef),
             Val::I64(-81985529216486896),
+            Val::I64(0x0123_4567_89ab_cdef),
             Val::I64(0),
             Val::I64(0),
         ],
@@ -328,28 +328,28 @@ fn test_mul_uint() {
     // 1 * 2 = 2
     mul.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(0), Val::I64(2)],
+        &[Val::I64(1), Val::I64(0), Val::I64(2), Val::I64(0)],
         &mut result,
     )
     .expect("call to mul-uint failed");
-    assert_eq!(result[0].i64(), Some(0));
-    assert_eq!(result[1].i64(), Some(2));
+    assert_eq!(result[0].i64(), Some(2));
+    assert_eq!(result[1].i64(), Some(0));
 
     // 0xffff_ffff_ffff_ffff * 0xffff_ffff_ffff_ffff = 0xffff_ffff_ffff_fffe_0000_0000_0000_0001
     mul.call(
         &mut store,
-        &[Val::I64(0), Val::I64(-1), Val::I64(0), Val::I64(-1)],
+        &[Val::I64(-1), Val::I64(0), Val::I64(-1), Val::I64(0)],
         &mut result,
     )
     .expect("call to mul-uint failed");
-    assert_eq!(result[0].i64(), Some(-2));
-    assert_eq!(result[1].i64(), Some(1));
+    assert_eq!(result[0].i64(), Some(1));
+    assert_eq!(result[1].i64(), Some(-2));
 
     // Overflow
     // 0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff * 2 = Overflow
     mul.call(
         &mut store,
-        &[Val::I64(-1), Val::I64(-1), Val::I64(0), Val::I64(2)],
+        &[Val::I64(-1), Val::I64(-1), Val::I64(2), Val::I64(0)],
         &mut result,
     )
     .expect_err("expected overflow");
@@ -358,7 +358,7 @@ fn test_mul_uint() {
     // 0x1_0000_0000_0000_0000 * 0x1_0000_0000_0000_0000 = Overflow
     mul.call(
         &mut store,
-        &[Val::I64(1), Val::I64(0), Val::I64(1), Val::I64(0)],
+        &[Val::I64(0), Val::I64(1), Val::I64(0), Val::I64(1)],
         &mut result,
     )
     .expect_err("expected overflow");
@@ -368,10 +368,10 @@ fn test_mul_uint() {
     mul.call(
         &mut store,
         &[
-            Val::I64(0x1_0000_0000),
-            Val::I64(0),
             Val::I64(0),
             Val::I64(0x1_0000_0000),
+            Val::I64(0x1_0000_0000),
+            Val::I64(0),
         ],
         &mut result,
     )
@@ -382,10 +382,10 @@ fn test_mul_uint() {
     mul.call(
         &mut store,
         &[
-            Val::I64(0),
-            Val::I64(0x1_0000_0000),
             Val::I64(0x1_0000_0000),
             Val::I64(0),
+            Val::I64(0),
+            Val::I64(0x1_0000_0000),
         ],
         &mut result,
     )
@@ -396,10 +396,10 @@ fn test_mul_uint() {
     mul.call(
         &mut store,
         &[
+            Val::I64(0),
             Val::I64(0x1_0000_0000),
             Val::I64(0),
             Val::I64(1),
-            Val::I64(0),
         ],
         &mut result,
     )
@@ -410,10 +410,10 @@ fn test_mul_uint() {
     mul.call(
         &mut store,
         &[
+            Val::I64(0),
             Val::I64(1),
             Val::I64(0),
             Val::I64(0x1_0000_0000),
-            Val::I64(0),
         ],
         &mut result,
     )
@@ -424,10 +424,10 @@ fn test_mul_uint() {
     mul.call(
         &mut store,
         &[
-            Val::I64(0x1_0000_0000),
             Val::I64(0),
             Val::I64(0x1_0000_0000),
             Val::I64(0),
+            Val::I64(0x1_0000_0000),
         ],
         &mut result,
     )
@@ -456,8 +456,8 @@ fn test_mul_int() {
         &[
             Val::I64(0),
             Val::I64(0),
-            Val::I64(0x0123_4567_89ab_cdef),
             Val::I64(-81985529216486896),
+            Val::I64(0x0123_4567_89ab_cdef),
         ],
         &mut result,
     )
@@ -469,8 +469,8 @@ fn test_mul_int() {
     mul.call(
         &mut store,
         &[
-            Val::I64(0x0123_4567_89ab_cdef),
             Val::I64(-81985529216486896),
+            Val::I64(0x0123_4567_89ab_cdef),
             Val::I64(0),
             Val::I64(0),
         ],
@@ -483,17 +483,17 @@ fn test_mul_int() {
     // 1 * 2 = 2
     mul.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(0), Val::I64(2)],
+        &[Val::I64(1), Val::I64(0), Val::I64(2), Val::I64(0)],
         &mut result,
     )
     .expect("call to mul-uint failed");
-    assert_eq!(result[0].i64(), Some(0));
-    assert_eq!(result[1].i64(), Some(2));
+    assert_eq!(result[0].i64(), Some(2));
+    assert_eq!(result[1].i64(), Some(0));
 
     // 0xffff_ffff_ffff_ffff * 0xffff_ffff_ffff_ffff = 0xffff_ffff_ffff_fffe_0000_0000_0000_0001
     mul.call(
         &mut store,
-        &[Val::I64(0), Val::I64(-1), Val::I64(0), Val::I64(-1)],
+        &[Val::I64(-1), Val::I64(0), Val::I64(-1), Val::I64(0)],
         &mut result,
     )
     .expect_err("expected overflow");
@@ -502,7 +502,7 @@ fn test_mul_int() {
     // 0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff * 2 = Overflow
     mul.call(
         &mut store,
-        &[Val::I64(-1), Val::I64(-1), Val::I64(0), Val::I64(2)],
+        &[Val::I64(-1), Val::I64(-1), Val::I64(2), Val::I64(0)],
         &mut result,
     )
     .expect_err("expected overflow");
@@ -517,27 +517,27 @@ fn test_div_uint() {
     // 4 / 2 = 2
     div.call(
         &mut store,
-        &[Val::I64(0), Val::I64(4), Val::I64(0), Val::I64(2)],
+        &[Val::I64(4), Val::I64(0), Val::I64(2), Val::I64(0)],
         &mut result,
     )
     .expect("call to div-uint failed");
-    assert_eq!(result[0].i64(), Some(0));
-    assert_eq!(result[1].i64(), Some(2));
+    assert_eq!(result[0].i64(), Some(2));
+    assert_eq!(result[1].i64(), Some(0));
 
     // 7 / 4 = 1
     div.call(
         &mut store,
-        &[Val::I64(0), Val::I64(7), Val::I64(0), Val::I64(4)],
+        &[Val::I64(7), Val::I64(0), Val::I64(4), Val::I64(0)],
         &mut result,
     )
     .expect("call to div-uint failed");
-    assert_eq!(result[0].i64(), Some(0));
-    assert_eq!(result[1].i64(), Some(1));
+    assert_eq!(result[0].i64(), Some(1));
+    assert_eq!(result[1].i64(), Some(0));
 
     // 123 / 456 = 0
     div.call(
         &mut store,
-        &[Val::I64(0), Val::I64(123), Val::I64(0), Val::I64(456)],
+        &[Val::I64(123), Val::I64(0), Val::I64(456), Val::I64(0)],
         &mut result,
     )
     .expect("call to div-uint failed");
@@ -547,7 +547,7 @@ fn test_div_uint() {
     // 0 / 0x123_0000_0000_0000_0456 = 0
     div.call(
         &mut store,
-        &[Val::I64(0), Val::I64(0), Val::I64(0x123), Val::I64(0x456)],
+        &[Val::I64(0), Val::I64(0), Val::I64(0x456), Val::I64(0x123)],
         &mut result,
     )
     .expect("call to div-uint failed");
@@ -557,7 +557,7 @@ fn test_div_uint() {
     // 0x123_0000_0000_0000_0456 / 0 = DivideByZero
     div.call(
         &mut store,
-        &[Val::I64(0x123), Val::I64(0x456), Val::I64(0), Val::I64(0)],
+        &[Val::I64(0x456), Val::I64(0x123), Val::I64(0), Val::I64(0)],
         &mut result,
     )
     .expect_err("expected divide by zero");
@@ -565,12 +565,12 @@ fn test_div_uint() {
     // 0x123_0000_0000_0000_0456 / 22 = 0xd_3a2e_8ba2_e8ba_2ebe
     div.call(
         &mut store,
-        &[Val::I64(0x123), Val::I64(0x456), Val::I64(0), Val::I64(22)],
+        &[Val::I64(0x456), Val::I64(0x123), Val::I64(22), Val::I64(0)],
         &mut result,
     )
     .expect("call to div-uint failed");
-    assert_eq!(result[0].i64(), Some(0xd));
-    assert_eq!(result[1].i64(), Some(0x3a2e_8ba2_e8ba_2ebe));
+    assert_eq!(result[0].i64(), Some(0x3a2e_8ba2_e8ba_2ebe));
+    assert_eq!(result[1].i64(), Some(0xd));
 }
 
 #[test]
@@ -582,57 +582,57 @@ fn test_div_int() {
     // 4 / 2 = 2
     div.call(
         &mut store,
-        &[Val::I64(0), Val::I64(4), Val::I64(0), Val::I64(2)],
+        &[Val::I64(4), Val::I64(0), Val::I64(2), Val::I64(0)],
         &mut result,
     )
     .expect("call to div-int failed");
-    assert_eq!(result[0].i64(), Some(0));
-    assert_eq!(result[1].i64(), Some(2));
+    assert_eq!(result[0].i64(), Some(2));
+    assert_eq!(result[1].i64(), Some(0));
 
     // -4 / 2 = -2
     div.call(
         &mut store,
-        &[Val::I64(-1), Val::I64(-4), Val::I64(0), Val::I64(2)],
+        &[Val::I64(-4), Val::I64(-1), Val::I64(2), Val::I64(0)],
         &mut result,
     )
     .expect("call to div-int failed");
-    assert_eq!(result[0].i64(), Some(-1));
-    assert_eq!(result[1].i64(), Some(-2));
+    assert_eq!(result[0].i64(), Some(-2));
+    assert_eq!(result[1].i64(), Some(-1));
 
     // 4 / -2 = -2
     div.call(
         &mut store,
-        &[Val::I64(0), Val::I64(4), Val::I64(-1), Val::I64(-2)],
+        &[Val::I64(4), Val::I64(0), Val::I64(-2), Val::I64(-1)],
         &mut result,
     )
     .expect("call to div-int failed");
-    assert_eq!(result[0].i64(), Some(-1));
-    assert_eq!(result[1].i64(), Some(-2));
+    assert_eq!(result[0].i64(), Some(-2));
+    assert_eq!(result[1].i64(), Some(-1));
 
     // -4 / -2 = 2
     div.call(
         &mut store,
-        &[Val::I64(-1), Val::I64(-4), Val::I64(-1), Val::I64(-2)],
+        &[Val::I64(-4), Val::I64(-1), Val::I64(-2), Val::I64(-1)],
         &mut result,
     )
     .expect("call to div-int failed");
-    assert_eq!(result[0].i64(), Some(0));
-    assert_eq!(result[1].i64(), Some(2));
+    assert_eq!(result[0].i64(), Some(2));
+    assert_eq!(result[1].i64(), Some(0));
 
     // 0x8000_0000_0000_0000_0000_0000_0000_0000 / -2 = 0xc000_0000_0000_0000_0000_0000_0000_0000
     div.call(
         &mut store,
         &[
+            Val::I64(0),
             Val::I64(-9223372036854775808),
-            Val::I64(0),
-            Val::I64(0),
             Val::I64(2),
+            Val::I64(0),
         ],
         &mut result,
     )
     .expect("call to div-int failed");
-    assert_eq!(result[0].i64(), Some(-4611686018427387904i64));
-    assert_eq!(result[1].i64(), Some(0));
+    assert_eq!(result[0].i64(), Some(0));
+    assert_eq!(result[1].i64(), Some(-4611686018427387904i64));
 }
 
 #[test]
@@ -645,7 +645,7 @@ fn test_mod_uint() {
     modulo
         .call(
             &mut store,
-            &[Val::I64(0), Val::I64(4), Val::I64(0), Val::I64(2)],
+            &[Val::I64(4), Val::I64(0), Val::I64(2), Val::I64(0)],
             &mut result,
         )
         .expect("call to mod-uint failed");
@@ -656,29 +656,29 @@ fn test_mod_uint() {
     modulo
         .call(
             &mut store,
-            &[Val::I64(0), Val::I64(7), Val::I64(0), Val::I64(4)],
+            &[Val::I64(7), Val::I64(0), Val::I64(4), Val::I64(0)],
             &mut result,
         )
         .expect("call to mod-uint failed");
-    assert_eq!(result[0].i64(), Some(0));
-    assert_eq!(result[1].i64(), Some(3));
+    assert_eq!(result[0].i64(), Some(3));
+    assert_eq!(result[1].i64(), Some(0));
 
     // 123 % 456 = 123
     modulo
         .call(
             &mut store,
-            &[Val::I64(0), Val::I64(123), Val::I64(0), Val::I64(456)],
+            &[Val::I64(123), Val::I64(0), Val::I64(456), Val::I64(0)],
             &mut result,
         )
         .expect("call to mod-uint failed");
-    assert_eq!(result[0].i64(), Some(0));
-    assert_eq!(result[1].i64(), Some(123));
+    assert_eq!(result[0].i64(), Some(123));
+    assert_eq!(result[1].i64(), Some(0));
 
     // 0 % 0x123_0000_0000_0000_0456 = 0
     modulo
         .call(
             &mut store,
-            &[Val::I64(0), Val::I64(0), Val::I64(0x123), Val::I64(0x456)],
+            &[Val::I64(0), Val::I64(0), Val::I64(0x456), Val::I64(0x123)],
             &mut result,
         )
         .expect("call to mod-uint failed");
@@ -689,7 +689,7 @@ fn test_mod_uint() {
     modulo
         .call(
             &mut store,
-            &[Val::I64(0x123), Val::I64(0x456), Val::I64(0), Val::I64(0)],
+            &[Val::I64(0x456), Val::I64(0x123), Val::I64(0), Val::I64(0)],
             &mut result,
         )
         .expect_err("expected divide by zero");
@@ -698,12 +698,12 @@ fn test_mod_uint() {
     modulo
         .call(
             &mut store,
-            &[Val::I64(0x123), Val::I64(0x456), Val::I64(0), Val::I64(22)],
+            &[Val::I64(0x456), Val::I64(0x123), Val::I64(22), Val::I64(0)],
             &mut result,
         )
         .expect("call to mod-uint failed");
-    assert_eq!(result[0].i64(), Some(0));
-    assert_eq!(result[1].i64(), Some(2));
+    assert_eq!(result[0].i64(), Some(2));
+    assert_eq!(result[1].i64(), Some(0));
 }
 
 #[test]
@@ -716,51 +716,51 @@ fn test_mod_int() {
     modulo
         .call(
             &mut store,
-            &[Val::I64(0), Val::I64(7), Val::I64(0), Val::I64(4)],
+            &[Val::I64(7), Val::I64(0), Val::I64(4), Val::I64(0)],
             &mut result,
         )
         .expect("call to mod-int failed");
-    assert_eq!(result[0].i64(), Some(0));
-    assert_eq!(result[1].i64(), Some(3));
+    assert_eq!(result[0].i64(), Some(3));
+    assert_eq!(result[1].i64(), Some(0));
 
     // -7 / 4 = -3
     modulo
         .call(
             &mut store,
-            &[Val::I64(-1), Val::I64(-7), Val::I64(0), Val::I64(4)],
+            &[Val::I64(-7), Val::I64(-1), Val::I64(4), Val::I64(0)],
             &mut result,
         )
         .expect("call to mod-int failed");
-    assert_eq!(result[0].i64(), Some(-1));
-    assert_eq!(result[1].i64(), Some(-3));
+    assert_eq!(result[0].i64(), Some(-3));
+    assert_eq!(result[1].i64(), Some(-1));
 
     // 7 / -4 = 3
     modulo
         .call(
             &mut store,
-            &[Val::I64(0), Val::I64(7), Val::I64(-1), Val::I64(-4)],
+            &[Val::I64(7), Val::I64(0), Val::I64(-4), Val::I64(-1)],
             &mut result,
         )
         .expect("call to mod-int failed");
-    assert_eq!(result[0].i64(), Some(0));
-    assert_eq!(result[1].i64(), Some(3));
+    assert_eq!(result[0].i64(), Some(3));
+    assert_eq!(result[1].i64(), Some(0));
 
     // -7 / -4 = -3
     modulo
         .call(
             &mut store,
-            &[Val::I64(-1), Val::I64(-7), Val::I64(-1), Val::I64(-4)],
+            &[Val::I64(-7), Val::I64(-1), Val::I64(-4), Val::I64(-1)],
             &mut result,
         )
         .expect("call to mod-int failed");
-    assert_eq!(result[0].i64(), Some(-1));
-    assert_eq!(result[1].i64(), Some(-3));
+    assert_eq!(result[0].i64(), Some(-3));
+    assert_eq!(result[1].i64(), Some(-1));
 
     // 0x123_0000_0000_0000_0456 % 0 = DivideByZero
     modulo
         .call(
             &mut store,
-            &[Val::I64(0x123), Val::I64(0x456), Val::I64(0), Val::I64(0)],
+            &[Val::I64(0x456), Val::I64(0x123), Val::I64(0), Val::I64(0)],
             &mut result,
         )
         .expect_err("expected divide by zero");
@@ -775,7 +775,7 @@ fn test_lt_uint() {
     // 0 < 1 is true
     lt.call(
         &mut store,
-        &[Val::I64(0), Val::I64(0), Val::I64(0), Val::I64(1)],
+        &[Val::I64(0), Val::I64(0), Val::I64(1), Val::I64(0)],
         &mut result,
     )
     .expect("call to lt-uint failed");
@@ -784,7 +784,7 @@ fn test_lt_uint() {
     // 1 < 0 is false
     lt.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(0), Val::I64(0)],
+        &[Val::I64(1), Val::I64(0), Val::I64(0), Val::I64(0)],
         &mut result,
     )
     .expect("call to lt-uint failed");
@@ -802,7 +802,7 @@ fn test_lt_uint() {
     // 1 < 4294967296 is true
     lt.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(1), Val::I64(0)],
+        &[Val::I64(1), Val::I64(0), Val::I64(0), Val::I64(1)],
         &mut result,
     )
     .expect("call to lt-uint failed");
@@ -811,7 +811,7 @@ fn test_lt_uint() {
     // 1 < 4294967297 is true
     lt.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(1), Val::I64(1)],
+        &[Val::I64(1), Val::I64(0), Val::I64(1), Val::I64(1)],
         &mut result,
     )
     .expect("call to lt-uint failed");
@@ -820,7 +820,7 @@ fn test_lt_uint() {
     // 4294967296 < 1 is false
     lt.call(
         &mut store,
-        &[Val::I64(1), Val::I64(0), Val::I64(0), Val::I64(1)],
+        &[Val::I64(0), Val::I64(1), Val::I64(1), Val::I64(0)],
         &mut result,
     )
     .expect("call to lt-uint failed");
@@ -829,7 +829,7 @@ fn test_lt_uint() {
     // 4294967297 < 1 is false
     lt.call(
         &mut store,
-        &[Val::I64(1), Val::I64(1), Val::I64(0), Val::I64(1)],
+        &[Val::I64(1), Val::I64(1), Val::I64(1), Val::I64(0)],
         &mut result,
     )
     .expect("call to lt-uint failed");
@@ -838,7 +838,7 @@ fn test_lt_uint() {
     // 4294967296 < 4294967297 is true
     lt.call(
         &mut store,
-        &[Val::I64(1), Val::I64(0), Val::I64(1), Val::I64(1)],
+        &[Val::I64(0), Val::I64(1), Val::I64(1), Val::I64(1)],
         &mut result,
     )
     .expect("call to lt-uint failed");
@@ -847,7 +847,7 @@ fn test_lt_uint() {
     // 4294967297 < 4294967296 is false
     lt.call(
         &mut store,
-        &[Val::I64(1), Val::I64(1), Val::I64(1), Val::I64(0)],
+        &[Val::I64(1), Val::I64(1), Val::I64(0), Val::I64(1)],
         &mut result,
     )
     .expect("call to lt-uint failed");
@@ -865,7 +865,7 @@ fn test_lt_uint() {
     // u128::MAX (-1 if signed) < 1 is false
     lt.call(
         &mut store,
-        &[Val::I64(-1), Val::I64(-1), Val::I64(0), Val::I64(1)],
+        &[Val::I64(-1), Val::I64(-1), Val::I64(1), Val::I64(0)],
         &mut result,
     )
     .expect("call to lt-uint failed");
@@ -890,7 +890,7 @@ fn test_gt_uint() {
     // 0 > 1 is false
     gt.call(
         &mut store,
-        &[Val::I64(0), Val::I64(0), Val::I64(0), Val::I64(1)],
+        &[Val::I64(0), Val::I64(0), Val::I64(1), Val::I64(0)],
         &mut result,
     )
     .expect("call to gt-uint failed");
@@ -899,7 +899,7 @@ fn test_gt_uint() {
     // 1 > 0 is true
     gt.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(0), Val::I64(0)],
+        &[Val::I64(1), Val::I64(0), Val::I64(0), Val::I64(0)],
         &mut result,
     )
     .expect("call to gt-uint failed");
@@ -908,7 +908,7 @@ fn test_gt_uint() {
     // 1 > 1 is false
     gt.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(0), Val::I64(1)],
+        &[Val::I64(1), Val::I64(0), Val::I64(1), Val::I64(0)],
         &mut result,
     )
     .expect("call to gt-uint failed");
@@ -917,7 +917,7 @@ fn test_gt_uint() {
     // 1 > 4294967296 is false
     gt.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(1), Val::I64(0)],
+        &[Val::I64(1), Val::I64(0), Val::I64(0), Val::I64(1)],
         &mut result,
     )
     .expect("call to gt-uint failed");
@@ -926,7 +926,7 @@ fn test_gt_uint() {
     // 1 > 4294967297 is false
     gt.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(1), Val::I64(1)],
+        &[Val::I64(1), Val::I64(0), Val::I64(1), Val::I64(1)],
         &mut result,
     )
     .expect("call to gt-uint failed");
@@ -935,7 +935,7 @@ fn test_gt_uint() {
     // 4294967296 > 1 is true
     gt.call(
         &mut store,
-        &[Val::I64(1), Val::I64(0), Val::I64(0), Val::I64(1)],
+        &[Val::I64(0), Val::I64(1), Val::I64(1), Val::I64(0)],
         &mut result,
     )
     .expect("call to gt-uint failed");
@@ -944,7 +944,7 @@ fn test_gt_uint() {
     // 4294967297 > 1 is true
     gt.call(
         &mut store,
-        &[Val::I64(1), Val::I64(1), Val::I64(0), Val::I64(1)],
+        &[Val::I64(1), Val::I64(1), Val::I64(1), Val::I64(0)],
         &mut result,
     )
     .expect("call to gt-uint failed");
@@ -953,7 +953,7 @@ fn test_gt_uint() {
     // 4294967296 > 4294967297 is false
     gt.call(
         &mut store,
-        &[Val::I64(1), Val::I64(0), Val::I64(1), Val::I64(1)],
+        &[Val::I64(0), Val::I64(1), Val::I64(1), Val::I64(1)],
         &mut result,
     )
     .expect("call to gt-uint failed");
@@ -962,7 +962,7 @@ fn test_gt_uint() {
     // 4294967297 > 4294967296 is true
     gt.call(
         &mut store,
-        &[Val::I64(1), Val::I64(1), Val::I64(1), Val::I64(0)],
+        &[Val::I64(1), Val::I64(1), Val::I64(0), Val::I64(1)],
         &mut result,
     )
     .expect("call to gt-uint failed");
@@ -980,7 +980,7 @@ fn test_gt_uint() {
     // u128::MAX (-1 if signed) > 1 is true
     gt.call(
         &mut store,
-        &[Val::I64(-1), Val::I64(-1), Val::I64(0), Val::I64(1)],
+        &[Val::I64(-1), Val::I64(-1), Val::I64(1), Val::I64(0)],
         &mut result,
     )
     .expect("call to lt-uint failed");
@@ -1005,7 +1005,7 @@ fn test_le_uint() {
     // 0 <= 1 is true
     le.call(
         &mut store,
-        &[Val::I64(0), Val::I64(0), Val::I64(0), Val::I64(1)],
+        &[Val::I64(0), Val::I64(0), Val::I64(1), Val::I64(0)],
         &mut result,
     )
     .expect("call to le-uint failed");
@@ -1014,7 +1014,7 @@ fn test_le_uint() {
     // 1 <= 0 is false
     le.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(0), Val::I64(0)],
+        &[Val::I64(1), Val::I64(0), Val::I64(0), Val::I64(0)],
         &mut result,
     )
     .expect("call to le-uint failed");
@@ -1023,7 +1023,7 @@ fn test_le_uint() {
     // 1 <= 1 is true
     le.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(0), Val::I64(1)],
+        &[Val::I64(1), Val::I64(0), Val::I64(1), Val::I64(0)],
         &mut result,
     )
     .expect("call to le-uint failed");
@@ -1032,7 +1032,7 @@ fn test_le_uint() {
     // 1 <= 4294967296 is true
     le.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(1), Val::I64(0)],
+        &[Val::I64(1), Val::I64(0), Val::I64(0), Val::I64(1)],
         &mut result,
     )
     .expect("call to le-uint failed");
@@ -1041,7 +1041,7 @@ fn test_le_uint() {
     // 1 <= 4294967297 is true
     le.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(1), Val::I64(1)],
+        &[Val::I64(1), Val::I64(0), Val::I64(1), Val::I64(1)],
         &mut result,
     )
     .expect("call to le-uint failed");
@@ -1050,7 +1050,7 @@ fn test_le_uint() {
     // 4294967296 <= 1 is false
     le.call(
         &mut store,
-        &[Val::I64(1), Val::I64(0), Val::I64(0), Val::I64(1)],
+        &[Val::I64(0), Val::I64(1), Val::I64(1), Val::I64(0)],
         &mut result,
     )
     .expect("call to le-uint failed");
@@ -1059,7 +1059,7 @@ fn test_le_uint() {
     // 4294967297 <= 1 is false
     le.call(
         &mut store,
-        &[Val::I64(1), Val::I64(1), Val::I64(0), Val::I64(1)],
+        &[Val::I64(1), Val::I64(1), Val::I64(1), Val::I64(0)],
         &mut result,
     )
     .expect("call to le-uint failed");
@@ -1068,7 +1068,7 @@ fn test_le_uint() {
     // 4294967296 <= 4294967297 is true
     le.call(
         &mut store,
-        &[Val::I64(1), Val::I64(0), Val::I64(1), Val::I64(1)],
+        &[Val::I64(0), Val::I64(1), Val::I64(1), Val::I64(1)],
         &mut result,
     )
     .expect("call to le-uint failed");
@@ -1077,7 +1077,7 @@ fn test_le_uint() {
     // 4294967297 <= 4294967296 is false
     le.call(
         &mut store,
-        &[Val::I64(1), Val::I64(1), Val::I64(1), Val::I64(0)],
+        &[Val::I64(1), Val::I64(1), Val::I64(0), Val::I64(1)],
         &mut result,
     )
     .expect("call to le-uint failed");
@@ -1095,7 +1095,7 @@ fn test_le_uint() {
     // u128::MAX (-1 if signed) <= 1 is false
     le.call(
         &mut store,
-        &[Val::I64(-1), Val::I64(-1), Val::I64(0), Val::I64(1)],
+        &[Val::I64(-1), Val::I64(-1), Val::I64(1), Val::I64(0)],
         &mut result,
     )
     .expect("call to lt-uint failed");
@@ -1120,7 +1120,7 @@ fn test_ge_uint() {
     // 0 >= 1 is false
     ge.call(
         &mut store,
-        &[Val::I64(0), Val::I64(0), Val::I64(0), Val::I64(1)],
+        &[Val::I64(0), Val::I64(0), Val::I64(1), Val::I64(0)],
         &mut result,
     )
     .expect("call to ge-uint failed");
@@ -1129,7 +1129,7 @@ fn test_ge_uint() {
     // 1 >= 0 is true
     ge.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(0), Val::I64(0)],
+        &[Val::I64(1), Val::I64(0), Val::I64(0), Val::I64(0)],
         &mut result,
     )
     .expect("call to ge-uint failed");
@@ -1138,7 +1138,7 @@ fn test_ge_uint() {
     // 1 >= 1 is true
     ge.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(0), Val::I64(1)],
+        &[Val::I64(1), Val::I64(0), Val::I64(1), Val::I64(0)],
         &mut result,
     )
     .expect("call to ge-uint failed");
@@ -1147,7 +1147,7 @@ fn test_ge_uint() {
     // 1 >= 4294967296 is false
     ge.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(1), Val::I64(0)],
+        &[Val::I64(1), Val::I64(0), Val::I64(0), Val::I64(1)],
         &mut result,
     )
     .expect("call to ge-uint failed");
@@ -1156,7 +1156,7 @@ fn test_ge_uint() {
     // 1 >= 4294967297 is false
     ge.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(1), Val::I64(1)],
+        &[Val::I64(1), Val::I64(0), Val::I64(1), Val::I64(1)],
         &mut result,
     )
     .expect("call to ge-uint failed");
@@ -1165,7 +1165,7 @@ fn test_ge_uint() {
     // 4294967296 >= 1 is true
     ge.call(
         &mut store,
-        &[Val::I64(1), Val::I64(0), Val::I64(0), Val::I64(1)],
+        &[Val::I64(0), Val::I64(1), Val::I64(1), Val::I64(0)],
         &mut result,
     )
     .expect("call to ge-uint failed");
@@ -1174,7 +1174,7 @@ fn test_ge_uint() {
     // 4294967297 >= 1 is true
     ge.call(
         &mut store,
-        &[Val::I64(1), Val::I64(1), Val::I64(0), Val::I64(1)],
+        &[Val::I64(1), Val::I64(1), Val::I64(1), Val::I64(0)],
         &mut result,
     )
     .expect("call to ge-uint failed");
@@ -1183,7 +1183,7 @@ fn test_ge_uint() {
     // 4294967296 >= 4294967297 is false
     ge.call(
         &mut store,
-        &[Val::I64(1), Val::I64(0), Val::I64(1), Val::I64(1)],
+        &[Val::I64(0), Val::I64(1), Val::I64(1), Val::I64(1)],
         &mut result,
     )
     .expect("call to ge-uint failed");
@@ -1192,7 +1192,7 @@ fn test_ge_uint() {
     // 4294967297 >= 4294967296 is true
     ge.call(
         &mut store,
-        &[Val::I64(1), Val::I64(1), Val::I64(1), Val::I64(0)],
+        &[Val::I64(1), Val::I64(1), Val::I64(0), Val::I64(1)],
         &mut result,
     )
     .expect("call to ge-uint failed");
@@ -1210,7 +1210,7 @@ fn test_ge_uint() {
     // u128::MAX (-1 if signed) >= 1 is true
     ge.call(
         &mut store,
-        &[Val::I64(-1), Val::I64(-1), Val::I64(0), Val::I64(1)],
+        &[Val::I64(-1), Val::I64(-1), Val::I64(1), Val::I64(0)],
         &mut result,
     )
     .expect("call to lt-uint failed");
@@ -1235,7 +1235,7 @@ fn test_lt_int() {
     // 1 < 1 is false
     lt.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(0), Val::I64(1)],
+        &[Val::I64(1), Val::I64(0), Val::I64(1), Val::I64(0)],
         &mut result,
     )
     .expect("call to lt-int failed");
@@ -1253,7 +1253,7 @@ fn test_lt_int() {
     // -1 < 1 is true
     lt.call(
         &mut store,
-        &[Val::I64(-1), Val::I64(-1), Val::I64(0), Val::I64(1)],
+        &[Val::I64(-1), Val::I64(-1), Val::I64(1), Val::I64(0)],
         &mut result,
     )
     .expect("call to lt-int failed");
@@ -1262,7 +1262,7 @@ fn test_lt_int() {
     // 1 < -1 is false
     lt.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(-1), Val::I64(-1)],
+        &[Val::I64(1), Val::I64(0), Val::I64(-1), Val::I64(-1)],
         &mut result,
     )
     .expect("call to lt-int failed");
@@ -1280,7 +1280,7 @@ fn test_lt_int() {
     // -2 < -1 is true
     lt.call(
         &mut store,
-        &[Val::I64(-1), Val::I64(-2), Val::I64(-1), Val::I64(-1)],
+        &[Val::I64(-2), Val::I64(-1), Val::I64(-1), Val::I64(-1)],
         &mut result,
     )
     .expect("call to lt-int failed");
@@ -1289,7 +1289,7 @@ fn test_lt_int() {
     // -2 < -3 is false
     lt.call(
         &mut store,
-        &[Val::I64(-1), Val::I64(-2), Val::I64(-1), Val::I64(-3)],
+        &[Val::I64(-2), Val::I64(-1), Val::I64(-3), Val::I64(-1)],
         &mut result,
     )
     .expect("call to lt-int failed");
@@ -1298,7 +1298,7 @@ fn test_lt_int() {
     // I128::MIN < -1 is true
     lt.call(
         &mut store,
-        &[Val::I64(i64::MIN), Val::I64(0), Val::I64(-1), Val::I64(-1)],
+        &[Val::I64(0), Val::I64(i64::MIN), Val::I64(-1), Val::I64(-1)],
         &mut result,
     )
     .expect("call to lt-int failed");
@@ -1307,7 +1307,7 @@ fn test_lt_int() {
     // -1 < I128::MIN is false
     lt.call(
         &mut store,
-        &[Val::I64(-1), Val::I64(-1), Val::I64(i64::MIN), Val::I64(0)],
+        &[Val::I64(-1), Val::I64(-1), Val::I64(0), Val::I64(i64::MIN)],
         &mut result,
     )
     .expect("call to lt-int failed");
@@ -1323,7 +1323,7 @@ fn test_gt_int() {
     // 1 > 1 is false
     gt.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(0), Val::I64(1)],
+        &[Val::I64(1), Val::I64(0), Val::I64(1), Val::I64(0)],
         &mut result,
     )
     .expect("call to gt-int failed");
@@ -1341,7 +1341,7 @@ fn test_gt_int() {
     // -1 > 1 is false
     gt.call(
         &mut store,
-        &[Val::I64(-1), Val::I64(-1), Val::I64(0), Val::I64(1)],
+        &[Val::I64(-1), Val::I64(-1), Val::I64(1), Val::I64(0)],
         &mut result,
     )
     .expect("call to gt-int failed");
@@ -1350,7 +1350,7 @@ fn test_gt_int() {
     // 1 > -1 is true
     gt.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(-1), Val::I64(-1)],
+        &[Val::I64(1), Val::I64(0), Val::I64(-1), Val::I64(-1)],
         &mut result,
     )
     .expect("call to gt-int failed");
@@ -1368,7 +1368,7 @@ fn test_gt_int() {
     // -2 > -1 is false
     gt.call(
         &mut store,
-        &[Val::I64(-1), Val::I64(-2), Val::I64(-1), Val::I64(-1)],
+        &[Val::I64(-2), Val::I64(-1), Val::I64(-1), Val::I64(-1)],
         &mut result,
     )
     .expect("call to gt-int failed");
@@ -1377,7 +1377,7 @@ fn test_gt_int() {
     // -2 > -3 is true
     gt.call(
         &mut store,
-        &[Val::I64(-1), Val::I64(-2), Val::I64(-1), Val::I64(-3)],
+        &[Val::I64(-2), Val::I64(-1), Val::I64(-3), Val::I64(-1)],
         &mut result,
     )
     .expect("call to gt-int failed");
@@ -1386,7 +1386,7 @@ fn test_gt_int() {
     // I128::MIN > -1 is false
     gt.call(
         &mut store,
-        &[Val::I64(i64::MIN), Val::I64(0), Val::I64(-1), Val::I64(-1)],
+        &[Val::I64(0), Val::I64(i64::MIN), Val::I64(-1), Val::I64(-1)],
         &mut result,
     )
     .expect("call to gt-int failed");
@@ -1395,7 +1395,7 @@ fn test_gt_int() {
     // -1 > I128::MIN is true
     gt.call(
         &mut store,
-        &[Val::I64(-1), Val::I64(-1), Val::I64(i64::MIN), Val::I64(0)],
+        &[Val::I64(-1), Val::I64(-1), Val::I64(0), Val::I64(i64::MIN)],
         &mut result,
     )
     .expect("call to gt-int failed");
@@ -1411,7 +1411,7 @@ fn test_le_int() {
     // 1 <= 1 is true
     le.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(0), Val::I64(1)],
+        &[Val::I64(1), Val::I64(0), Val::I64(1), Val::I64(0)],
         &mut result,
     )
     .expect("call to le-int failed");
@@ -1429,7 +1429,7 @@ fn test_le_int() {
     // -1 <= 1 is true
     le.call(
         &mut store,
-        &[Val::I64(-1), Val::I64(-1), Val::I64(0), Val::I64(1)],
+        &[Val::I64(-1), Val::I64(-1), Val::I64(1), Val::I64(0)],
         &mut result,
     )
     .expect("call to le-int failed");
@@ -1438,7 +1438,7 @@ fn test_le_int() {
     // 1 <= -1 is false
     le.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(-1), Val::I64(-1)],
+        &[Val::I64(1), Val::I64(0), Val::I64(-1), Val::I64(-1)],
         &mut result,
     )
     .expect("call to le-int failed");
@@ -1456,7 +1456,7 @@ fn test_le_int() {
     // -2 <= -1 is true
     le.call(
         &mut store,
-        &[Val::I64(-1), Val::I64(-2), Val::I64(-1), Val::I64(-1)],
+        &[Val::I64(-2), Val::I64(-1), Val::I64(-1), Val::I64(-1)],
         &mut result,
     )
     .expect("call to le-int failed");
@@ -1465,7 +1465,7 @@ fn test_le_int() {
     // -2 <= -3 is false
     le.call(
         &mut store,
-        &[Val::I64(-1), Val::I64(-2), Val::I64(-1), Val::I64(-3)],
+        &[Val::I64(-2), Val::I64(-1), Val::I64(-3), Val::I64(-1)],
         &mut result,
     )
     .expect("call to le-int failed");
@@ -1474,7 +1474,7 @@ fn test_le_int() {
     // I128::MIN <= -1 is true
     le.call(
         &mut store,
-        &[Val::I64(i64::MIN), Val::I64(0), Val::I64(-1), Val::I64(-1)],
+        &[Val::I64(0), Val::I64(i64::MIN), Val::I64(-1), Val::I64(-1)],
         &mut result,
     )
     .expect("call to le-int failed");
@@ -1483,7 +1483,7 @@ fn test_le_int() {
     // -1 <= I128::MIN is false
     le.call(
         &mut store,
-        &[Val::I64(-1), Val::I64(-1), Val::I64(i64::MIN), Val::I64(0)],
+        &[Val::I64(-1), Val::I64(-1), Val::I64(0), Val::I64(i64::MIN)],
         &mut result,
     )
     .expect("call to le-int failed");
@@ -1499,7 +1499,7 @@ fn test_ge_int() {
     // 1 >= 1 is true
     ge.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(0), Val::I64(1)],
+        &[Val::I64(1), Val::I64(0), Val::I64(1), Val::I64(0)],
         &mut result,
     )
     .expect("call to ge-int failed");
@@ -1517,7 +1517,7 @@ fn test_ge_int() {
     // -1 >= 1 is false
     ge.call(
         &mut store,
-        &[Val::I64(-1), Val::I64(-1), Val::I64(0), Val::I64(1)],
+        &[Val::I64(-1), Val::I64(-1), Val::I64(1), Val::I64(0)],
         &mut result,
     )
     .expect("call to ge-int failed");
@@ -1526,7 +1526,7 @@ fn test_ge_int() {
     // 1 >= -1 is true
     ge.call(
         &mut store,
-        &[Val::I64(0), Val::I64(1), Val::I64(-1), Val::I64(-1)],
+        &[Val::I64(1), Val::I64(0), Val::I64(-1), Val::I64(-1)],
         &mut result,
     )
     .expect("call to ge-int failed");
@@ -1544,7 +1544,7 @@ fn test_ge_int() {
     // -2 >= -1 is false
     ge.call(
         &mut store,
-        &[Val::I64(-1), Val::I64(-2), Val::I64(-1), Val::I64(-1)],
+        &[Val::I64(-2), Val::I64(-1), Val::I64(-1), Val::I64(-1)],
         &mut result,
     )
     .expect("call to ge-int failed");
@@ -1553,7 +1553,7 @@ fn test_ge_int() {
     // -2 >= -3 is true
     ge.call(
         &mut store,
-        &[Val::I64(-1), Val::I64(-2), Val::I64(-1), Val::I64(-3)],
+        &[Val::I64(-2), Val::I64(-1), Val::I64(-3), Val::I64(-1)],
         &mut result,
     )
     .expect("call to ge-int failed");
@@ -1562,7 +1562,7 @@ fn test_ge_int() {
     // I128::MIN >= -1 is false
     ge.call(
         &mut store,
-        &[Val::I64(i64::MIN), Val::I64(0), Val::I64(-1), Val::I64(-1)],
+        &[Val::I64(0), Val::I64(i64::MIN), Val::I64(-1), Val::I64(-1)],
         &mut result,
     )
     .expect("call to ge-int failed");
@@ -1571,7 +1571,7 @@ fn test_ge_int() {
     // -1 >= I128::MIN is true
     ge.call(
         &mut store,
-        &[Val::I64(-1), Val::I64(-1), Val::I64(i64::MIN), Val::I64(0)],
+        &[Val::I64(-1), Val::I64(-1), Val::I64(0), Val::I64(i64::MIN)],
         &mut result,
     )
     .expect("call to ge-int failed");
@@ -1591,20 +1591,20 @@ fn test_log2_uint() {
     // log2(u128::MAX) is not an error (-1 if signed)
     log2.call(&mut store, &[Val::I64(-1), Val::I64(-1)], &mut result)
         .expect("call to log2-uint failed");
-    assert_eq!(result[0].i64(), Some(0));
-    assert_eq!(result[1].i64(), Some(127));
+    assert_eq!(result[0].i64(), Some(127));
+    assert_eq!(result[1].i64(), Some(0));
 
     // log2(u64::MAX) is not an error
-    log2.call(&mut store, &[Val::I64(0), Val::I64(-1)], &mut result)
-        .expect("call to log2-uint failed");
-    assert_eq!(result[0].i64(), Some(0));
-    assert_eq!(result[1].i64(), Some(63));
-
-    // log2(u128::MAX-u64::MAX) is not an error
     log2.call(&mut store, &[Val::I64(-1), Val::I64(0)], &mut result)
         .expect("call to log2-uint failed");
-    assert_eq!(result[0].i64(), Some(0));
-    assert_eq!(result[1].i64(), Some(127));
+    assert_eq!(result[0].i64(), Some(63));
+    assert_eq!(result[1].i64(), Some(0));
+
+    // log2(u128::MAX-u64::MAX) is not an error
+    log2.call(&mut store, &[Val::I64(0), Val::I64(-1)], &mut result)
+        .expect("call to log2-uint failed");
+    assert_eq!(result[0].i64(), Some(127));
+    assert_eq!(result[1].i64(), Some(0));
 }
 
 #[test]
@@ -1622,12 +1622,12 @@ fn test_log2_int() {
         .expect_err("expected log of negative number error");
 
     // log2(u64::MAX) is not an error
-    log2.call(&mut store, &[Val::I64(0), Val::I64(-1)], &mut result)
+    log2.call(&mut store, &[Val::I64(-1), Val::I64(0)], &mut result)
         .expect("call to log2-int failed");
-    assert_eq!(result[0].i64(), Some(0));
-    assert_eq!(result[1].i64(), Some(63));
+    assert_eq!(result[0].i64(), Some(63));
+    assert_eq!(result[1].i64(), Some(0));
 
     // log2(u128::MAX-u64::MAX) is an error
-    log2.call(&mut store, &[Val::I64(-1), Val::I64(0)], &mut result)
+    log2.call(&mut store, &[Val::I64(0), Val::I64(-1)], &mut result)
         .expect_err("expected log of negative number error");
 }

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -15,8 +15,8 @@ fn test_add_uint() {
         &mut sum,
     )
     .expect("call to add-uint failed");
-    assert_eq!(sum[1].i64(), Some(0));
     assert_eq!(sum[0].i64(), Some(0));
+    assert_eq!(sum[1].i64(), Some(0));
 
     // 1 + 2 = 3
     add.call(

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -113,13 +113,13 @@ fn map_wasm_result(fn_sig: &FunctionType, result: &[Val]) -> Value {
 fn map_wasm_value(type_sig: &TypeSignature, index: usize, buffer: &[Val]) -> (Value, usize) {
     match type_sig {
         TypeSignature::IntType => {
-            let upper = buffer[index].unwrap_i64();
-            let lower = buffer[index + 1].unwrap_i64();
+            let lower = buffer[index].unwrap_i64();
+            let upper = buffer[index + 1].unwrap_i64();
             (Value::Int(((upper as i128) << 64) | lower as i128), 2)
         }
         TypeSignature::UIntType => {
-            let upper = buffer[index].unwrap_i64();
-            let lower = buffer[index + 1].unwrap_i64();
+            let lower = buffer[index].unwrap_i64();
+            let upper = buffer[index + 1].unwrap_i64();
             (Value::UInt(((upper as u128) << 64) | lower as u128), 2)
         }
         TypeSignature::BoolType => (Value::Bool(buffer[index].unwrap_i32() != 0), 1),

--- a/tests/tests/lib_tests.rs
+++ b/tests/tests/lib_tests.rs
@@ -114,7 +114,7 @@ test_contract!(
     test_call_public_with_args,
     "call-public-with-args",
     "simple",
-    &[Val::I64(0), Val::I64(20), Val::I64(0), Val::I64(22)],
+    &[Val::I64(20), Val::I64(0), Val::I64(22), Val::I64(0)],
     |response: ResponseData| {
         assert!(response.committed);
         assert_eq!(*response.data, Value::Int(42));


### PR DESCRIPTION
Fixes #49 

This PR reverses the passing order of high and low parts of int and uint, to give them a better little-endianness feeling.