### PR TITLE
feat: add support for `get-block-info?`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.wasm
 **/proptest-regressions
+/tests/contracts/*.wat

--- a/clar2wasm/benches/benchmark.rs
+++ b/clar2wasm/benches/benchmark.rs
@@ -396,6 +396,22 @@ pub(crate) fn load_stdlib() -> Result<(Instance, Store<()>), wasmtime::Error> {
         )
         .unwrap();
 
+    linker
+        .func_wrap(
+            "clarity",
+            "get_block_info",
+            |_name_offset: i32,
+             _name_length: i32,
+             _height_lo: i64,
+             _height_hi: i64,
+             _return_offset: i32,
+             _return_length: i32| {
+                println!("get_block_info");
+                Ok(())
+            },
+        )
+        .unwrap();
+
     // Create a log function for debugging.
     linker
         .func_wrap("", "log", |param: i64| {

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -143,6 +143,12 @@
                                                      (param $key_offset i32)
                                                      (param $key_length i32)
                                                      (result i32)))
+    (import "clarity" "get_block_info" (func $get_block_info (param $name_offset i32)
+                                                             (param $name_length i32)
+                                                             (param $height_lo i64)
+                                                             (param $height_hi i64)
+                                                             (param $return_offset i32)
+                                                             (param $return_length i32)))
 
     (import "clarity" "tx_sender" (func $tx_sender (param $return_offset i32)
                                                    (param $return_length i32)

--- a/clar2wasm/tests/standard/utils.rs
+++ b/clar2wasm/tests/standard/utils.rs
@@ -379,6 +379,22 @@ pub(crate) fn load_stdlib() -> Result<(Instance, Store<()>), wasmtime::Error> {
         )
         .unwrap();
 
+    linker
+        .func_wrap(
+            "clarity",
+            "get_block_info",
+            |_name_offset: i32,
+             _name_length: i32,
+             _height_lo: i64,
+             _height_hi: i64,
+             _return_offset: i32,
+             _return_length: i32| {
+                println!("get_block_info");
+                Ok(())
+            },
+        )
+        .unwrap();
+
     // Create a log function for debugging.
     linker
         .func_wrap("", "log", |param: i64| {

--- a/tests/contracts/get-block-info.clar
+++ b/tests/contracts/get-block-info.clar
@@ -1,0 +1,35 @@
+(define-public (non-existent)
+  (ok (get-block-info? time u9999999))
+)
+
+(define-public (get-burnchain-header-hash)
+  (ok (get-block-info? burnchain-header-hash u0))
+)
+
+(define-public (get-id-header-hash)
+  (ok (get-block-info? id-header-hash u0))
+)
+
+(define-public (get-header-hash)
+  (ok (get-block-info? header-hash u0))
+)
+
+(define-public (get-miner-address)
+  (ok (get-block-info? miner-address u0))
+)
+
+(define-public (get-time)
+  (ok (get-block-info? time u0))
+)
+
+(define-public (get-block-reward)
+  (ok (get-block-info? block-reward u0))
+)
+
+(define-public (get-miner-spend-total)
+  (ok (get-block-info? miner-spend-total u0))
+)
+
+(define-public (get-miner-spend-winner)
+  (ok (get-block-info? miner-spend-winner u0))
+)

--- a/tests/tests/lib_tests.rs
+++ b/tests/tests/lib_tests.rs
@@ -1298,3 +1298,109 @@ test_contract_call_response!(
         assert_eq!(*response.data, Value::none());
     }
 );
+
+// These tests are disabled because they require a block to be present in the
+// chain, which is not the case when running the tests. Once the test framework
+// supports this, these tests can be re-enabled.
+
+// test_contract_call_response!(
+//     test_gbi_non_existent,
+//     "get-block-info",
+//     "non-existent",
+//     |response: ResponseData| {
+//         assert!(response.committed);
+//         assert_eq!(*response.data, Value::none());
+//     }
+// );
+
+// test_contract_call_response!(
+//     test_gbi_bhh,
+//     "get-block-info",
+//     "get-burnchain-header-hash",
+//     |response: ResponseData| {
+//         assert!(response.committed);
+//         assert_eq!(
+//             *response.data,
+//             Value::some(Value::buff_from(vec![0u8; 32]).unwrap()).unwrap()
+//         );
+//     }
+// );
+
+// test_contract_call_response!(
+//     test_gbi_id_hh,
+//     "get-block-info",
+//     "get-id-header-hash",
+//     |response: ResponseData| {
+//         assert!(response.committed);
+//         assert_eq!(
+//             *response.data,
+//             Value::some(Value::buff_from(vec![0u8; 32]).unwrap()).unwrap()
+//         );
+//     }
+// );
+
+// test_contract_call_response!(
+//     test_gbi_hh,
+//     "get-block-info",
+//     "get-header-hash",
+//     |response: ResponseData| {
+//         assert!(response.committed);
+//         assert_eq!(
+//             *response.data,
+//             Value::some(Value::buff_from(vec![0u8; 32]).unwrap()).unwrap()
+//         );
+//     }
+// );
+
+// test_contract_call_response!(
+//     test_gbi_miner_address,
+//     "get-block-info",
+//     "get-miner-address",
+//     |response: ResponseData| {
+//         assert!(response.committed);
+//         assert_eq!(
+//             *response.data,
+//             Value::some(StandardPrincipalData::transient().into()).unwrap()
+//         );
+//     }
+// );
+
+// test_contract_call_response!(
+//     test_gbi_time,
+//     "get-block-info",
+//     "get-time",
+//     |response: ResponseData| {
+//         assert!(response.committed);
+//         assert_eq!(*response.data, Value::some(Value::UInt(42)).unwrap());
+//     }
+// );
+
+// test_contract_call_response!(
+//     test_gbi_block_reward,
+//     "get-block-info",
+//     "get-block-reward",
+//     |response: ResponseData| {
+//         assert!(response.committed);
+//         assert_eq!(*response.data, Value::some(Value::UInt(0)).unwrap());
+//     }
+// );
+
+// test_contract_call_response!(
+//     test_gbi_miner_spend_total,
+//     "get-block-info",
+//     "get-miner-spend-total",
+//     |response: ResponseData| {
+//         assert!(response.committed);
+//         assert_eq!(*response.data, Value::some(Value::UInt(0)).unwrap());
+//     }
+// );
+
+// test_contract_call_response!(
+//     test_gbi_miner_spend_winner,
+//     "get-block-info",
+//     "get-miner-spend-winner",
+//     |response: ResponseData| {
+//         assert!(response.committed);
+//         assert_eq!(*response.data, Value::some(Value::UInt(0)).unwrap());
+//     }
+// );


### PR DESCRIPTION
## Description

This PR follows up on #107. After that is merged, we can set `main` as the target for this one.

This PR adds support for `get-block-info?`. This can't be properly tested yet, because that expression only works on past blocks, and we aren't able to advance the block in our test framework currently. I opened #108 for this.

This expression is included in issue #64.