### PR TITLE
Implement buffer functions

### DIFF
--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -218,7 +218,8 @@
         ;; 2: divide by zero
         ;; 3: log of a number <= 0
         ;; 4: expected a non-negative number
-        ;; 5: panic
+        ;; 5: buffer to integer expects a buffer length <= 16
+        ;; 6: panic
     (func $runtime-error (type 0) (param $error-code i32)
         ;; TODO: Implement runtime error
         unreachable
@@ -1727,6 +1728,44 @@
         )
     )
 
+    (func $buff-to-uint-be (param $offset i32) (param $length i32) (result i64 i64)
+        (local $mask_lo i64) (local $mask_hi i64) (local $double v128)
+        (if (i32.gt_u (local.get $length) (i32.const 16))
+            (then (call $runtime-error (i32.const 5)))
+        )
+
+        (if (i32.eqz (local.get $length))
+            (then (return (i64.const 0) (i64.const 0)))
+        )
+
+        ;; SAFETY: this function works because we already have data in the memory,
+        ;;         otherwise we could have a negative offset.
+        (local.set $offset (i32.sub (i32.add (local.get $offset) (local.get $length)) (i32.const 16)))
+
+        ;; we compute masks for the low and high part of the resulting integer
+        (local.set $mask_lo
+            (select
+                (i64.const -1)
+                (local.tee $mask_hi
+                    (i64.shr_u (i64.const -1) (i64.extend_i32_u (i32.and (i32.mul (local.get $length) (i32.const 56)) (i32.const 56))))
+                )
+                (i32.ge_u (local.get $length) (i32.const 8))
+            )
+        )
+        (local.set $mask_hi (select (local.get $mask_hi) (i64.const 0) (i32.gt_u (local.get $length) (i32.const 8))))
+
+        ;; we load both low and high part at once, and rearrange the bytes for endianness
+        (local.set $double
+            (i8x16.swizzle
+                (v128.load (local.get $offset))
+                (v128.const i8x16 7 6 5 4 3 2 1 0 15 14 13 12 11 10 9 8)
+            )
+        )
+
+        (i64.and (i64x2.extract_lane 1 (local.get $double)) (local.get $mask_lo))
+        (i64.and (i64x2.extract_lane 0 (local.get $double)) (local.get $mask_hi))
+    )
+
     (export "memcpy" (func $memcpy))
     (export "add-uint" (func $add-uint))
     (export "add-int" (func $add-int))
@@ -1770,4 +1809,5 @@
     (export "hash160-int" (func $hash160-int))
     (export "store-i32-be" (func $store-i32-be))
     (export "store-i64-be" (func $store-i64-be))
+    (export "buff-to-uint-be" (func $buff-to-uint-be))
 )

--- a/clar2wasm/src/words/buff_to_integer.rs
+++ b/clar2wasm/src/words/buff_to_integer.rs
@@ -36,9 +36,9 @@ impl Word for BuffToUintBe {
 }
 
 #[derive(Debug)]
-pub struct BuffTointBe;
+pub struct BuffToIntBe;
 
-impl Word for BuffTointBe {
+impl Word for BuffToIntBe {
     fn name(&self) -> clarity::vm::ClarityName {
         "buff-to-int-be".into()
     }
@@ -53,5 +53,45 @@ impl Word for BuffTointBe {
         // This is the same function as "buff-to-uint-be", with the result interpreted
         // as i128 instead of u128.
         traverse_buffer_to_integer("buff-to-uint-be", generator, builder, args)
+    }
+}
+
+#[derive(Debug)]
+pub struct BuffToUintLe;
+
+impl Word for BuffToUintLe {
+    fn name(&self) -> clarity::vm::ClarityName {
+        "buff-to-uint-Le".into()
+    }
+
+    fn traverse(
+        &self,
+        generator: &mut crate::wasm_generator::WasmGenerator,
+        builder: &mut walrus::InstrSeqBuilder,
+        _expr: &clarity::vm::SymbolicExpression,
+        args: &[clarity::vm::SymbolicExpression],
+    ) -> Result<(), crate::wasm_generator::GeneratorError> {
+        traverse_buffer_to_integer("buff-to-uint-le", generator, builder, args)
+    }
+}
+
+#[derive(Debug)]
+pub struct BuffToIntLe;
+
+impl Word for BuffToIntLe {
+    fn name(&self) -> clarity::vm::ClarityName {
+        "buff-to-int-le".into()
+    }
+
+    fn traverse(
+        &self,
+        generator: &mut crate::wasm_generator::WasmGenerator,
+        builder: &mut walrus::InstrSeqBuilder,
+        _expr: &clarity::vm::SymbolicExpression,
+        args: &[clarity::vm::SymbolicExpression],
+    ) -> Result<(), crate::wasm_generator::GeneratorError> {
+        // This is the same function as "buff-to-uint-le", with the result interpreted
+        // as i128 instead of u128.
+        traverse_buffer_to_integer("buff-to-uint-le", generator, builder, args)
     }
 }

--- a/clar2wasm/src/words/buff_to_integer.rs
+++ b/clar2wasm/src/words/buff_to_integer.rs
@@ -1,0 +1,37 @@
+use super::Word;
+
+fn traverse_buffer_to_integer(
+    word: &impl Word,
+    generator: &mut crate::wasm_generator::WasmGenerator,
+    builder: &mut walrus::InstrSeqBuilder,
+    args: &[clarity::vm::SymbolicExpression],
+) -> Result<(), crate::wasm_generator::GeneratorError> {
+    let name = &word.name();
+    let func = generator
+        .module
+        .funcs
+        .by_name(name)
+        .unwrap_or_else(|| panic!("function not found: {name}"));
+    generator.traverse_args(builder, args)?;
+    builder.call(func);
+    Ok(())
+}
+
+#[derive(Debug)]
+pub struct BuffToUintBe;
+
+impl Word for BuffToUintBe {
+    fn name(&self) -> clarity::vm::ClarityName {
+        "buff-to-uint-be".into()
+    }
+
+    fn traverse(
+        &self,
+        generator: &mut crate::wasm_generator::WasmGenerator,
+        builder: &mut walrus::InstrSeqBuilder,
+        _expr: &clarity::vm::SymbolicExpression,
+        args: &[clarity::vm::SymbolicExpression],
+    ) -> Result<(), crate::wasm_generator::GeneratorError> {
+        traverse_buffer_to_integer(self, generator, builder, args)
+    }
+}

--- a/clar2wasm/src/words/buff_to_integer.rs
+++ b/clar2wasm/src/words/buff_to_integer.rs
@@ -1,12 +1,11 @@
 use super::Word;
 
 fn traverse_buffer_to_integer(
-    word: &impl Word,
+    name: &str,
     generator: &mut crate::wasm_generator::WasmGenerator,
     builder: &mut walrus::InstrSeqBuilder,
     args: &[clarity::vm::SymbolicExpression],
 ) -> Result<(), crate::wasm_generator::GeneratorError> {
-    let name = &word.name();
     let func = generator
         .module
         .funcs
@@ -32,6 +31,27 @@ impl Word for BuffToUintBe {
         _expr: &clarity::vm::SymbolicExpression,
         args: &[clarity::vm::SymbolicExpression],
     ) -> Result<(), crate::wasm_generator::GeneratorError> {
-        traverse_buffer_to_integer(self, generator, builder, args)
+        traverse_buffer_to_integer("buff-to-uint-be", generator, builder, args)
+    }
+}
+
+#[derive(Debug)]
+pub struct BuffTointBe;
+
+impl Word for BuffTointBe {
+    fn name(&self) -> clarity::vm::ClarityName {
+        "buff-to-int-be".into()
+    }
+
+    fn traverse(
+        &self,
+        generator: &mut crate::wasm_generator::WasmGenerator,
+        builder: &mut walrus::InstrSeqBuilder,
+        _expr: &clarity::vm::SymbolicExpression,
+        args: &[clarity::vm::SymbolicExpression],
+    ) -> Result<(), crate::wasm_generator::GeneratorError> {
+        // This is the same function as "buff-to-uint-be", with the result interpreted
+        // as i128 instead of u128.
+        traverse_buffer_to_integer("buff-to-uint-be", generator, builder, args)
     }
 }

--- a/clar2wasm/src/words/buff_to_integer.rs
+++ b/clar2wasm/src/words/buff_to_integer.rs
@@ -61,7 +61,7 @@ pub struct BuffToUintLe;
 
 impl Word for BuffToUintLe {
     fn name(&self) -> clarity::vm::ClarityName {
-        "buff-to-uint-Le".into()
+        "buff-to-uint-le".into()
     }
 
     fn traverse(

--- a/clar2wasm/src/words/mod.rs
+++ b/clar2wasm/src/words/mod.rs
@@ -89,6 +89,10 @@ pub(crate) static WORDS: &[&'static dyn Word] = &[
     &contract::ContractCall,
     &blockinfo::GetBlockInfo,
     &print::Print,
+    &buff_to_integer::BuffToIntBe,
+    &buff_to_integer::BuffToIntLe,
+    &buff_to_integer::BuffToUintBe,
+    &buff_to_integer::BuffToUintLe,
 ];
 
 pub trait Word: Sync + core::fmt::Debug {

--- a/clar2wasm/src/words/mod.rs
+++ b/clar2wasm/src/words/mod.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 pub mod arithmetic;
 pub mod bitwise;
 pub mod blockinfo;
+pub mod buff_to_integer;
 pub mod comparison;
 pub mod constants;
 pub mod contract;

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -8,7 +8,7 @@ use wasmtime::Val;
 use crate::utils::{
     self, load_stdlib, medium_int128, medium_uint128, small_int128, small_uint128,
     test_on_buffer_hash, test_on_int_hash, test_on_uint_hash, tiny_int128, tiny_uint128,
-    FromWasmResult, SIGNED_STRATEGIES, UNSIGNED_STRATEGIES,
+    FromWasmResult, PropInt, SIGNED_STRATEGIES, UNSIGNED_STRATEGIES,
 };
 
 #[test]
@@ -543,4 +543,43 @@ fn prop_hash160_int_on_unsigned() {
     test_on_uint_hash("hash160-int", 1024, END_OF_STANDARD_DATA as i32, 20, |n| {
         Hash160::from_data(&n.to_le_bytes()).as_bytes().to_vec()
     })
+}
+
+#[test]
+fn prop_buff_to_uint_be() {
+    let (instance, store) = load_stdlib().unwrap();
+    let store = RefCell::new(store);
+
+    let memory = instance
+        .get_memory(store.borrow_mut().deref_mut(), "memory")
+        .expect("Could not find memory");
+
+    let buff_to_uint_be = instance
+        .get_func(store.borrow_mut().deref_mut(), "buff-to-uint-be")
+        .unwrap();
+
+    proptest!(|(buff in utils::buffer(1500, 16))| {
+        let expected_result = PropInt::new({ 
+            let mut b = buff.to_vec();
+            let offset = 16 - buff.len();
+            b.extend(std::iter::repeat(0).take(offset));
+            b.rotate_right(offset);
+            u128::from_be_bytes(b.try_into().unwrap())
+        });
+
+        let mut result = [Val::I64(0), Val::I64(0)];
+        let (offset, length) = buff
+            .write_to_memory(memory, store.borrow_mut().deref_mut())
+            .expect("Could not write to memory");
+
+        buff_to_uint_be
+            .call(
+                store.borrow_mut().deref_mut(),
+                &[offset.into(), length.into()],
+                &mut result,
+            )
+            .expect("call to buff-to-uint-be failed");
+        prop_assert_eq!(result[0].unwrap_i64(), expected_result.low());
+        prop_assert_eq!(result[1].unwrap_i64(), expected_result.high());
+    });
 }

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -2655,3 +2655,65 @@ fn store_i64_be() {
         .expect("Could not read value from memory");
     assert_eq!(buffer, [0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]);
 }
+
+#[test]
+fn buff_to_uint_be() {
+    let (instance, mut store) = load_stdlib().unwrap();
+
+    let memory = instance
+        .get_memory(&mut store, "memory")
+        .expect("Could not find memory");
+
+    let buff_to_uint_be = instance.get_func(&mut store, "buff-to-uint-be").unwrap();
+    let mut result = [Val::I64(0), Val::I64(0)];
+
+    let mut test_buff = |buf: &[u8], expected_lo: u64, expected_hi: u64| {
+        memory
+            .write(&mut store, 1500, buf)
+            .expect("Could not write to memory");
+        buff_to_uint_be
+            .call(
+                &mut store,
+                &[Val::I32(1500), Val::I32(buf.len() as i32)],
+                &mut result,
+            )
+            .expect("call to buff-to-uint-be failed");
+        assert_eq!(result[0].unwrap_i64(), expected_lo as i64);
+        assert_eq!(result[1].unwrap_i64(), expected_hi as i64);
+    };
+
+    // Empty buffer == 0
+    test_buff(&[], 0, 0);
+
+    // 0x01
+    test_buff(&[1], 1, 0);
+
+    // 0x0102
+    test_buff(&[1, 2], 0x0102, 0);
+
+    // 0x0102030405060708
+    test_buff(&[1, 2, 3, 4, 5, 6, 7, 8], 0x0102030405060708, 0);
+
+    // 0x010203040506070809
+    test_buff(&[1, 2, 3, 4, 5, 6, 7, 8, 9], 0x0203040506070809, 0x01);
+
+    // 0x0102030405060708090a0b0c0d0e0f10
+    test_buff(
+        &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+        0x090a0b0c0d0e0f10,
+        0x0102030405060708,
+    );
+
+    // Fail for buffer with length > 16
+    let buf = [0u8; 17];
+    memory
+        .write(&mut store, 1500, &buf)
+        .expect("Could not write to memory");
+    buff_to_uint_be
+        .call(
+            &mut store,
+            &[Val::I32(1500), Val::I32(buf.len() as i32)],
+            &mut result,
+        )
+        .expect_err("expected runtime error");
+}

--- a/clar2wasm/tests/standard/utils.rs
+++ b/clar2wasm/tests/standard/utils.rs
@@ -873,7 +873,7 @@ impl AsRef<[u8]> for PropBuffer {
 
 prop_compose! {
     /// Generates random PropBuffer with given `offset`. The length will be between 1 and `max_length`.
-    fn buffer(offset: usize, max_length: usize)
+    pub(crate) fn buffer(offset: usize, max_length: usize)
         (buf in proptest::collection::vec(any::<u8>(), 1..max_length))
         -> PropBuffer {
             PropBuffer::new(buf, offset)

--- a/tests/contracts/buffer-to-integer.clar
+++ b/tests/contracts/buffer-to-integer.clar
@@ -1,0 +1,15 @@
+(define-public (buff_to_uint_be)
+    (ok (buff-to-uint-be 0x812154782113679921369489623ade12))
+)
+
+(define-public (buff_to_int_be)
+    (ok (buff-to-int-be 0x812154782113679921369489623ade12))
+)
+
+(define-public (buff_to_uint_le)
+    (ok (buff-to-uint-le 0x812154782113679921369489623ade12))
+)
+
+(define-public (buff_to_int_le)
+    (ok (buff-to-int-le 0x812154782113679921369489623ade12))
+)

--- a/tests/src/lib_tests.rs
+++ b/tests/src/lib_tests.rs
@@ -2793,3 +2793,55 @@ test_contract_call_response!(
         );
     }
 );
+
+test_contract_call_response!(
+    test_buff_to_uint_be,
+    "buffer-to-integer",
+    "buff_to_uint_be",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(
+            *response.data,
+            Value::UInt(171643470492608469511538647592439832082)
+        )
+    }
+);
+
+test_contract_call_response!(
+    test_buff_to_int_be,
+    "buffer-to-integer",
+    "buff_to_int_be",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(
+            *response.data,
+            Value::Int(-168638896428329993951835959839328379374),
+        )
+    }
+);
+
+test_contract_call_response!(
+    test_buff_to_uint_le,
+    "buffer-to-integer",
+    "buff_to_uint_le",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(
+            *response.data,
+            Value::UInt(25079978013418778635005664149300846977)
+        )
+    }
+);
+
+test_contract_call_response!(
+    test_buff_to_int_le,
+    "buffer-to-integer",
+    "buff_to_int_le",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(
+            *response.data,
+            Value::Int(25079978013418778635005664149300846977),
+        )
+    }
+);


### PR DESCRIPTION
Adds the implementation for the buffer functions defined in #65.

There is a little "safety concern" for the `buff-to-x-be`, where I read from memory an offset that is before the one passed as an argument. However, since the standard has data in memory, this offset should never start at 0, and the implementation is safe for our use case.