### PR TITLE
Increase the quantity of property tests

### DIFF
--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -291,6 +291,16 @@
     (func $mul-int (type 1) (param $a_lo i64) (param $a_hi i64) (param $b_lo i64) (param $b_hi i64) (result i64 i64)
         (local $sign i32)
 
+        ;; this is a shortcut for a multiplication by 1.
+        ;; also, it prevents us from dealing with the infamous abs(i128::MIN), and 
+        ;; the only operation that would work on that number would be (i128::MIN * 1)
+        (if (i64.eqz (i64.or (local.get $a_hi) (i64.xor (local.get $a_lo) (i64.const 1))))
+            (return (local.get $b_lo) (local.get $b_hi))
+        )
+        (if (i64.eqz (i64.or (local.get $b_hi) (i64.xor (local.get $b_lo) (i64.const 1))))
+            (return (local.get $a_lo) (local.get $a_hi))
+        )
+
         ;; take the absolute value of the operands, and compute the expected sign in 3 steps:
         ;; 1. Absolute value of a
         (select

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -303,6 +303,8 @@
 
         ;; take the absolute value of the operands, and compute the expected sign in 3 steps:
         ;; 1. Absolute value of a
+        ;; NOTE: the absolute value algorithm was generated from
+        ;;       `fn abs(a: i128) -> i128 { a.abs() }`
         (select
             (i64.sub (i64.const 0) (local.get $a_lo))
             (local.get $a_lo)

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -289,34 +289,59 @@
     
 
     (func $mul-int (type 1) (param $a_lo i64) (param $a_hi i64) (param $b_lo i64) (param $b_hi i64) (result i64 i64)
-        (local $expected_sign i64)
+        (local $sign i32)
 
-        ;; Shortcut if either a or b is zero
-        (if (i32.or
-                (i64.eqz (i64.or (local.get $a_lo) (local.get $a_hi)))
-                (i64.eqz (i64.or (local.get $b_lo) (local.get $b_hi))))
-            (return (i64.const 0) (i64.const 0))
+        ;; take the absolute value of the operands, and compute the expected sign in 3 steps:
+        ;; 1. Absolute value of a
+        (select
+            (i64.sub (i64.const 0) (local.get $a_lo))
+            (local.get $a_lo)
+            (local.tee $sign (i64.lt_s (local.get $a_hi) (i64.const 0))) ;; sign is the sign bit of a
         )
-
-        ;; compute the expected sign of the product
-        (local.set $expected_sign 
-            (i64.xor 
-                (i64.shr_s (local.get $a_hi) (i64.const 63)) 
-                (i64.shr_s (local.get $b_hi) (i64.const 63))
+        (select
+            (i64.sub (i64.const 0) (i64.add (local.get $a_hi) (i64.extend_i32_u (i64.ne (local.get $a_lo) (i64.const 0)))))
+            (local.get $a_hi)
+            (local.get $sign)
+        )
+        ;; 2. Absolute value of b
+        (select
+            (i64.sub (i64.const 0) (local.get $b_lo))
+            (local.get $b_lo)
+            (local.tee $sign (i64.lt_s (local.get $b_hi) (i64.const 0))) ;; sign is sign bit of b now
+        )
+        (select
+            (i64.sub (i64.const 0) (i64.add (local.get $b_hi) (i64.extend_i32_u (i64.ne (local.get $b_lo) (i64.const 0)))))
+            (local.get $b_hi)
+            (local.get $sign) 
+        )
+        ;; 3. Compute expected sign
+        (local.set $sign
+            (i32.xor 
+                (i64.lt_s (local.get $a_hi) (i64.const 0)) ;; sign of a 
+                (local.get $sign) ;; sign is sign of b
             )
-        )
+        ) 
 
-        (call $mul-uint (local.get $a_lo) (local.get $a_hi) (local.get $b_lo) (local.get $b_hi))
+        (call $mul-uint)
         (local.set $a_hi)
         (local.set $a_lo)
 
-        ;; Check for overflow into sign bit
-        (if (i64.ne (i64.shr_s (local.get $a_hi) (i64.const 63)) (local.get $expected_sign))
+        ;; Sign bit should be 0, otherwise there is an overflow
+        (if (i64.lt_s (local.get $a_hi) (i64.const 0))
             (call $runtime-error (i32.const 0))
         )
-
-        ;; Return the result
-        (return (local.get $a_lo) (local.get $a_hi))
+        
+        ;; Return the result and adapt with sign bit
+        (select
+            (i64.sub (i64.const 0) (local.get $a_lo))
+            (local.get $a_lo)
+            (local.get $sign)
+        )
+        (select
+            (i64.sub (i64.const 0) (i64.add (local.get $a_hi) (i64.extend_i32_u (i64.ne (local.get $a_lo) (i64.const 0)))))
+            (local.get $a_hi)
+            (local.get $sign)
+        )
     )
 
     (func $div-int128 (type 2) (param $dividend_lo i64) (param $dividend_hi i64) (param $divisor_lo i64) (param $divisor_hi i64) (result i64 i64 i64 i64)

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -225,7 +225,7 @@
     (func $mul-uint (type 1) (param $a_lo i64) (param $a_hi i64) (param $b_lo i64) (param $b_hi i64) (result i64 i64)
         (local $tmp i32)
 
-        (local.set $tmp  ;; lz countains the sum of number of leading zeros of arguments
+        (local.set $tmp  ;; tmp contains the sum of number of leading zeros of arguments
             (i32.add 
                 (call $clz-int128 (local.get $a_lo) (local.get $a_hi))
                 (call $clz-int128 (local.get $b_lo) (local.get $b_hi))

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -191,17 +191,17 @@
 
         ;;;;;;;;;;;;;;;;;;;;;;;;;;;; res_lo ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
         (local.tee $t1
-            (i64.mul 
+            (i64.mul
                 ;; $v2 contains u1 temporarily
-                (local.tee $v2 (i64.and (local.get $a_lo) (i64.const 0xffffffff))) 
+                (local.tee $v2 (i64.and (local.get $a_lo) (i64.const 0xffffffff)))
                 ;; $u2 contains v1 temporarily
-                (local.tee $u2 (i64.and (local.get $b_lo) (i64.const 0xffffffff))) 
+                (local.tee $u2 (i64.and (local.get $b_lo) (i64.const 0xffffffff)))
             )
         )
         (i64.shr_u (i64.const 32))              ;; (t1 >> 32)
         (i64.mul                                ;; (u2 * v1)
             (local.get $u2) ;; contains v1 at that point
-            (local.tee $u2 (i64.shr_u (local.get $a_lo) (i64.const 32))) 
+            (local.tee $u2 (i64.shr_u (local.get $a_lo) (i64.const 32)))
         )
         (local.tee $t2 (i64.add))               ;; (u2 * v1) + (t1 >> 32)
         (i64.and (i64.const 0xffffffff))        ;; (t2 & 0xffffffff)
@@ -226,7 +226,7 @@
         (local $tmp i32)
 
         (local.set $tmp  ;; tmp contains the sum of number of leading zeros of arguments
-            (i32.add 
+            (i32.add
                 (call $clz-int128 (local.get $a_lo) (local.get $a_hi))
                 (call $clz-int128 (local.get $b_lo) (local.get $b_hi))
             )
@@ -245,10 +245,10 @@
         ;; Other case might overflow. We compute (a * b/2) and check if result > 2**127
         ;;    -> if yes, overflow
         ;;    -> if not, we double the product, and add a one more time if b was odd
-        
+
         ;; tmp is 1 if b was odd else 0
         (local.set $tmp (i32.wrap_i64 (i64.and (local.get $b_lo) (i64.const 1))))
-        
+
         ;; b / 2
         (i64.or
             (i64.shl (local.get $b_hi) (i64.const 63))
@@ -286,13 +286,13 @@
         )
         (local.get $b_lo) (local.get $b_hi)
     )
-    
+
 
     (func $mul-int (type 1) (param $a_lo i64) (param $a_hi i64) (param $b_lo i64) (param $b_hi i64) (result i64 i64)
         (local $sign i32)
 
         ;; this is a shortcut for a multiplication by 1.
-        ;; also, it prevents us from dealing with the infamous abs(i128::MIN), and 
+        ;; also, it prevents us from dealing with the infamous abs(i128::MIN), and
         ;; the only operation that would work on that number would be (i128::MIN * 1)
         (if (i64.eqz (i64.or (local.get $a_hi) (i64.xor (local.get $a_lo) (i64.const 1))))
             (return (local.get $b_lo) (local.get $b_hi))
@@ -324,15 +324,15 @@
         (select
             (i64.sub (i64.const 0) (i64.add (local.get $b_hi) (i64.extend_i32_u (i64.ne (local.get $b_lo) (i64.const 0)))))
             (local.get $b_hi)
-            (local.get $sign) 
+            (local.get $sign)
         )
         ;; 3. Compute expected sign
         (local.set $sign
-            (i32.xor 
-                (i64.lt_s (local.get $a_hi) (i64.const 0)) ;; sign of a 
+            (i32.xor
+                (i64.lt_s (local.get $a_hi) (i64.const 0)) ;; sign of a
                 (local.get $sign) ;; sign is sign of b
             )
-        ) 
+        )
 
         (call $mul-uint)
         (local.set $a_hi)
@@ -342,7 +342,7 @@
         (if (i64.lt_s (local.get $a_hi) (i64.const 0))
             (call $runtime-error (i32.const 0))
         )
-        
+
         ;; Return the result and adapt with sign bit
         (select
             (i64.sub (i64.const 0) (local.get $a_lo))

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -262,8 +262,8 @@
         (local.set $b_hi)
         (local.set $b_lo)
 
-        ;; if result/2 > 2**127, meaning clz == 0 -> overflow
-        (if (i64.eqz (i64.clz (local.get $b_hi)))
+        ;; if result/2 > 2**127 overflow
+        (if (i64.lt_s (local.get $b_hi) (i64.const 0))
             (call $runtime-error (i32.const 0))
         )
 

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -112,11 +112,7 @@ fn prop_sqrti_uint() {
 #[test]
 fn prop_sqrti_int() {
     utils::test_export_one_signed_arg_checked("sqrti-int", |a: i128| {
-        if a > 0 {
-            Some(num_integer::Roots::sqrt(&a))
-        } else {
-            None
-        }
+        (a >= 0).then(|| num_integer::Roots::sqrt(&a))
     })
 }
 

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -2,112 +2,116 @@ use crate::utils;
 
 #[test]
 fn prop_add_uint() {
-    utils::test_export_two_args_checked("add-uint", |a: u128, b: u128| a.checked_add(b))
+    utils::test_export_two_unsigned_args_checked("add-uint", |a: u128, b: u128| a.checked_add(b))
 }
 
 #[test]
 fn prop_add_int() {
-    utils::test_export_two_args_checked("add-int", |a: i128, b: i128| a.checked_add(b))
+    utils::test_export_two_signed_args_checked("add-int", |a: i128, b: i128| a.checked_add(b))
 }
 
 #[test]
 fn prop_sub_uint() {
-    utils::test_export_two_args_checked("sub-uint", |a: u128, b: u128| a.checked_sub(b))
+    utils::test_export_two_unsigned_args_checked("sub-uint", |a: u128, b: u128| a.checked_sub(b))
 }
 
 #[test]
 fn prop_sub_int() {
-    utils::test_export_two_args_checked("sub-int", |a: i128, b: i128| a.checked_sub(b))
+    utils::test_export_two_signed_args_checked("sub-int", |a: i128, b: i128| a.checked_sub(b))
 }
 
 #[test]
 fn prop_mul_uint() {
-    utils::test_export_two_args_checked("mul-uint", |a: u128, b: u128| a.checked_mul(b))
+    utils::test_export_two_unsigned_args_checked("mul-uint", |a: u128, b: u128| a.checked_mul(b))
 }
 
 #[test]
 fn prop_mul_int() {
-    utils::test_export_two_args_checked("mul-int", |a: i128, b: i128| a.checked_mul(b))
+    utils::test_export_two_signed_args_checked("mul-int", |a: i128, b: i128| a.checked_mul(b))
 }
 
 #[test]
 fn prop_div_uint() {
-    utils::test_export_two_args_checked("div-uint", |a: u128, b: u128| a.checked_div(b))
+    utils::test_export_two_unsigned_args_checked("div-uint", |a: u128, b: u128| a.checked_div(b))
 }
 
 #[test]
 fn prop_div_int() {
-    utils::test_export_two_args_checked("div-int", |a: i128, b: i128| a.checked_div(b))
+    utils::test_export_two_signed_args_checked("div-int", |a: i128, b: i128| a.checked_div(b))
 }
 
 #[test]
 fn prop_mod_uint() {
-    utils::test_export_two_args_checked("mod-uint", |a: u128, b: u128| a.checked_rem(b))
+    utils::test_export_two_unsigned_args_checked("mod-uint", |a: u128, b: u128| a.checked_rem(b))
 }
 
 #[test]
 fn prop_mod_int() {
-    utils::test_export_two_args_checked("mod-int", |a: i128, b: i128| a.checked_rem(b))
+    utils::test_export_two_signed_args_checked("mod-int", |a: i128, b: i128| a.checked_rem(b))
 }
 
 #[test]
 fn prop_lt_uint() {
-    utils::test_export_two_args("lt-uint", |a: u128, b: u128| a < b)
+    utils::test_export_two_unsigned_args("lt-uint", |a: u128, b: u128| a < b)
 }
 
 #[test]
 fn prop_lt_int() {
-    utils::test_export_two_args("lt-int", |a: i128, b: i128| a < b);
+    utils::test_export_two_signed_args("lt-int", |a: i128, b: i128| a < b);
 }
 
 #[test]
 fn prop_gt_uint() {
-    utils::test_export_two_args("gt-uint", |a: u128, b: u128| a > b);
+    utils::test_export_two_unsigned_args("gt-uint", |a: u128, b: u128| a > b);
 }
 
 #[test]
 fn prop_gt_int() {
-    utils::test_export_two_args("gt-int", |a: i128, b: i128| a > b);
+    utils::test_export_two_signed_args("gt-int", |a: i128, b: i128| a > b);
 }
 
 #[test]
 fn prop_le_uint() {
-    utils::test_export_two_args("le-uint", |a: u128, b: u128| a <= b);
+    utils::test_export_two_unsigned_args("le-uint", |a: u128, b: u128| a <= b);
 }
 
 #[test]
 fn prop_le_int() {
-    utils::test_export_two_args("le-int", |a: i128, b: i128| a <= b);
+    utils::test_export_two_signed_args("le-int", |a: i128, b: i128| a <= b);
 }
 
 #[test]
 fn prop_ge_uint() {
-    utils::test_export_two_args("ge-uint", |a: u128, b: u128| a >= b);
+    utils::test_export_two_unsigned_args("ge-uint", |a: u128, b: u128| a >= b);
 }
 
 #[test]
 fn prop_ge_int() {
-    utils::test_export_two_args("ge-int", |a: i128, b: i128| a >= b);
+    utils::test_export_two_signed_args("ge-int", |a: i128, b: i128| a >= b);
 }
 
 #[test]
 fn prop_log2_uint() {
-    utils::test_export_one_arg_checked("log2-uint", |a: u128| a.checked_ilog2().map(|u| u as u128))
+    utils::test_export_one_unsigned_arg_checked("log2-uint", |a: u128| {
+        a.checked_ilog2().map(|u| u as u128)
+    })
 }
 
 #[test]
 fn prop_log2_int() {
-    utils::test_export_one_arg_checked("log2-int", |a: i128| a.checked_ilog2().map(|u| u as i128))
+    utils::test_export_one_signed_arg_checked("log2-int", |a: i128| {
+        a.checked_ilog2().map(|u| u as i128)
+    })
 }
 
 #[test]
 fn prop_sqrti_uint() {
-    utils::test_export_one_arg("sqrti-uint", |a: u128| num_integer::Roots::sqrt(&a))
+    utils::test_export_one_unsigned_arg("sqrti-uint", |a: u128| num_integer::Roots::sqrt(&a))
 }
 
 #[test]
 fn prop_sqrti_int() {
-    utils::test_export_one_arg_checked("sqrti-int", |a: i128| {
+    utils::test_export_one_signed_arg_checked("sqrti-int", |a: i128| {
         if a > 0 {
             Some(num_integer::Roots::sqrt(&a))
         } else {
@@ -118,47 +122,47 @@ fn prop_sqrti_int() {
 
 #[test]
 fn prop_bit_and_uint() {
-    utils::test_export_two_args("bit-and-uint", |a: u128, b: u128| a & b)
+    utils::test_export_two_unsigned_args("bit-and-uint", |a: u128, b: u128| a & b)
 }
 
 #[test]
 fn prop_bit_and_int() {
-    utils::test_export_two_args("bit-and-int", |a: i128, b: i128| a & b)
+    utils::test_export_two_signed_args("bit-and-int", |a: i128, b: i128| a & b)
 }
 
 #[test]
 fn prop_bit_or_uint() {
-    utils::test_export_two_args("bit-or-uint", |a: u128, b: u128| a | b)
+    utils::test_export_two_unsigned_args("bit-or-uint", |a: u128, b: u128| a | b)
 }
 
 #[test]
 fn prop_bit_or_int() {
-    utils::test_export_two_args("bit-or-int", |a: i128, b: i128| a | b)
+    utils::test_export_two_signed_args("bit-or-int", |a: i128, b: i128| a | b)
 }
 
 #[test]
 fn prop_bit_not_uint() {
-    utils::test_export_one_arg("bit-not-uint", |a: u128| !a)
+    utils::test_export_one_unsigned_arg("bit-not-uint", |a: u128| !a)
 }
 
 #[test]
 fn prop_bit_not_int() {
-    utils::test_export_one_arg("bit-not-int", |a: i128| !a)
+    utils::test_export_one_signed_arg("bit-not-int", |a: i128| !a)
 }
 
 #[test]
 fn prop_bit_xor_uint() {
-    utils::test_export_two_args("bit-xor-uint", |a: u128, b: u128| a ^ b)
+    utils::test_export_two_unsigned_args("bit-xor-uint", |a: u128, b: u128| a ^ b)
 }
 
 #[test]
 fn prop_bit_xor_int() {
-    utils::test_export_two_args("bit-xor-int", |a: i128, b: i128| a ^ b)
+    utils::test_export_two_signed_args("bit-xor-int", |a: i128, b: i128| a ^ b)
 }
 
 #[test]
 fn prop_bit_shift_left_uint() {
-    utils::test_export_two_args("bit-shift-left-uint", |a: u128, b: u128| {
+    utils::test_export_two_unsigned_args("bit-shift-left-uint", |a: u128, b: u128| {
         a.wrapping_shl((b % 128) as u32)
     })
 }
@@ -166,14 +170,14 @@ fn prop_bit_shift_left_uint() {
 #[test]
 fn prop_bit_shift_left_int() {
     // NOTE that the two arguments differ in type
-    utils::test_export_two_args("bit-shift-left-int", |a: i128, b: u128| {
+    utils::test_export_two_signed_args("bit-shift-left-int", |a: i128, b: u128| {
         a.wrapping_shl((b % 128) as u32)
     })
 }
 
 #[test]
 fn prop_bit_shift_right_uint() {
-    utils::test_export_two_args("bit-shift-right-uint", |a: u128, b: u128| {
+    utils::test_export_two_unsigned_args("bit-shift-right-uint", |a: u128, b: u128| {
         a.wrapping_shr((b % 128) as u32)
     })
 }
@@ -181,7 +185,7 @@ fn prop_bit_shift_right_uint() {
 #[test]
 fn prop_bit_shift_right_int() {
     // NOTE that the two arguments differ in type
-    utils::test_export_two_args("bit-shift-right-int", |a: i128, b: u128| {
+    utils::test_export_two_signed_args("bit-shift-right-int", |a: i128, b: u128| {
         a.wrapping_shr((b % 128) as u32)
     })
 }

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -536,6 +536,75 @@ fn test_mul_int() {
     .expect("call to mul-int failed");
     assert_eq!(result[0].i64(), Some(-2));
     assert_eq!(result[1].i64(), Some(-1));
+
+    // cannot take the absolute value of i128::MIN but should be able to multiply by 1
+    mul.call(
+        &mut store,
+        &[
+            Val::I64(1),
+            Val::I64(0),
+            Val::I64(0),
+            Val::I64(0x8000000000000000u64 as i64),
+        ],
+        &mut result,
+    )
+    .expect("call to mul-int failed");
+    assert_eq!(result[0].i64(), Some(0));
+    assert_eq!(result[1].i64(), Some(0x8000000000000000u64 as i64));
+
+    // cannot take the absolute value of i128::MIN but should be able to multiply by 1 (reverse)
+    mul.call(
+        &mut store,
+        &[
+            Val::I64(0),
+            Val::I64(0x8000000000000000u64 as i64),
+            Val::I64(1),
+            Val::I64(0),
+        ],
+        &mut result,
+    )
+    .expect("call to mul-int failed");
+    assert_eq!(result[0].i64(), Some(0));
+    assert_eq!(result[1].i64(), Some(0x8000000000000000u64 as i64));
+
+    // i128::MIN * 2 overflows
+    mul.call(
+        &mut store,
+        &[
+            Val::I64(2),
+            Val::I64(0),
+            Val::I64(0),
+            Val::I64(0x8000000000000000u64 as i64),
+        ],
+        &mut result,
+    )
+    .expect_err("expected overflow");
+
+    // i128::MIN * -1 overflows
+    mul.call(
+        &mut store,
+        &[
+            Val::I64(-1),
+            Val::I64(-1),
+            Val::I64(0),
+            Val::I64(0x8000000000000000u64 as i64),
+        ],
+        &mut result,
+    )
+    .expect_err("expected overflow");
+
+    // -1 * i128::MIN overflows
+    mul.call(
+        &mut store,
+        &[
+            Val::I64(0),
+            Val::I64(0x8000000000000000u64 as i64),
+            Val::I64(-1),
+            Val::I64(-1),
+        ],
+        &mut result,
+    )
+    .expect_err("expected overflow");
 }
 
 #[test]

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -526,7 +526,7 @@ fn test_mul_int() {
     )
     .expect_err("expected overflow");
 
-    // Overflow
+    // Overflow on unsigned multiplication
     // 0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff * 2 = -2
     mul.call(
         &mut store,

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -474,7 +474,7 @@ fn test_mul_int() {
         &[Val::I64(0), Val::I64(0), Val::I64(0), Val::I64(0)],
         &mut result,
     )
-    .expect("call to mul-uint failed");
+    .expect("call to mul-int failed");
     assert_eq!(result[0].i64(), Some(0));
     assert_eq!(result[1].i64(), Some(0));
 
@@ -489,7 +489,7 @@ fn test_mul_int() {
         ],
         &mut result,
     )
-    .expect("call to mul-uint failed");
+    .expect("call to mul-int failed");
     assert_eq!(result[0].i64(), Some(0));
     assert_eq!(result[1].i64(), Some(0));
 
@@ -504,7 +504,7 @@ fn test_mul_int() {
         ],
         &mut result,
     )
-    .expect("call to mul-uint failed");
+    .expect("call to mul-int failed");
     assert_eq!(result[0].i64(), Some(0));
     assert_eq!(result[1].i64(), Some(0));
 
@@ -514,7 +514,7 @@ fn test_mul_int() {
         &[Val::I64(1), Val::I64(0), Val::I64(2), Val::I64(0)],
         &mut result,
     )
-    .expect("call to mul-uint failed");
+    .expect("call to mul-int failed");
     assert_eq!(result[0].i64(), Some(2));
     assert_eq!(result[1].i64(), Some(0));
 
@@ -527,13 +527,15 @@ fn test_mul_int() {
     .expect_err("expected overflow");
 
     // Overflow
-    // 0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff * 2 = Overflow
+    // 0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff * 2 = -2
     mul.call(
         &mut store,
         &[Val::I64(-1), Val::I64(-1), Val::I64(2), Val::I64(0)],
         &mut result,
     )
-    .expect_err("expected overflow");
+    .expect("call to mul-int failed");
+    assert_eq!(result[0].i64(), Some(-2));
+    assert_eq!(result[1].i64(), Some(-1));
 }
 
 #[test]


### PR DESCRIPTION
Fixes #54 

Now we have a huge load of tests, on all kind of ranges of integers, in all configurations.

Good thing, most stuffs work.
Bad thing, the multiplication doesn't.

UPDATE: 
Finally everything works:
- mul-uint had a stupid mistake in the case where the sum of leading zeros was 127 and b is odd
- mul-int overflow detection didn't work. The new algorithm does.
- there was a mistake in the proptests of sqrti-int.