### PR TITLE
test: Clean up and de-duplicate the property test runners

### DIFF
--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -102,47 +102,16 @@ fn prop_log2_int() {
 
 #[test]
 fn prop_sqrti_uint() {
-    let (instance, store) = load_stdlib().unwrap();
-    let store = RefCell::new(store);
-    let sqrti = instance
-        .get_func(store.borrow_mut().deref_mut(), "sqrti-uint")
-        .unwrap();
-
-    proptest!(|(n in int128())| {
-        let mut res = [Val::I64(0), Val::I64(0)];
-        sqrti.call(
-            store.borrow_mut().deref_mut(),
-            &[n.low().into(), n.high().into()],
-            &mut res,
-        ).expect("call to sqrti-uint failed");
-        let rust_result = num_integer::Roots::sqrt(&n.unsigned());
-        let wasm_result = PropInt::from_wasm(res[0].i64().unwrap(), res[1].i64().unwrap());
-        prop_assert_eq!(rust_result, wasm_result.unsigned())
-    })
+    utils::test_export_one_arg("sqrti-uint", |a: u128| num_integer::Roots::sqrt(&a) as u128)
 }
 
 #[test]
 fn prop_sqrti_int() {
-    let (instance, store) = load_stdlib().unwrap();
-    let store = RefCell::new(store);
-    let sqrti = instance
-        .get_func(store.borrow_mut().deref_mut(), "sqrti-int")
-        .unwrap();
-
-    proptest!(|(n in int128())| {
-        let mut res = [Val::I64(0), Val::I64(0)];
-        let call = sqrti.call(
-            store.borrow_mut().deref_mut(),
-            &[n.low().into(), n.high().into()],
-            &mut res,
-        );
-        if n.signed() > 0 {
-            call.expect("call to sqrti-int failed");
-            let rust_result = num_integer::Roots::sqrt(&n.signed());
-            let wasm_result = PropInt::from_wasm(res[0].i64().unwrap(), res[1].i64().unwrap());
-            prop_assert_eq!(rust_result, wasm_result.signed())
+    utils::test_export_one_arg_checked("sqrti-int", |a: i128| {
+        if a > 0 {
+            Some(num_integer::Roots::sqrt(&a))
         } else {
-            call.expect_err("expected sqrti of negative number");
+            None
         }
     })
 }

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -1,508 +1,103 @@
-use std::{cell::RefCell, ops::DerefMut};
-
-use crate::utils::load_stdlib;
-
-use proptest::prelude::*;
-use wasmtime::Val;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-struct PropInt(u128);
-
-impl PropInt {
-    const fn new(n: u128) -> Self {
-        Self(n)
-    }
-
-    const fn from_wasm(low: i64, high: i64) -> Self {
-        Self(((high as u64) as u128) << 64 | ((low as u64) as u128))
-    }
-
-    const fn signed(&self) -> i128 {
-        self.0 as i128
-    }
-
-    const fn unsigned(&self) -> u128 {
-        self.0
-    }
-
-    const fn high(&self) -> i64 {
-        (self.0 >> 64) as i64
-    }
-
-    const fn low(&self) -> i64 {
-        self.0 as i64
-    }
-}
-
-prop_compose! {
-    fn int128()(n in any::<u128>()) -> PropInt {
-        PropInt::new(n)
-    }
-}
+use crate::utils;
 
 #[test]
 fn prop_add_uint() {
-    let (instance, store) = load_stdlib().unwrap();
-    let store = RefCell::new(store);
-    let add = instance
-        .get_func(store.borrow_mut().deref_mut(), "add-uint")
-        .unwrap();
-
-    proptest!(|(n in int128(), m in int128())| {
-        let mut res = [Val::I64(0), Val::I64(0)];
-        let call = add.call(
-            store.borrow_mut().deref_mut(),
-            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
-            &mut res,
-        );
-        match n.unsigned().checked_add(m.unsigned()) {
-            Some(rust_result) => {
-                call.expect("call to add-uint failed");
-                let wasm_result = PropInt::from_wasm(res[0].i64().unwrap(), res[1].i64().unwrap());
-                prop_assert_eq!(rust_result, wasm_result.unsigned());
-            }
-            None => { call.expect_err("expected overflow"); }
-        }
-    })
+    utils::test_export_two_args_checked("add-uint", |a: u128, b: u128| a.checked_add(b))
 }
 
 #[test]
 fn prop_add_int() {
-    let (instance, store) = load_stdlib().unwrap();
-    let store = RefCell::new(store);
-    let add = instance
-        .get_func(store.borrow_mut().deref_mut(), "add-int")
-        .unwrap();
-
-    proptest!(|(n in int128(), m in int128())| {
-        let mut res = [Val::I64(0), Val::I64(0)];
-        let call = add.call(
-            store.borrow_mut().deref_mut(),
-            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
-            &mut res,
-        );
-        match n.signed().checked_add(m.signed()) {
-            Some(rust_result) => {
-                call.expect("call to add-int failed");
-                let wasm_result = PropInt::from_wasm(res[0].i64().unwrap(), res[1].i64().unwrap());
-                prop_assert_eq!(rust_result, wasm_result.signed());
-            }
-            None => { call.expect_err("expected overflow"); }
-        }
-    })
+    utils::test_export_two_args_checked("add-int", |a: i128, b: i128| a.checked_add(b))
 }
 
 #[test]
 fn prop_sub_uint() {
-    let (instance, store) = load_stdlib().unwrap();
-    let store = RefCell::new(store);
-    let sub = instance
-        .get_func(store.borrow_mut().deref_mut(), "sub-uint")
-        .unwrap();
-
-    proptest!(|(n in int128(), m in int128())| {
-        let mut res = [Val::I64(0), Val::I64(0)];
-        let call = sub.call(
-            store.borrow_mut().deref_mut(),
-            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
-            &mut res,
-        );
-        match n.unsigned().checked_sub(m.unsigned()) {
-            Some(rust_result) => {
-                call.expect("call to sub-uint failed");
-                let wasm_result = PropInt::from_wasm(res[0].i64().unwrap(), res[1].i64().unwrap());
-                prop_assert_eq!(rust_result, wasm_result.unsigned());
-            }
-            None => { call.expect_err("expected underflow"); }
-        }
-    })
+    utils::test_export_two_args_checked("sub-uint", |a: u128, b: u128| a.checked_sub(b))
 }
 
 #[test]
 fn prop_sub_int() {
-    let (instance, store) = load_stdlib().unwrap();
-    let store = RefCell::new(store);
-    let sub = instance
-        .get_func(store.borrow_mut().deref_mut(), "sub-int")
-        .unwrap();
-
-    proptest!(|(n in int128(), m in int128())| {
-        let mut res = [Val::I64(0), Val::I64(0)];
-        let call = sub.call(
-            store.borrow_mut().deref_mut(),
-            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
-            &mut res,
-        );
-        match n.signed().checked_sub(m.signed()) {
-            Some(rust_result) => {
-                call.expect("call to sub-int failed");
-                let wasm_result = PropInt::from_wasm(res[0].i64().unwrap(), res[1].i64().unwrap());
-                prop_assert_eq!(rust_result, wasm_result.signed());
-            }
-            None => { call.expect_err("expected underflow"); }
-        }
-    })
+    utils::test_export_two_args_checked("sub-int", |a: i128, b: i128| a.checked_sub(b))
 }
 
 #[test]
 fn prop_mul_uint() {
-    let (instance, store) = load_stdlib().unwrap();
-    let store = RefCell::new(store);
-    let mul = instance
-        .get_func(store.borrow_mut().deref_mut(), "mul-uint")
-        .unwrap();
-
-    proptest!(|(n in int128(), m in int128())| {
-        let mut res = [Val::I64(0), Val::I64(0)];
-        let call = mul.call(
-            store.borrow_mut().deref_mut(),
-            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
-            &mut res,
-        );
-        match n.unsigned().checked_mul(m.unsigned()) {
-            Some(rust_result) => {
-                call.expect("call to mul-uint failed");
-                let wasm_result = PropInt::from_wasm(res[0].i64().unwrap(), res[1].i64().unwrap());
-                prop_assert_eq!(rust_result, wasm_result.unsigned());
-            }
-            None => { call.expect_err("expected overflow"); }
-        }
-    })
+    utils::test_export_two_args_checked("mul-uint", |a: u128, b: u128| a.checked_mul(b))
 }
 
 #[test]
 fn prop_mul_int() {
-    let (instance, store) = load_stdlib().unwrap();
-    let store = RefCell::new(store);
-    let mul = instance
-        .get_func(store.borrow_mut().deref_mut(), "mul-int")
-        .unwrap();
-
-    proptest!(|(n in int128(), m in int128())| {
-        let mut res = [Val::I64(0), Val::I64(0)];
-        let call = mul.call(
-            store.borrow_mut().deref_mut(),
-            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
-            &mut res,
-        );
-        match n.signed().checked_mul(m.signed()) {
-            Some(rust_result) => {
-                call.expect("call to mul-int failed");
-                let wasm_result = PropInt::from_wasm(res[0].i64().unwrap(), res[1].i64().unwrap());
-                prop_assert_eq!(rust_result, wasm_result.signed());
-            }
-            None => { call.expect_err("expected overflow"); }
-        }
-    })
+    utils::test_export_two_args_checked("mul-int", |a: i128, b: i128| a.checked_mul(b))
 }
 
 #[test]
 fn prop_div_uint() {
-    let (instance, store) = load_stdlib().unwrap();
-    let store = RefCell::new(store);
-    let div = instance
-        .get_func(store.borrow_mut().deref_mut(), "div-uint")
-        .unwrap();
-
-    proptest!(|(n in int128(), m in int128())| {
-        let mut res = [Val::I64(0), Val::I64(0)];
-        let call = div.call(
-            store.borrow_mut().deref_mut(),
-            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
-            &mut res,
-        );
-        match n.unsigned().checked_div(m.unsigned()) {
-            Some(rust_result) => {
-                call.expect("call to div-uint failed");
-                let wasm_result = PropInt::from_wasm(res[0].i64().unwrap(), res[1].i64().unwrap());
-                prop_assert_eq!(rust_result, wasm_result.unsigned());
-            }
-            None => { call.expect_err("expected divide by zero"); }
-        }
-    })
+    utils::test_export_two_args_checked("div-uint", |a: u128, b: u128| a.checked_div(b))
 }
 
 #[test]
 fn prop_div_int() {
-    let (instance, store) = load_stdlib().unwrap();
-    let store = RefCell::new(store);
-    let div = instance
-        .get_func(store.borrow_mut().deref_mut(), "div-int")
-        .unwrap();
-
-    proptest!(|(n in int128(), m in int128())| {
-        let mut res = [Val::I64(0), Val::I64(0)];
-        let call = div.call(
-            store.borrow_mut().deref_mut(),
-            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
-            &mut res,
-        );
-        match n.signed().checked_div(m.signed()) {
-            Some(rust_result) => {
-                call.expect("call to div-int failed");
-                let wasm_result = PropInt::from_wasm(res[0].i64().unwrap(), res[1].i64().unwrap());
-                prop_assert_eq!(rust_result, wasm_result.signed());
-            }
-            None => { call.expect_err("expected divide by zero"); }
-        }
-    })
+    utils::test_export_two_args_checked("div-int", |a: i128, b: i128| a.checked_div(b))
 }
 
 #[test]
 fn prop_mod_uint() {
-    let (instance, store) = load_stdlib().unwrap();
-    let store = RefCell::new(store);
-    let modulo = instance
-        .get_func(store.borrow_mut().deref_mut(), "mod-uint")
-        .unwrap();
-
-    proptest!(|(n in int128(), m in int128())| {
-        let mut res = [Val::I64(0), Val::I64(0)];
-        let call = modulo.call(
-            store.borrow_mut().deref_mut(),
-            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
-            &mut res,
-        );
-        match n.unsigned().checked_rem(m.unsigned()) {
-            Some(rust_result) => {
-                call.expect("call to mod-uint failed");
-                let wasm_result = PropInt::from_wasm(res[0].i64().unwrap(), res[1].i64().unwrap());
-                prop_assert_eq!(rust_result, wasm_result.unsigned());
-            }
-            None => { call.expect_err("expected divide by zero"); }
-        }
-    })
+    utils::test_export_two_args_checked("mod-uint", |a: u128, b: u128| a.checked_rem(b))
 }
 
 #[test]
 fn prop_mod_int() {
-    let (instance, store) = load_stdlib().unwrap();
-    let store = RefCell::new(store);
-    let modulo = instance
-        .get_func(store.borrow_mut().deref_mut(), "mod-int")
-        .unwrap();
-
-    proptest!(|(n in int128(), m in int128())| {
-        let mut res = [Val::I64(0), Val::I64(0)];
-        let call = modulo.call(
-            store.borrow_mut().deref_mut(),
-            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
-            &mut res,
-        );
-        match n.signed().checked_rem(m.signed()) {
-            Some(rust_result) => {
-                call.expect("call to div-int failed");
-                let wasm_result = PropInt::from_wasm(res[0].i64().unwrap(), res[1].i64().unwrap());
-                prop_assert_eq!(rust_result, wasm_result.signed());
-            }
-            None if m.signed() == 0 => { call.expect_err("expected divide by zero"); }
-            None => { call.expect_err("expected overflow"); }
-        }
-    })
+    utils::test_export_two_args_checked("mod-int", |a: i128, b: i128| a.checked_rem(b))
 }
 
 #[test]
 fn prop_lt_uint() {
-    let (instance, store) = load_stdlib().unwrap();
-    let store = RefCell::new(store);
-    let lt = instance
-        .get_func(store.borrow_mut().deref_mut(), "lt-uint")
-        .unwrap();
-
-    proptest!(|(n in int128(), m in int128())| {
-        let mut res = [Val::I32(0)];
-        lt.call(
-            store.borrow_mut().deref_mut(),
-            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
-            &mut res,
-        ).expect("call to lt-uint failed");
-        prop_assert_eq!(n.unsigned() < m.unsigned(), res[0].i32().unwrap() == 1);
-    })
+    utils::test_export_two_args("lt-uint", |a: u128, b: u128| a < b)
 }
 
 #[test]
 fn prop_lt_int() {
-    let (instance, store) = load_stdlib().unwrap();
-    let store = RefCell::new(store);
-    let lt = instance
-        .get_func(store.borrow_mut().deref_mut(), "lt-int")
-        .unwrap();
-
-    proptest!(|(n in int128(), m in int128())| {
-        let mut res = [Val::I32(0)];
-        lt.call(
-            store.borrow_mut().deref_mut(),
-            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
-            &mut res,
-        ).expect("call to lt-int failed");
-        prop_assert_eq!(n.signed() < m.signed(), res[0].i32().unwrap() == 1);
-    })
+    utils::test_export_two_args("lt-int", |a: i128, b: i128| a < b);
 }
 
 #[test]
 fn prop_gt_uint() {
-    let (instance, store) = load_stdlib().unwrap();
-    let store = RefCell::new(store);
-    let gt = instance
-        .get_func(store.borrow_mut().deref_mut(), "gt-uint")
-        .unwrap();
-
-    proptest!(|(n in int128(), m in int128())| {
-        let mut res = [Val::I32(0)];
-        gt.call(
-            store.borrow_mut().deref_mut(),
-            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
-            &mut res,
-        ).expect("call to gt-uint failed");
-        prop_assert_eq!(n.unsigned() > m.unsigned(), res[0].i32().unwrap() == 1);
-    })
+    utils::test_export_two_args("gt-uint", |a: u128, b: u128| a > b);
 }
 
 #[test]
 fn prop_gt_int() {
-    let (instance, store) = load_stdlib().unwrap();
-    let store = RefCell::new(store);
-    let gt = instance
-        .get_func(store.borrow_mut().deref_mut(), "gt-int")
-        .unwrap();
-
-    proptest!(|(n in int128(), m in int128())| {
-        let mut res = [Val::I32(0)];
-        gt.call(
-            store.borrow_mut().deref_mut(),
-            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
-            &mut res,
-        ).expect("call to gt-int failed");
-        prop_assert_eq!(n.signed() > m.signed(), res[0].i32().unwrap() == 1);
-    })
+    utils::test_export_two_args("gt-int", |a: i128, b: i128| a > b);
 }
 
 #[test]
 fn prop_le_uint() {
-    let (instance, store) = load_stdlib().unwrap();
-    let store = RefCell::new(store);
-    let le = instance
-        .get_func(store.borrow_mut().deref_mut(), "le-uint")
-        .unwrap();
-
-    proptest!(|(n in int128(), m in int128())| {
-        let mut res = [Val::I32(0)];
-        le.call(
-            store.borrow_mut().deref_mut(),
-            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
-            &mut res,
-        ).expect("call to le-uint failed");
-        prop_assert_eq!(n.unsigned() <= m.unsigned(), res[0].i32().unwrap() == 1);
-    })
+    utils::test_export_two_args("le-uint", |a: u128, b: u128| a <= b);
 }
 
 #[test]
 fn prop_le_int() {
-    let (instance, store) = load_stdlib().unwrap();
-    let store = RefCell::new(store);
-    let le = instance
-        .get_func(store.borrow_mut().deref_mut(), "le-int")
-        .unwrap();
-
-    proptest!(|(n in int128(), m in int128())| {
-        let mut res = [Val::I32(0)];
-        le.call(
-            store.borrow_mut().deref_mut(),
-            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
-            &mut res,
-        ).expect("call to le-int failed");
-        prop_assert_eq!(n.signed() <= m.signed(), res[0].i32().unwrap() == 1);
-    })
+    utils::test_export_two_args("le-int", |a: i128, b: i128| a <= b);
 }
 
 #[test]
 fn prop_ge_uint() {
-    let (instance, store) = load_stdlib().unwrap();
-    let store = RefCell::new(store);
-    let ge = instance
-        .get_func(store.borrow_mut().deref_mut(), "ge-uint")
-        .unwrap();
-
-    proptest!(|(n in int128(), m in int128())| {
-        let mut res = [Val::I32(0)];
-        ge.call(
-            store.borrow_mut().deref_mut(),
-            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
-            &mut res,
-        ).expect("call to ge-uint failed");
-        prop_assert_eq!(n.unsigned() >= m.unsigned(), res[0].i32().unwrap() == 1);
-    })
+    utils::test_export_two_args("ge-uint", |a: u128, b: u128| a >= b);
 }
 
 #[test]
 fn prop_ge_int() {
-    let (instance, store) = load_stdlib().unwrap();
-    let store = RefCell::new(store);
-    let ge = instance
-        .get_func(store.borrow_mut().deref_mut(), "ge-int")
-        .unwrap();
-
-    proptest!(|(n in int128(), m in int128())| {
-        let mut res = [Val::I32(0)];
-        ge.call(
-            store.borrow_mut().deref_mut(),
-            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
-            &mut res,
-        ).expect("call to ge-int failed");
-        prop_assert_eq!(n.signed() >= m.signed(), res[0].i32().unwrap() == 1);
-    })
+    utils::test_export_two_args("ge-int", |a: i128, b: i128| a >= b);
 }
 
 #[test]
 fn prop_log2_uint() {
-    let (instance, store) = load_stdlib().unwrap();
-    let store = RefCell::new(store);
-    let log2 = instance
-        .get_func(store.borrow_mut().deref_mut(), "log2-uint")
-        .unwrap();
-
-    proptest!(|(n in int128())| {
-        let mut res = [Val::I64(0), Val::I64(0)];
-        let call = log2.call(
-            store.borrow_mut().deref_mut(),
-            &[n.low().into(), n.high().into()],
-            &mut res,
-        );
-        match n.unsigned().checked_ilog2() {
-            Some(rust_result) => {
-                call.expect("call to log2-uint failed");
-                let wasm_result = PropInt::from_wasm(res[0].i64().unwrap(), res[1].i64().unwrap());
-                prop_assert_eq!(rust_result as u128, wasm_result.unsigned());
-            }
-            None => { call.expect_err("expected log2 of 0"); }
-        }
-    })
+    utils::test_export_one_arg_checked("log2-uint", |a: u128| a.checked_ilog2().map(|u| u as u128))
 }
 
 #[test]
 fn prop_log2_int() {
-    let (instance, store) = load_stdlib().unwrap();
-    let store = RefCell::new(store);
-    let log2 = instance
-        .get_func(store.borrow_mut().deref_mut(), "log2-int")
-        .unwrap();
-
-    proptest!(|(n in int128())| {
-        let mut res = [Val::I64(0), Val::I64(0)];
-        let call = log2.call(
-            store.borrow_mut().deref_mut(),
-            &[n.low().into(), n.high().into()],
-            &mut res,
-        );
-        match n.signed().checked_ilog2() {
-            Some(rust_result) => {
-                call.expect("call to log2-int failed");
-                let wasm_result = PropInt::from_wasm(res[0].i64().unwrap(), res[1].i64().unwrap());
-                prop_assert_eq!(rust_result as i128, wasm_result.signed());
-            }
-            None => { call.expect_err("expected log2 of negative number or 0"); }
-        }
-    })
+    utils::test_export_one_arg_checked("log2-int", |a: i128| a.checked_ilog2().map(|u| u as i128))
 }
 
 #[test]

--- a/clar2wasm/tests/standard/utils.rs
+++ b/clar2wasm/tests/standard/utils.rs
@@ -159,7 +159,7 @@ where
             store.borrow_mut().deref_mut(),
             &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
             res_slice,
-        ).expect("call to succeed");
+        ).expect(&format!("Could not call exported function {name}"));
 
 		let rust_result = closure(n.into(), m.into());
 		let wasm_result = R::from_wasm_result(res_slice);
@@ -201,8 +201,7 @@ where
     });
 }
 
-#[allow(unused)]
-pub(crate) fn test_export_one_arg<N, M, R, C>(name: &str, closure: C)
+pub(crate) fn test_export_one_arg<N, R, C>(name: &str, closure: C)
 where
     N: From<PropInt>,
     R: FromWasmResult + PartialEq + std::fmt::Debug,
@@ -222,7 +221,7 @@ where
             store.borrow_mut().deref_mut(),
             &[n.low().into(), n.high().into()],
             res_slice,
-        ).expect("call to succeed");
+        ).expect(&format("Could not call exported function {name}"));
 
 		let rust_result = closure(n.into());
 		let wasm_result = R::from_wasm_result(res_slice);

--- a/clar2wasm/tests/standard/utils.rs
+++ b/clar2wasm/tests/standard/utils.rs
@@ -153,18 +153,18 @@ where
 
     proptest!(|(n in int128(), m in int128())| {
         let mut res = [Val::I64(0), Val::I64(0)];
-		let res_slice = R::relevant_slice(&mut res);
+        let res_slice = R::relevant_slice(&mut res);
 
-		fun.call(
+        fun.call(
             store.borrow_mut().deref_mut(),
             &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
             res_slice,
         ).expect(&format!("Could not call exported function {name}"));
 
-		let rust_result = closure(n.into(), m.into());
-		let wasm_result = R::from_wasm_result(res_slice);
+        let rust_result = closure(n.into(), m.into());
+        let wasm_result = R::from_wasm_result(res_slice);
 
-		prop_assert_eq!(rust_result, wasm_result);
+        prop_assert_eq!(rust_result, wasm_result);
     });
 }
 
@@ -191,13 +191,13 @@ where
         );
 
         match closure(n.into(), m.into()) {
-			Some(rust_result) => {
-				call.expect(&format!("call to {name} failed"));
-				let wasm_result = R::from_wasm_result(&res);
-				prop_assert_eq!(rust_result, wasm_result);
-			},
-			None => { call.expect_err("expected error"); }
-		}
+            Some(rust_result) => {
+                call.expect(&format!("call to {name} failed"));
+                let wasm_result = R::from_wasm_result(&res);
+                prop_assert_eq!(rust_result, wasm_result);
+            },
+            None => { call.expect_err("expected error"); }
+        }
     });
 }
 
@@ -215,18 +215,18 @@ where
 
     proptest!(|(n in int128())| {
         let mut res = [Val::I64(0), Val::I64(0)];
-		let res_slice = R::relevant_slice(&mut res);
+        let res_slice = R::relevant_slice(&mut res);
 
-		fun.call(
+        fun.call(
             store.borrow_mut().deref_mut(),
             &[n.low().into(), n.high().into()],
             res_slice,
-        ).expect(&format("Could not call exported function {name}"));
+        ).expect(&format!("Could not call exported function {name}"));
 
-		let rust_result = closure(n.into());
-		let wasm_result = R::from_wasm_result(res_slice);
+        let rust_result = closure(n.into());
+        let wasm_result = R::from_wasm_result(res_slice);
 
-		prop_assert_eq!(rust_result, wasm_result);
+        prop_assert_eq!(rust_result, wasm_result);
     });
 }
 
@@ -252,12 +252,12 @@ where
         );
 
         match closure(n.into()) {
-			Some(rust_result) => {
-				call.expect(&format!("call to {name} failed"));
-				let wasm_result = R::from_wasm_result(&res);
-				prop_assert_eq!(rust_result, wasm_result);
-			},
-			None => { call.expect_err("expected error"); }
-		}
+            Some(rust_result) => {
+                call.expect(&format!("call to {name} failed"));
+                let wasm_result = R::from_wasm_result(&res);
+                prop_assert_eq!(rust_result, wasm_result);
+            },
+            None => { call.expect_err("expected error"); }
+        }
     });
 }

--- a/clar2wasm/tests/standard/utils.rs
+++ b/clar2wasm/tests/standard/utils.rs
@@ -1,3 +1,6 @@
+use proptest::prelude::*;
+use std::{cell::RefCell, ops::DerefMut};
+use wasmtime::Val;
 use wasmtime::{Caller, Engine, Instance, Linker, Module, Store};
 
 /// Load the standard library into a Wasmtime instance. This is used to load in
@@ -55,4 +58,207 @@ pub(crate) fn load_stdlib() -> Result<(Instance, Store<()>), wasmtime::Error> {
     let module = Module::new(&engine, standard_lib).unwrap();
     let instance = linker.instantiate(&mut store, &module)?;
     Ok((instance, store))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct PropInt(u128);
+
+impl PropInt {
+    pub const fn new(n: u128) -> Self {
+        Self(n)
+    }
+
+    pub const fn high(&self) -> i64 {
+        (self.0 >> 64) as i64
+    }
+
+    pub const fn low(&self) -> i64 {
+        self.0 as i64
+    }
+}
+
+impl From<PropInt> for u128 {
+    fn from(p: PropInt) -> u128 {
+        p.0 as u128
+    }
+}
+
+impl From<PropInt> for i128 {
+    fn from(p: PropInt) -> i128 {
+        p.0 as i128
+    }
+}
+
+/// Convenience trait to unify the result handling of different return values
+pub(crate) trait FromWasmResult {
+    fn from_wasm_result(v: &[Val]) -> Self;
+    fn relevant_slice(s: &mut [Val]) -> &mut [Val];
+}
+
+impl FromWasmResult for u128 {
+    fn from_wasm_result(v: &[Val]) -> Self {
+        match v {
+            &[Val::I64(lo), Val::I64(hi)] => ((lo as u64) as u128) | ((hi as u64) as u128) << 64,
+            _ => panic!("invalid wasm result"),
+        }
+    }
+
+    fn relevant_slice(s: &mut [Val]) -> &mut [Val] {
+        &mut s[..2]
+    }
+}
+
+impl FromWasmResult for i128 {
+    fn from_wasm_result(v: &[Val]) -> Self {
+        u128::from_wasm_result(v) as i128
+    }
+
+    fn relevant_slice(s: &mut [Val]) -> &mut [Val] {
+        &mut s[..2]
+    }
+}
+
+impl FromWasmResult for bool {
+    fn from_wasm_result(v: &[Val]) -> Self {
+        match v {
+            &[Val::I32(0), ..] => false,
+            &[Val::I32(1), ..] => true,
+            _ => panic!("invalid wasm result"),
+        }
+    }
+
+    fn relevant_slice(s: &mut [Val]) -> &mut [Val] {
+        &mut s[..1]
+    }
+}
+
+prop_compose! {
+    pub(crate) fn int128()(n in any::<u128>()) -> PropInt {
+        PropInt::new(n)
+    }
+}
+
+pub(crate) fn test_export_two_args<N, M, R, C>(name: &str, closure: C)
+where
+    N: From<PropInt>,
+    M: From<PropInt>,
+    R: FromWasmResult + PartialEq + std::fmt::Debug,
+    C: Fn(N, M) -> R,
+{
+    let (instance, store) = load_stdlib().unwrap();
+    let store = RefCell::new(store);
+    let fun = instance
+        .get_func(store.borrow_mut().deref_mut(), name)
+        .unwrap();
+
+    proptest!(|(n in int128(), m in int128())| {
+        let mut res = [Val::I64(0), Val::I64(0)];
+		let res_slice = R::relevant_slice(&mut res);
+
+		fun.call(
+            store.borrow_mut().deref_mut(),
+            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
+            res_slice,
+        ).expect("call to succeed");
+
+		let rust_result = closure(n.into(), m.into());
+		let wasm_result = R::from_wasm_result(res_slice);
+
+		prop_assert_eq!(rust_result, wasm_result);
+    });
+}
+
+pub(crate) fn test_export_two_args_checked<N, M, R, C>(name: &str, closure: C)
+where
+    N: From<PropInt>,
+    M: From<PropInt>,
+    R: FromWasmResult + PartialEq + std::fmt::Debug,
+    C: Fn(N, M) -> Option<R>,
+{
+    let (instance, store) = load_stdlib().unwrap();
+    let store = RefCell::new(store);
+    let fun = instance
+        .get_func(store.borrow_mut().deref_mut(), name)
+        .unwrap();
+
+    proptest!(|(n in int128(), m in int128())| {
+        let mut res = [Val::I64(0), Val::I64(0)];
+
+        let call = fun.call(
+            store.borrow_mut().deref_mut(),
+            &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
+            &mut res,
+        );
+
+        match closure(n.into(), m.into()) {
+			Some(rust_result) => {
+				call.expect(&format!("call to {name} failed"));
+				let wasm_result = R::from_wasm_result(&res);
+				prop_assert_eq!(rust_result, wasm_result);
+			},
+			None => { call.expect_err("expected error"); }
+		}
+    });
+}
+
+#[allow(unused)]
+pub(crate) fn test_export_one_arg<N, M, R, C>(name: &str, closure: C)
+where
+    N: From<PropInt>,
+    R: FromWasmResult + PartialEq + std::fmt::Debug,
+    C: Fn(N) -> R,
+{
+    let (instance, store) = load_stdlib().unwrap();
+    let store = RefCell::new(store);
+    let fun = instance
+        .get_func(store.borrow_mut().deref_mut(), name)
+        .unwrap();
+
+    proptest!(|(n in int128())| {
+        let mut res = [Val::I64(0), Val::I64(0)];
+		let res_slice = R::relevant_slice(&mut res);
+
+		fun.call(
+            store.borrow_mut().deref_mut(),
+            &[n.low().into(), n.high().into()],
+            res_slice,
+        ).expect("call to succeed");
+
+		let rust_result = closure(n.into());
+		let wasm_result = R::from_wasm_result(res_slice);
+
+		prop_assert_eq!(rust_result, wasm_result);
+    });
+}
+
+pub(crate) fn test_export_one_arg_checked<N, R, C>(name: &str, closure: C)
+where
+    N: From<PropInt>,
+    R: FromWasmResult + PartialEq + std::fmt::Debug,
+    C: Fn(N) -> Option<R>,
+{
+    let (instance, store) = load_stdlib().unwrap();
+    let store = RefCell::new(store);
+    let fun = instance
+        .get_func(store.borrow_mut().deref_mut(), name)
+        .unwrap();
+
+    proptest!(|(n in int128())| {
+        let mut res = [Val::I64(0), Val::I64(0)];
+
+        let call = fun.call(
+            store.borrow_mut().deref_mut(),
+            &[n.low().into(), n.high().into()],
+            &mut res,
+        );
+
+        match closure(n.into()) {
+			Some(rust_result) => {
+				call.expect(&format!("call to {name} failed"));
+				let wasm_result = R::from_wasm_result(&res);
+				prop_assert_eq!(rust_result, wasm_result);
+			},
+			None => { call.expect_err("expected error"); }
+		}
+    });
 }


### PR DESCRIPTION
## Description

This removes a lot of duplicated code in the property test runner.

There was a lot of copy-pasting happening in the property tests, which led to some friction in adding new test, and some error messages referenced the wrong names, easy to overlook errors when copy pasting.