### PR TITLE
ci: add clippy checks in tests and benches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,4 +39,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - run: cargo clippy --all --all-features -- -D warnings 
+      - run: cargo clippy --workspace --all-features --all-targets -- -D warnings 

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -102,7 +102,7 @@ fn prop_log2_int() {
 
 #[test]
 fn prop_sqrti_uint() {
-    utils::test_export_one_arg("sqrti-uint", |a: u128| num_integer::Roots::sqrt(&a) as u128)
+    utils::test_export_one_arg("sqrti-uint", |a: u128| num_integer::Roots::sqrt(&a))
 }
 
 #[test]

--- a/clar2wasm/tests/standard/utils.rs
+++ b/clar2wasm/tests/standard/utils.rs
@@ -79,7 +79,7 @@ impl PropInt {
 
 impl From<PropInt> for u128 {
     fn from(p: PropInt) -> u128 {
-        p.0 as u128
+        p.0
     }
 }
 
@@ -121,8 +121,8 @@ impl FromWasmResult for i128 {
 impl FromWasmResult for bool {
     fn from_wasm_result(v: &[Val]) -> Self {
         match v {
-            &[Val::I32(0), ..] => false,
-            &[Val::I32(1), ..] => true,
+            [Val::I32(0), ..] => false,
+            [Val::I32(1), ..] => true,
             _ => panic!("invalid wasm result"),
         }
     }
@@ -159,7 +159,7 @@ where
             store.borrow_mut().deref_mut(),
             &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
             res_slice,
-        ).expect(&format!("Could not call exported function {name}"));
+        ).unwrap_or_else(|_| panic!("Could not call exported function {name}"));
 
         let rust_result = closure(n.into(), m.into());
         let wasm_result = R::from_wasm_result(res_slice);
@@ -192,7 +192,7 @@ where
 
         match closure(n.into(), m.into()) {
             Some(rust_result) => {
-                call.expect(&format!("call to {name} failed"));
+                call.unwrap_or_else(|_| panic!("call to {name} failed"));
                 let wasm_result = R::from_wasm_result(&res);
                 prop_assert_eq!(rust_result, wasm_result);
             },
@@ -221,7 +221,7 @@ where
             store.borrow_mut().deref_mut(),
             &[n.low().into(), n.high().into()],
             res_slice,
-        ).expect(&format!("Could not call exported function {name}"));
+        ).unwrap_or_else(|_| panic!("Could not call exported function {name}"));
 
         let rust_result = closure(n.into());
         let wasm_result = R::from_wasm_result(res_slice);
@@ -253,7 +253,7 @@ where
 
         match closure(n.into()) {
             Some(rust_result) => {
-                call.expect(&format!("call to {name} failed"));
+                call.unwrap_or_else(|_| panic!("call to {name} failed"));
                 let wasm_result = R::from_wasm_result(&res);
                 prop_assert_eq!(rust_result, wasm_result);
             },

--- a/tests/tests/lib_tests.rs
+++ b/tests/tests/lib_tests.rs
@@ -60,6 +60,8 @@ macro_rules! test_contract {
                 if let Value::Response(response_data) =
                     helper.call_public_function($contract_func, $params)
                 {
+                    // https://github.com/rust-lang/rust-clippy/issues/1553
+                    #[allow(clippy::redundant_closure_call)]
                     $test(response_data);
                 } else {
                     panic!("Unexpected result received from WASM function call.");


### PR DESCRIPTION
Reviewing another PR, I noticed that the clippy task in CI does not check tests and benches files.

This PR adds this functionality and fixes now existing warnings.