### PR TITLE
Standard: implementation of pow

### DIFF
--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -735,6 +735,11 @@ impl ASTVisitor for WasmGenerator<'_> {
                 .funcs
                 .by_name(&format!("sqrti-{type_suffix}"))
                 .unwrap_or_else(|| panic!("function not found: sqrti-{type_suffix}")),
+            NativeFunctions::Power => self
+                .module
+                .funcs
+                .by_name(&format!("pow-{type_suffix}"))
+                .unwrap_or_else(|| panic!("function not found: pow-{type_suffix}")),
             _ => {
                 self.error = Some(GeneratorError::NotImplemented);
                 return Err(builder);

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -222,6 +222,33 @@ fn prop_0_pow_uint_something_is_zero() {
 }
 
 #[test]
+fn prop_1_pow_uint_something_is_one() {
+    let (instance, store) = load_stdlib().unwrap();
+    let store = RefCell::new(store);
+    let fun = instance
+        .get_func(store.borrow_mut().deref_mut(), "pow-uint")
+        .unwrap();
+
+    for st_a in UNSIGNED_STRATEGIES {
+        proptest! {|(m in st_a())| {
+                let mut res = [Val::I64(0), Val::I64(0)];
+                let res_slice = u128::relevant_slice(&mut res);
+
+                fun.call(
+                    store.borrow_mut().deref_mut(),
+                    &[Val::I64(1), Val::I64(0), m.low().into(), m.high().into()],
+                    res_slice,
+                )
+                .unwrap_or_else(|_| panic!("Could not call exported function pow-uint"));
+                let wasm_result = u128::from_wasm_result(res_slice);
+
+                prop_assert_eq!(1, wasm_result);
+            }
+        };
+    }
+}
+
+#[test]
 fn prop_something_pow_uint_zero_is_one() {
     let (instance, store) = load_stdlib().unwrap();
     let store = RefCell::new(store);
@@ -302,6 +329,33 @@ fn prop_0_pow_int_something_is_zero() {
                 let wasm_result = i128::from_wasm_result(res_slice);
 
                 prop_assert_eq!(if i128::from(m) == 0 {1} else {0}, wasm_result);
+            }
+        };
+    }
+}
+
+#[test]
+fn prop_1_pow_int_something_is_one() {
+    let (instance, store) = load_stdlib().unwrap();
+    let store = RefCell::new(store);
+    let fun = instance
+        .get_func(store.borrow_mut().deref_mut(), "pow-int")
+        .unwrap();
+
+    for st_a in SIGNED_STRATEGIES {
+        proptest! {|(m in st_a())| {
+                let mut res = [Val::I64(0), Val::I64(0)];
+                let res_slice = i128::relevant_slice(&mut res);
+
+                fun.call(
+                    store.borrow_mut().deref_mut(),
+                    &[Val::I64(1), Val::I64(0), m.low().into(), m.high().into()],
+                    res_slice,
+                )
+                .unwrap_or_else(|_| panic!("Could not call exported function pow-uint"));
+                let wasm_result = i128::from_wasm_result(res_slice);
+
+                prop_assert_eq!(1, wasm_result);
             }
         };
     }

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -222,7 +222,7 @@ fn prop_0_pow_uint_something_is_zero() {
 }
 
 #[test]
-fn prop_somethin_pow_uint_zero_is_one() {
+fn prop_something_pow_uint_zero_is_one() {
     let (instance, store) = load_stdlib().unwrap();
     let store = RefCell::new(store);
     let fun = instance
@@ -308,7 +308,7 @@ fn prop_0_pow_int_something_is_zero() {
 }
 
 #[test]
-fn prop_somethin_pow_int_zero_is_one() {
+fn prop_something_pow_int_zero_is_one() {
     let (instance, store) = load_stdlib().unwrap();
     let store = RefCell::new(store);
     let fun = instance

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -1,4 +1,12 @@
-use crate::utils;
+use std::{cell::RefCell, ops::DerefMut};
+
+use proptest::{prop_assert_eq, proptest};
+use wasmtime::Val;
+
+use crate::utils::{
+    self, load_stdlib, medium_int128, medium_uint128, small_int128, small_uint128, tiny_int128,
+    tiny_uint128, FromWasmResult, SIGNED_STRATEGIES, UNSIGNED_STRATEGIES,
+};
 
 #[test]
 fn prop_add_uint() {
@@ -184,4 +192,180 @@ fn prop_bit_shift_right_int() {
     utils::test_export_two_signed_args("bit-shift-right-int", |a: i128, b: u128| {
         a.wrapping_shr((b % 128) as u32)
     })
+}
+
+#[test]
+fn prop_0_pow_uint_something_is_zero() {
+    let (instance, store) = load_stdlib().unwrap();
+    let store = RefCell::new(store);
+    let fun = instance
+        .get_func(store.borrow_mut().deref_mut(), "pow-uint")
+        .unwrap();
+
+    for st_a in UNSIGNED_STRATEGIES {
+        proptest! {|(m in st_a())| {
+                let mut res = [Val::I64(0), Val::I64(0)];
+                let res_slice = u128::relevant_slice(&mut res);
+
+                fun.call(
+                    store.borrow_mut().deref_mut(),
+                    &[Val::I64(0), Val::I64(0), m.low().into(), m.high().into()],
+                    res_slice,
+                )
+                .unwrap_or_else(|_| panic!("Could not call exported function pow-uint"));
+                let wasm_result = u128::from_wasm_result(res_slice);
+
+                prop_assert_eq!(if u128::from(m) == 0 {1} else {0}, wasm_result);
+            }
+        };
+    }
+}
+
+#[test]
+fn prop_somethin_pow_uint_zero_is_one() {
+    let (instance, store) = load_stdlib().unwrap();
+    let store = RefCell::new(store);
+    let fun = instance
+        .get_func(store.borrow_mut().deref_mut(), "pow-uint")
+        .unwrap();
+
+    for st_a in UNSIGNED_STRATEGIES {
+        proptest! {|(m in st_a())| {
+                let mut res = [Val::I64(0), Val::I64(0)];
+                let res_slice = u128::relevant_slice(&mut res);
+
+                fun.call(
+                    store.borrow_mut().deref_mut(),
+                    &[m.low().into(), m.high().into(), Val::I64(0), Val::I64(0)],
+                    res_slice,
+                )
+                .unwrap_or_else(|_| panic!("Could not call exported function pow-uint"));
+                let wasm_result = u128::from_wasm_result(res_slice);
+
+                prop_assert_eq!(1, wasm_result);
+            }
+        };
+    }
+}
+
+#[test]
+fn prop_pow_uint() {
+    let (instance, store) = load_stdlib().unwrap();
+    let store = RefCell::new(store);
+    let fun = instance
+        .get_func(store.borrow_mut().deref_mut(), "pow-uint")
+        .unwrap();
+
+    for st_a in UNSIGNED_STRATEGIES {
+        for st_b in &[tiny_uint128, small_uint128, medium_uint128] {
+            proptest!(|(n in st_a(), m in st_b())| {
+                let mut res = [Val::I64(0), Val::I64(0)];
+
+                let call = fun.call(
+                    store.borrow_mut().deref_mut(),
+                    &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
+                    &mut res,
+                );
+
+                match u128::from(n).checked_pow(u128::from(m) as u32) {
+                    Some(rust_result) => {
+                        call.unwrap_or_else(|_| panic!("call to pow-uint failed"));
+                        let wasm_result = u128::from_wasm_result(&res);
+                        prop_assert_eq!(rust_result, wasm_result);
+                    },
+                    None => { call.expect_err("expected error"); }
+                }
+            });
+        }
+    }
+}
+
+#[test]
+fn prop_0_pow_int_something_is_zero() {
+    let (instance, store) = load_stdlib().unwrap();
+    let store = RefCell::new(store);
+    let fun = instance
+        .get_func(store.borrow_mut().deref_mut(), "pow-int")
+        .unwrap();
+
+    for st_a in SIGNED_STRATEGIES {
+        proptest! {|(m in st_a())| {
+                let mut res = [Val::I64(0), Val::I64(0)];
+                let res_slice = i128::relevant_slice(&mut res);
+
+                fun.call(
+                    store.borrow_mut().deref_mut(),
+                    &[Val::I64(0), Val::I64(0), m.low().into(), m.high().into()],
+                    res_slice,
+                )
+                .unwrap_or_else(|_| panic!("Could not call exported function pow-uint"));
+                let wasm_result = i128::from_wasm_result(res_slice);
+
+                prop_assert_eq!(if i128::from(m) == 0 {1} else {0}, wasm_result);
+            }
+        };
+    }
+}
+
+#[test]
+fn prop_somethin_pow_int_zero_is_one() {
+    let (instance, store) = load_stdlib().unwrap();
+    let store = RefCell::new(store);
+    let fun = instance
+        .get_func(store.borrow_mut().deref_mut(), "pow-int")
+        .unwrap();
+
+    for st_a in SIGNED_STRATEGIES {
+        proptest! {|(m in st_a())| {
+                let mut res = [Val::I64(0), Val::I64(0)];
+                let res_slice = i128::relevant_slice(&mut res);
+
+                fun.call(
+                    store.borrow_mut().deref_mut(),
+                    &[m.low().into(), m.high().into(), Val::I64(0), Val::I64(0)],
+                    res_slice,
+                )
+                .unwrap_or_else(|_| panic!("Could not call exported function pow-uint"));
+                let wasm_result = i128::from_wasm_result(res_slice);
+
+                prop_assert_eq!(1, wasm_result);
+            }
+        };
+    }
+}
+
+#[test]
+fn prop_pow_int() {
+    let (instance, store) = load_stdlib().unwrap();
+    let store = RefCell::new(store);
+    let fun = instance
+        .get_func(store.borrow_mut().deref_mut(), "pow-int")
+        .unwrap();
+
+    for st_a in UNSIGNED_STRATEGIES {
+        for st_b in &[tiny_int128, small_int128, medium_int128] {
+            proptest!(|(n in st_a(), m in st_b())| {
+                let mut res = [Val::I64(0), Val::I64(0)];
+
+                let call = fun.call(
+                    store.borrow_mut().deref_mut(),
+                    &[n.low().into(), n.high().into(), m.low().into(), m.high().into()],
+                    &mut res,
+                );
+
+                if ![0i128, 1].contains(&n.into()) && i128::from(m) < 0 {
+                    call.expect_err("expected error");
+                } else {
+                    match i128::from(n).checked_pow(u128::from(m) as u32) {
+                        Some(rust_result) => {
+                            call.unwrap_or_else(|_| panic!("call to pow-uint failed"));
+                            let wasm_result = i128::from_wasm_result(&res);
+                            prop_assert_eq!(rust_result, wasm_result);
+                        },
+                        None => { call.expect_err("expected error"); }
+                    }
+                }
+            });
+        }
+    }
 }

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -1949,3 +1949,174 @@ fn pow_uint() {
     )
     .expect_err("expected overflow");
 }
+
+#[test]
+fn pow_int() {
+    let (instance, mut store) = load_stdlib().unwrap();
+    let pow = instance.get_func(&mut store, "pow-int").unwrap();
+    let mut result = [Val::I64(0), Val::I64(0)];
+
+    // pow(0, 0) == 1
+    pow.call(
+        &mut store,
+        &[Val::I64(0), Val::I64(0), Val::I64(0), Val::I64(0)],
+        &mut result,
+    )
+    .expect("call to pow-int failed");
+    assert_eq!(result[0].unwrap_i64(), 1);
+    assert_eq!(result[1].unwrap_i64(), 0);
+
+    // pow(0, 0) == 1
+    pow.call(
+        &mut store,
+        &[Val::I64(0), Val::I64(0), Val::I64(0), Val::I64(0)],
+        &mut result,
+    )
+    .expect("call to pow-int failed");
+    assert_eq!(result[0].unwrap_i64(), 1);
+    assert_eq!(result[1].unwrap_i64(), 0);
+
+    // pow(1, 0) == 1
+    pow.call(
+        &mut store,
+        &[Val::I64(1), Val::I64(0), Val::I64(0), Val::I64(0)],
+        &mut result,
+    )
+    .expect("call to pow-int failed");
+    assert_eq!(result[0].unwrap_i64(), 1);
+    assert_eq!(result[1].unwrap_i64(), 0);
+
+    // pow(2, 0) == 1
+    pow.call(
+        &mut store,
+        &[Val::I64(2), Val::I64(0), Val::I64(0), Val::I64(0)],
+        &mut result,
+    )
+    .expect("call to pow-int failed");
+    assert_eq!(result[0].unwrap_i64(), 1);
+    assert_eq!(result[1].unwrap_i64(), 0);
+
+    // pow(0, 1) == 0
+    pow.call(
+        &mut store,
+        &[Val::I64(0), Val::I64(0), Val::I64(1), Val::I64(0)],
+        &mut result,
+    )
+    .expect("call to pow-int failed");
+    assert_eq!(result[0].unwrap_i64(), 0);
+    assert_eq!(result[1].unwrap_i64(), 0);
+
+    // pow(123, 1) == 123
+    pow.call(
+        &mut store,
+        &[Val::I64(123), Val::I64(0), Val::I64(1), Val::I64(0)],
+        &mut result,
+    )
+    .expect("call to pow-int failed");
+    assert_eq!(result[0].unwrap_i64(), 123);
+    assert_eq!(result[1].unwrap_i64(), 0);
+
+    // pow(3, 2) == 9
+    pow.call(
+        &mut store,
+        &[Val::I64(3), Val::I64(0), Val::I64(2), Val::I64(0)],
+        &mut result,
+    )
+    .expect("call to pow-int failed");
+    assert_eq!(result[0].unwrap_i64(), 9);
+    assert_eq!(result[1].unwrap_i64(), 0);
+
+    // pow(3, 3) == 27
+    pow.call(
+        &mut store,
+        &[Val::I64(3), Val::I64(0), Val::I64(3), Val::I64(0)],
+        &mut result,
+    )
+    .expect("call to pow-int failed");
+    assert_eq!(result[0].unwrap_i64(), 27);
+    assert_eq!(result[1].unwrap_i64(), 0);
+
+    // pow(3, 80) = large number
+    pow.call(
+        &mut store,
+        &[Val::I64(3), Val::I64(0), Val::I64(80), Val::I64(0)],
+        &mut result,
+    )
+    .expect("call to pow-int failed");
+    assert_eq!(result[0].unwrap_i64(), 4389419161382147137);
+    assert_eq!(result[1].unwrap_i64(), 8012732698178659004);
+
+    // pow(3, 81) overflows
+    pow.call(
+        &mut store,
+        &[Val::I64(3), Val::I64(0), Val::I64(81), Val::I64(0)],
+        &mut result,
+    )
+    .expect_err("expected overflow");
+
+    // pow(2, 126) = 1 << 126
+    pow.call(
+        &mut store,
+        &[Val::I64(2), Val::I64(0), Val::I64(126), Val::I64(0)],
+        &mut result,
+    )
+    .expect("call to pow-uint failed");
+    assert_eq!(result[0].unwrap_i64(), 0);
+    assert_eq!(result[1].unwrap_i64(), 0x4000000000000000u64 as i64);
+
+    // pow(2, 127) overflows
+    pow.call(
+        &mut store,
+        &[Val::I64(2), Val::I64(0), Val::I64(127), Val::I64(0)],
+        &mut result,
+    )
+    .expect_err("expected overflow");
+
+    // pow(-3, 2) = 9
+    pow.call(
+        &mut store,
+        &[Val::I64(-3), Val::I64(-1), Val::I64(2), Val::I64(0)],
+        &mut result,
+    )
+    .expect("call to pow-int failed");
+    assert_eq!(result[0].unwrap_i64(), 9);
+    assert_eq!(result[1].unwrap_i64(), 0);
+
+    // pow(-3, 3) = -27
+    pow.call(
+        &mut store,
+        &[Val::I64(-3), Val::I64(-1), Val::I64(3), Val::I64(0)],
+        &mut result,
+    )
+    .expect("call to pow-int failed");
+    assert_eq!(result[0].unwrap_i64(), -27);
+    assert_eq!(result[1].unwrap_i64(), -1);
+
+    // edge case i128::MIN^1 is ok
+    pow.call(
+        &mut store,
+        &[
+            Val::I64(0),
+            Val::I64(0x8000000000000000u64 as i64),
+            Val::I64(1),
+            Val::I64(0),
+        ],
+        &mut result,
+    )
+    .expect("call to pow-int failed");
+    assert_eq!(result[0].unwrap_i64(), 0);
+    assert_eq!(result[1].unwrap_i64(), 0x8000000000000000u64 as i64);
+
+    // edge case i128::MIN^2 overflows
+    pow.call(
+        &mut store,
+        &[
+            Val::I64(0),
+            Val::I64(0x8000000000000000u64 as i64),
+            Val::I64(2),
+            Val::I64(0),
+        ],
+        &mut result,
+    )
+    .expect_err("expected overflow");
+}

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -2052,6 +2052,36 @@ fn pow_int() {
     )
     .expect_err("expected overflow");
 
+    // pow(-2, 1) == -2
+    pow.call(
+        &mut store,
+        &[Val::I64(-2), Val::I64(-1), Val::I64(1), Val::I64(0)],
+        &mut result,
+    )
+    .expect("call to pow-uint failed");
+    assert_eq!(result[0].unwrap_i64(), -2);
+    assert_eq!(result[1].unwrap_i64(), -1);
+
+    // pow(-2, 2) == 4
+    pow.call(
+        &mut store,
+        &[Val::I64(-2), Val::I64(-1), Val::I64(2), Val::I64(0)],
+        &mut result,
+    )
+    .expect("call to pow-uint failed");
+    assert_eq!(result[0].unwrap_i64(), 4);
+    assert_eq!(result[1].unwrap_i64(), 0);
+
+    // pow(-2, 126) == 0x40000000000000000000000000000000
+    pow.call(
+        &mut store,
+        &[Val::I64(-2), Val::I64(-1), Val::I64(126), Val::I64(0)],
+        &mut result,
+    )
+    .expect("call to pow-uint failed");
+    assert_eq!(result[0].unwrap_i64(), 0);
+    assert_eq!(result[1].unwrap_i64(), 0x4000000000000000u64 as i64);
+
     // pow(-2, 127) == i128::MIN
     pow.call(
         &mut store,

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -2052,6 +2052,16 @@ fn pow_int() {
     )
     .expect_err("expected overflow");
 
+    // pow(-2, 127) == i128::MIN
+    pow.call(
+        &mut store,
+        &[Val::I64(-2), Val::I64(-1), Val::I64(127), Val::I64(0)],
+        &mut result,
+    )
+    .expect("call to pow-uint failed");
+    assert_eq!(result[0].unwrap_i64(), 0);
+    assert_eq!(result[1].unwrap_i64(), 0x8000000000000000u64 as i64);
+
     // pow(-3, 2) = 9
     pow.call(
         &mut store,

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -1826,3 +1826,126 @@ fn bit_not_int() {
     assert_eq!(result[0].i64(), Some(-4));
     assert_eq!(result[1].i64(), Some(-1));
 }
+
+#[test]
+fn pow_uint() {
+    let (instance, mut store) = load_stdlib().unwrap();
+    let pow = instance.get_func(&mut store, "pow-uint").unwrap();
+    let mut result = [Val::I64(0), Val::I64(0)];
+
+    // pow(0, 0) == 1
+    pow.call(
+        &mut store,
+        &[Val::I64(0), Val::I64(0), Val::I64(0), Val::I64(0)],
+        &mut result,
+    )
+    .expect("call to pow-uint failed");
+    assert_eq!(result[0].unwrap_i64(), 1);
+    assert_eq!(result[1].unwrap_i64(), 0);
+
+    // pow(0, 0) == 1
+    pow.call(
+        &mut store,
+        &[Val::I64(0), Val::I64(0), Val::I64(0), Val::I64(0)],
+        &mut result,
+    )
+    .expect("call to pow-uint failed");
+    assert_eq!(result[0].unwrap_i64(), 1);
+    assert_eq!(result[1].unwrap_i64(), 0);
+
+    // pow(1, 0) == 1
+    pow.call(
+        &mut store,
+        &[Val::I64(1), Val::I64(0), Val::I64(0), Val::I64(0)],
+        &mut result,
+    )
+    .expect("call to pow-uint failed");
+    assert_eq!(result[0].unwrap_i64(), 1);
+    assert_eq!(result[1].unwrap_i64(), 0);
+
+    // pow(2, 0) == 1
+    pow.call(
+        &mut store,
+        &[Val::I64(2), Val::I64(0), Val::I64(0), Val::I64(0)],
+        &mut result,
+    )
+    .expect("call to pow-uint failed");
+    assert_eq!(result[0].unwrap_i64(), 1);
+    assert_eq!(result[1].unwrap_i64(), 0);
+
+    // pow(0, 1) == 0
+    pow.call(
+        &mut store,
+        &[Val::I64(0), Val::I64(0), Val::I64(1), Val::I64(0)],
+        &mut result,
+    )
+    .expect("call to pow-uint failed");
+    assert_eq!(result[0].unwrap_i64(), 0);
+    assert_eq!(result[1].unwrap_i64(), 0);
+
+    // pow(123, 1) == 123
+    pow.call(
+        &mut store,
+        &[Val::I64(123), Val::I64(0), Val::I64(1), Val::I64(0)],
+        &mut result,
+    )
+    .expect("call to pow-uint failed");
+    assert_eq!(result[0].unwrap_i64(), 123);
+    assert_eq!(result[1].unwrap_i64(), 0);
+
+    // pow(3, 2) == 9
+    pow.call(
+        &mut store,
+        &[Val::I64(3), Val::I64(0), Val::I64(2), Val::I64(0)],
+        &mut result,
+    )
+    .expect("call to pow-uint failed");
+    assert_eq!(result[0].unwrap_i64(), 9);
+    assert_eq!(result[1].unwrap_i64(), 0);
+
+    // pow(3, 3) == 27
+    pow.call(
+        &mut store,
+        &[Val::I64(3), Val::I64(0), Val::I64(3), Val::I64(0)],
+        &mut result,
+    )
+    .expect("call to pow-uint failed");
+    assert_eq!(result[0].unwrap_i64(), 27);
+    assert_eq!(result[1].unwrap_i64(), 0);
+
+    // pow(3, 80) = large number
+    pow.call(
+        &mut store,
+        &[Val::I64(3), Val::I64(0), Val::I64(80), Val::I64(0)],
+        &mut result,
+    )
+    .expect("call to pow-uint failed");
+    assert_eq!(result[0].unwrap_i64(), 4389419161382147137);
+    assert_eq!(result[1].unwrap_i64(), 8012732698178659004);
+
+    // pow(3, 81) overflows
+    pow.call(
+        &mut store,
+        &[Val::I64(3), Val::I64(0), Val::I64(81), Val::I64(0)],
+        &mut result,
+    )
+    .expect_err("expected overflow");
+
+    // pow(2, 127) = 1 << 127
+    pow.call(
+        &mut store,
+        &[Val::I64(2), Val::I64(0), Val::I64(127), Val::I64(0)],
+        &mut result,
+    )
+    .expect("call to pow-uint failed");
+    assert_eq!(result[0].unwrap_i64(), 0);
+    assert_eq!(result[1].unwrap_i64(), 0x8000000000000000u64 as i64);
+
+    // pow(2, 128) overflows
+    pow.call(
+        &mut store,
+        &[Val::I64(2), Val::I64(0), Val::I64(128), Val::I64(0)],
+        &mut result,
+    )
+    .expect_err("expected overflow");
+}

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -1843,16 +1843,6 @@ fn pow_uint() {
     assert_eq!(result[0].unwrap_i64(), 1);
     assert_eq!(result[1].unwrap_i64(), 0);
 
-    // pow(0, 0) == 1
-    pow.call(
-        &mut store,
-        &[Val::I64(0), Val::I64(0), Val::I64(0), Val::I64(0)],
-        &mut result,
-    )
-    .expect("call to pow-uint failed");
-    assert_eq!(result[0].unwrap_i64(), 1);
-    assert_eq!(result[1].unwrap_i64(), 0);
-
     // pow(1, 0) == 1
     pow.call(
         &mut store,
@@ -1955,16 +1945,6 @@ fn pow_int() {
     let (instance, mut store) = load_stdlib().unwrap();
     let pow = instance.get_func(&mut store, "pow-int").unwrap();
     let mut result = [Val::I64(0), Val::I64(0)];
-
-    // pow(0, 0) == 1
-    pow.call(
-        &mut store,
-        &[Val::I64(0), Val::I64(0), Val::I64(0), Val::I64(0)],
-        &mut result,
-    )
-    .expect("call to pow-int failed");
-    assert_eq!(result[0].unwrap_i64(), 1);
-    assert_eq!(result[1].unwrap_i64(), 0);
 
     // pow(0, 0) == 1
     pow.call(

--- a/clar2wasm/tests/standard/utils.rs
+++ b/clar2wasm/tests/standard/utils.rs
@@ -277,7 +277,7 @@ impl FromWasmResult for bool {
 macro_rules! propints {
     ($(($name: ident, $range: ty)),+ $(,)?) => {
         $(
-            fn $name() -> proptest::strategy::BoxedStrategy<crate::utils::PropInt> {
+            pub(crate) fn $name() -> proptest::strategy::BoxedStrategy<crate::utils::PropInt> {
                 any::<$range>().prop_map(|n| crate::utils::PropInt::new(n as u128)).boxed()
             }
         )+
@@ -301,7 +301,7 @@ propints! {
 
 type PropIntStrategy = fn() -> BoxedStrategy<PropInt>;
 
-const UNSIGNED_STRATEGIES: [PropIntStrategy; 5] = [
+pub(crate) const UNSIGNED_STRATEGIES: [PropIntStrategy; 5] = [
     tiny_uint128,
     small_uint128,
     medium_uint128,
@@ -309,7 +309,7 @@ const UNSIGNED_STRATEGIES: [PropIntStrategy; 5] = [
     huge_uint128,
 ];
 
-const SIGNED_STRATEGIES: [PropIntStrategy; 5] = [
+pub(crate) const SIGNED_STRATEGIES: [PropIntStrategy; 5] = [
     tiny_int128,
     small_int128,
     medium_int128,

--- a/tests/contracts/power.clar
+++ b/tests/contracts/power.clar
@@ -1,0 +1,7 @@
+(define-public (with-int)
+    (ok (pow 42 7))
+)
+
+(define-public (with-uint)
+    (ok (pow u7 u42))
+)

--- a/tests/tests/lib_tests.rs
+++ b/tests/tests/lib_tests.rs
@@ -595,3 +595,26 @@ test_contract!(
         assert_eq!(*response.data, Value::UInt(4));
     }
 );
+
+test_contract!(
+    test_pow_int,
+    "power",
+    "with-int",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Int(230539333248));
+    }
+);
+
+test_contract!(
+    test_pow_uint,
+    "power",
+    "with-uint",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(
+            *response.data,
+            Value::UInt(311973482284542371301330321821976049)
+        );
+    }
+);


### PR DESCRIPTION
This is part of #69 

This PR implements the `pow` function for uint and int types.

~DRAFT: It still needs modifications of `wasm_generator` and "clar-file" tests.~

UPDATE: done.