### PR TITLE
Property tests for sha256 and hash160

### DIFF
--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -1309,8 +1309,8 @@
         (local.set $res_len ;; total size of data with expansion
             (i32.add
                 (i32.or
-                    ;; len + 1 byte for the added "1" + 8 bytes for the size
-                    (i32.add (local.get $length) (i32.const 9))
+                    ;; len + 8 bytes for the size
+                    (i32.add (local.get $length) (i32.const 8))
                     (i32.const 0x3f)
                 )
                 (i32.const 1)

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -530,3 +530,17 @@ fn prop_hash160_buff() {
         |buf| Hash160::from_data(buf).as_bytes().to_vec(),
     )
 }
+
+#[test]
+fn prop_hash160_int_on_signed() {
+    test_on_int_hash("hash160-int", 1024, END_OF_STANDARD_DATA as i32, 20, |n| {
+        Hash160::from_data(&n.to_le_bytes()).as_bytes().to_vec()
+    })
+}
+
+#[test]
+fn prop_hash160_int_on_unsigned() {
+    test_on_uint_hash("hash160-int", 1024, END_OF_STANDARD_DATA as i32, 20, |n| {
+        Hash160::from_data(&n.to_le_bytes()).as_bytes().to_vec()
+    })
+}

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -7,8 +7,8 @@ use wasmtime::Val;
 
 use crate::utils::{
     self, load_stdlib, medium_int128, medium_uint128, small_int128, small_uint128,
-    test_on_buffer_hash, tiny_int128, tiny_uint128, FromWasmResult, SIGNED_STRATEGIES,
-    UNSIGNED_STRATEGIES,
+    test_on_buffer_hash, test_on_int_hash, test_on_uint_hash, tiny_int128, tiny_uint128,
+    FromWasmResult, SIGNED_STRATEGIES, UNSIGNED_STRATEGIES,
 };
 
 #[test]
@@ -502,4 +502,18 @@ fn prop_sha256_buff() {
         32,
         |buf| Sha256Sum::from_data(buf).as_bytes().to_vec(),
     )
+}
+
+#[test]
+fn prop_sha256_int_on_signed() {
+    test_on_int_hash("sha256-int", 1024, END_OF_STANDARD_DATA as i32, 32, |n| {
+        Sha256Sum::from_data(&n.to_le_bytes()).as_bytes().to_vec()
+    })
+}
+
+#[test]
+fn prop_sha256_int_on_unsigned() {
+    test_on_uint_hash("sha256-int", 1024, END_OF_STANDARD_DATA as i32, 32, |n| {
+        Sha256Sum::from_data(&n.to_le_bytes()).as_bytes().to_vec()
+    })
 }

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -1,11 +1,14 @@
 use std::{cell::RefCell, ops::DerefMut};
 
+use clar2wasm::wasm_generator::END_OF_STANDARD_DATA;
+use clarity::util::hash::Sha256Sum;
 use proptest::{prop_assert_eq, proptest};
 use wasmtime::Val;
 
 use crate::utils::{
-    self, load_stdlib, medium_int128, medium_uint128, small_int128, small_uint128, tiny_int128,
-    tiny_uint128, FromWasmResult, SIGNED_STRATEGIES, UNSIGNED_STRATEGIES,
+    self, load_stdlib, medium_int128, medium_uint128, small_int128, small_uint128,
+    test_on_buffer_hash, tiny_int128, tiny_uint128, FromWasmResult, SIGNED_STRATEGIES,
+    UNSIGNED_STRATEGIES,
 };
 
 #[test]
@@ -486,4 +489,17 @@ fn prop_store_i64_be() {
             .expect("Could not read value from memory");
         prop_assert_eq!(buffer, val.to_be_bytes());
     });
+}
+
+#[test]
+fn prop_sha256_buff() {
+    test_on_buffer_hash(
+        "sha256-buf",
+        1024,
+        END_OF_STANDARD_DATA as usize + 32,
+        300,
+        END_OF_STANDARD_DATA as i32,
+        32,
+        |buf| Sha256Sum::from_data(buf).as_bytes().to_vec(),
+    )
 }

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -1,7 +1,7 @@
 use std::{cell::RefCell, ops::DerefMut};
 
 use clar2wasm::wasm_generator::END_OF_STANDARD_DATA;
-use clarity::util::hash::Sha256Sum;
+use clarity::util::hash::{Hash160, Sha256Sum};
 use proptest::{prop_assert_eq, proptest};
 use wasmtime::Val;
 
@@ -516,4 +516,17 @@ fn prop_sha256_int_on_unsigned() {
     test_on_uint_hash("sha256-int", 1024, END_OF_STANDARD_DATA as i32, 32, |n| {
         Sha256Sum::from_data(&n.to_le_bytes()).as_bytes().to_vec()
     })
+}
+
+#[test]
+fn prop_hash160_buff() {
+    test_on_buffer_hash(
+        "hash160-buf",
+        2048,
+        END_OF_STANDARD_DATA as usize + 20,
+        300,
+        END_OF_STANDARD_DATA as i32,
+        20,
+        |buf| Hash160::from_data(buf).as_bytes().to_vec(),
+    )
 }

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -2322,6 +2322,34 @@ fn sha256_buf() {
     let expected_result =
         Vec::from_hex("973153f86ec2da1748e63f0cf85b89835b42f8ee8018c549868a1308a19f6ca3").unwrap();
     assert_eq!(&buffer, &expected_result);
+
+    // test with buffer of size 55, the limit between 1 and 2 blocks
+    let text = &[0; 55];
+    memory
+        .write(&mut store, END_OF_STANDARD_DATA as usize, text)
+        .expect("Should be able to write to memory");
+
+    sha256
+        .call(
+            &mut store,
+            &[
+                Val::I32(END_OF_STANDARD_DATA as i32),
+                Val::I32(text.len() as i32),
+                res_offset.into(),
+            ],
+            &mut result,
+        )
+        .expect("call to sha256-buf failed");
+    assert_eq!(result[0].unwrap_i32(), res_offset);
+    assert_eq!(result[1].unwrap_i32(), 32);
+
+    let mut buffer = vec![0u8; result[1].unwrap_i32() as usize];
+    memory
+        .read(&mut store, result[0].unwrap_i32() as usize, &mut buffer)
+        .expect("could not read resulting hash from memory");
+    let expected_result =
+        Vec::from_hex("02779466cdec163811d078815c633f21901413081449002f24aa3e80f0b88ef7").unwrap();
+    assert_eq!(&buffer, &expected_result);
 }
 
 #[test]

--- a/clar2wasm/tests/standard/utils.rs
+++ b/clar2wasm/tests/standard/utils.rs
@@ -1,3 +1,4 @@
+use hex::ToHex;
 use proptest::prelude::*;
 use std::ops::Deref;
 use std::{cell::RefCell, ops::DerefMut};
@@ -763,10 +764,22 @@ where
     test_export_one_arg_checked(&SIGNED_STRATEGIES, name, closure)
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct PropBuffer {
     buffer: Vec<u8>,
     offset: usize,
+}
+
+impl std::fmt::Debug for PropBuffer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PropBuffer")
+            .field(
+                "buffer",
+                &format!("0x{}", self.buffer.encode_hex::<String>()),
+            )
+            .field("offset", &self.offset)
+            .finish()
+    }
 }
 
 impl PropBuffer {


### PR DESCRIPTION
This PR adds tests for the Wasm functions `sha256-buf`, `sha256-int`, `hash160-buf` and `hash160-int`.

It introduces a new "Property Struct": `PropBuffer`, to make it easy to generate buffers up to a maximum size and to deal with writing to and reading from memory.

It also adds generic property tests functions for testing hash functions. We should be able to reuse them for `sha512` or `keccak`.

Adding the property tests for those functions, I noticed a of-by-one error in my `sha256-buf` algorithm, in the `extend-data` part. This error is fixed, and a unit test added for this edge case.

This PR solves the buffer part of #125.