### PR TITLE
Add comparison operators for buffers and ascii strings

### DIFF
--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -796,7 +796,7 @@
             (br_if $done
                 (i32.eqz
                     (local.tee $i
-                        ;; no i32.min is Wasm...
+                        ;; no i32.min in Wasm...
                         (select
                             (local.get $length_a)
                             (local.get $length_b)

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -791,6 +791,14 @@
 
     (func $lt-buff (type 9) (param $offset_a i32) (param $length_a i32) (param $offset_b i32) (param $length_b i32) (result i32)
         (local $i i32) (local $sub i32)
+        ;; pseudo-code:
+        ;; let i = min(length_a, length_b)
+        ;; while i != 0 {
+        ;;   if ((sub = a[offset_a] - b[offset_b]) == 0) {
+        ;;     offset_a += 1; offset_b += 1; i -= 1;
+        ;;   } else { break }
+        ;; }
+        ;; return (sub != 0) ? (sub < 0) : (length_a < length_b)
         (block $done
             ;; we can skip the comparison loop if $i (min length) is 0
             (br_if $done
@@ -808,6 +816,7 @@
             (loop $loop
                 (if
                     (i32.eqz
+                        ;; $sub will be 0 if both are equal, otherwise its sign indicates which is smaller
                         (local.tee $sub
                             (i32.sub (i32.load8_u (local.get $offset_a)) (i32.load8_u (local.get $offset_b)))
                         )

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -907,6 +907,43 @@
         )
     )
 
+    (func $ge-buff (type 9) (param $offset_a i32) (param $length_a i32) (param $offset_b i32) (param $length_b i32) (result i32)
+        (local $i i32) (local $sub i32)
+        ;; same algorithm as $lt-buff
+        (block $done
+            (br_if $done
+                (i32.eqz
+                    (local.tee $i
+                        (select
+                            (local.get $length_a)
+                            (local.get $length_b)
+                            (i32.lt_u (local.get $length_a) (local.get $length_b))
+                        )
+                    )
+                )
+            )
+            (loop $loop
+                (if
+                    (i32.eqz
+                        (local.tee $sub
+                            (i32.sub (i32.load8_u (local.get $offset_a)) (i32.load8_u (local.get $offset_b)))
+                        )
+                    )
+                    (then
+                        (local.set $offset_a (i32.add (local.get $offset_a) (i32.const 1)))
+                        (local.set $offset_b (i32.add (local.get $offset_b) (i32.const 1)))
+                        (br_if $loop (local.tee $i (i32.sub (local.get $i) (i32.const 1))))
+                    )
+                )
+            )
+        )
+        (select
+            (i32.ge_s (local.get $sub) (i32.const 0))
+            (i32.ge_u (local.get $length_a) (local.get $length_b))
+            (local.get $sub)
+        )
+    )
+
     (func $log2 (param $lo i64) (param $hi i64) (result i64)
         (select
             (i64.xor (i64.clz (local.get $lo)) (i64.const 63))
@@ -1914,6 +1951,7 @@
     (export "lt-buff" (func $lt-buff))
     (export "gt-buff" (func $gt-buff))
     (export "le-buff" (func $le-buff))
+    (export "ge-buff" (func $ge-buff))
     (export "log2-uint" (func $log2-uint))
     (export "log2-int" (func $log2-int))
     (export "sqrti-uint" (func $sqrti-uint))

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -830,6 +830,43 @@
         )
     )
 
+    (func $gt-buff (type 9) (param $offset_a i32) (param $length_a i32) (param $offset_b i32) (param $length_b i32) (result i32)
+        (local $i i32) (local $sub i32)
+        ;; same algorithm as $lt-buff, with the arguments flipped (a > b == b < a)
+        (block $done
+            (br_if $done
+                (i32.eqz
+                    (local.tee $i
+                        (select
+                            (local.get $length_a)
+                            (local.get $length_b)
+                            (i32.lt_u (local.get $length_a) (local.get $length_b))
+                        )
+                    )
+                )
+            )
+            (loop $loop
+                (if
+                    (i32.eqz
+                        (local.tee $sub
+                            (i32.sub (i32.load8_u (local.get $offset_b)) (i32.load8_u (local.get $offset_a)))
+                        )
+                    )
+                    (then
+                        (local.set $offset_a (i32.add (local.get $offset_a) (i32.const 1)))
+                        (local.set $offset_b (i32.add (local.get $offset_b) (i32.const 1)))
+                        (br_if $loop (local.tee $i (i32.sub (local.get $i) (i32.const 1))))
+                    )
+                )
+            )
+        )
+        (select
+            (i32.shr_u (local.get $sub) (i32.const 31))
+            (i32.lt_u (local.get $length_b) (local.get $length_a))
+            (local.get $sub)
+        )
+    )
+
     (func $log2 (param $lo i64) (param $hi i64) (result i64)
         (select
             (i64.xor (i64.clz (local.get $lo)) (i64.const 63))
@@ -1835,6 +1872,7 @@
     (export "le-int" (func $le-int))
     (export "ge-int" (func $ge-int))
     (export "lt-buff" (func $lt-buff))
+    (export "gt-buff" (func $gt-buff))
     (export "log2-uint" (func $log2-uint))
     (export "log2-int" (func $log2-int))
     (export "sqrti-uint" (func $sqrti-uint))

--- a/clar2wasm/src/words/comparison.rs
+++ b/clar2wasm/src/words/comparison.rs
@@ -21,13 +21,12 @@ fn traverse_comparison(
     let type_suffix = match ty {
         TypeSignature::IntType => "int",
         TypeSignature::UIntType => "uint",
-        TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::ASCII(_))) => {
-            "string-ascii"
-        }
+        // same function for buffer and string-ascii
+        TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::ASCII(_)))
+        | TypeSignature::SequenceType(SequenceSubtype::BufferType(_)) => "buff",
         TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::UTF8(_))) => {
-            "string-utf8"
+            todo!()
         }
-        TypeSignature::SequenceType(SequenceSubtype::BufferType(_)) => "buffer",
         _ => {
             return Err(GeneratorError::InternalError(
                 "invalid type for comparison".to_string(),

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -579,3 +579,8 @@ fn prop_lt_buff() {
 fn prop_gt_buff() {
     test_buff_comparison("gt-buff", |a, b| a > b)
 }
+
+#[test]
+fn prop_le_buff() {
+    test_buff_comparison("le-buff", |a, b| a <= b)
+}

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -584,3 +584,8 @@ fn prop_gt_buff() {
 fn prop_le_buff() {
     test_buff_comparison("le-buff", |a, b| a <= b)
 }
+
+#[test]
+fn prop_ge_buff() {
+    test_buff_comparison("ge-buff", |a, b| a >= b)
+}

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -7,8 +7,9 @@ use wasmtime::Val;
 
 use crate::utils::{
     self, load_stdlib, medium_int128, medium_uint128, small_int128, small_uint128,
-    test_buff_to_uint, test_on_buffer_hash, test_on_int_hash, test_on_uint_hash, tiny_int128,
-    tiny_uint128, FromWasmResult, PropInt, SIGNED_STRATEGIES, UNSIGNED_STRATEGIES,
+    test_buff_comparison, test_buff_to_uint, test_on_buffer_hash, test_on_int_hash,
+    test_on_uint_hash, tiny_int128, tiny_uint128, FromWasmResult, PropInt, SIGNED_STRATEGIES,
+    UNSIGNED_STRATEGIES,
 };
 
 #[test]
@@ -567,4 +568,9 @@ fn prop_buff_to_uint_le() {
             u128::from_le_bytes(b.try_into().unwrap())
         })
     })
+}
+
+#[test]
+fn prop_lt_buff() {
+    test_buff_comparison("lt-buff", |a, b| a < b)
 }

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -574,3 +574,8 @@ fn prop_buff_to_uint_le() {
 fn prop_lt_buff() {
     test_buff_comparison("lt-buff", |a, b| a < b)
 }
+
+#[test]
+fn prop_gt_buff() {
+    test_buff_comparison("gt-buff", |a, b| a > b)
+}

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -1772,6 +1772,52 @@ fn test_gt_buff() {
 }
 
 #[test]
+fn test_le_buff() {
+    let (instance, mut store) = load_stdlib().unwrap();
+    let memory = instance
+        .get_memory(&mut store, "memory")
+        .expect("Could not find memory");
+
+    let le = instance.get_func(&mut store, "le-buff").unwrap();
+    let mut result = [Val::I32(0)];
+
+    let mut test_cmp = |buff_a: &[u8], buff_b: &[u8]| {
+        let offset_a = 1000;
+        let offset_b = offset_a + buff_a.len();
+        memory
+            .write(&mut store, offset_a, buff_a)
+            .expect("could not write to memory");
+        memory
+            .write(&mut store, offset_b, buff_b)
+            .expect("could not write to memory");
+
+        le.call(
+            &mut store,
+            &[
+                Val::I32(offset_a as i32),
+                Val::I32(buff_a.len() as i32),
+                Val::I32(offset_b as i32),
+                Val::I32(buff_b.len() as i32),
+            ],
+            &mut result,
+        )
+        .expect("call to lt-buff failed");
+
+        assert_eq!(result[0].unwrap_i32(), (buff_a <= buff_b) as i32)
+    };
+
+    // tests with empty buffers
+    test_cmp(&[], &[]);
+    test_cmp(&[], &[0]);
+    test_cmp(&[0], &[]);
+
+    // test with longer equal buffers up to...
+    test_cmp(&[1, 2, 3], &[1, 2, 3]);
+    test_cmp(&[1, 2, 3, 4], &[1, 2, 3]);
+    test_cmp(&[1, 2, 3], &[1, 2, 3, 4]);
+}
+
+#[test]
 fn test_log2_uint() {
     let (instance, mut store) = load_stdlib().unwrap();
     let log2 = instance.get_func(&mut store, "log2-uint").unwrap();

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -1726,6 +1726,52 @@ fn test_lt_buff() {
 }
 
 #[test]
+fn test_gt_buff() {
+    let (instance, mut store) = load_stdlib().unwrap();
+    let memory = instance
+        .get_memory(&mut store, "memory")
+        .expect("Could not find memory");
+
+    let gt = instance.get_func(&mut store, "gt-buff").unwrap();
+    let mut result = [Val::I32(0)];
+
+    let mut test_cmp = |buff_a: &[u8], buff_b: &[u8]| {
+        let offset_a = 1000;
+        let offset_b = offset_a + buff_a.len();
+        memory
+            .write(&mut store, offset_a, buff_a)
+            .expect("could not write to memory");
+        memory
+            .write(&mut store, offset_b, buff_b)
+            .expect("could not write to memory");
+
+        gt.call(
+            &mut store,
+            &[
+                Val::I32(offset_a as i32),
+                Val::I32(buff_a.len() as i32),
+                Val::I32(offset_b as i32),
+                Val::I32(buff_b.len() as i32),
+            ],
+            &mut result,
+        )
+        .expect("call to lt-buff failed");
+
+        assert_eq!(result[0].unwrap_i32(), (buff_a > buff_b) as i32)
+    };
+
+    // tests with empty buffers
+    test_cmp(&[], &[]);
+    test_cmp(&[], &[0]);
+    test_cmp(&[0], &[]);
+
+    // test with longer equal buffers up to...
+    test_cmp(&[1, 2, 3], &[1, 2, 3]);
+    test_cmp(&[1, 2, 3, 4], &[1, 2, 3]);
+    test_cmp(&[1, 2, 3], &[1, 2, 3, 4]);
+}
+
+#[test]
 fn test_log2_uint() {
     let (instance, mut store) = load_stdlib().unwrap();
     let log2 = instance.get_func(&mut store, "log2-uint").unwrap();

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -1818,6 +1818,52 @@ fn test_le_buff() {
 }
 
 #[test]
+fn test_ge_buff() {
+    let (instance, mut store) = load_stdlib().unwrap();
+    let memory = instance
+        .get_memory(&mut store, "memory")
+        .expect("Could not find memory");
+
+    let ge = instance.get_func(&mut store, "ge-buff").unwrap();
+    let mut result = [Val::I32(0)];
+
+    let mut test_cmp = |buff_a: &[u8], buff_b: &[u8]| {
+        let offset_a = 1000;
+        let offset_b = offset_a + buff_a.len();
+        memory
+            .write(&mut store, offset_a, buff_a)
+            .expect("could not write to memory");
+        memory
+            .write(&mut store, offset_b, buff_b)
+            .expect("could not write to memory");
+
+        ge.call(
+            &mut store,
+            &[
+                Val::I32(offset_a as i32),
+                Val::I32(buff_a.len() as i32),
+                Val::I32(offset_b as i32),
+                Val::I32(buff_b.len() as i32),
+            ],
+            &mut result,
+        )
+        .expect("call to lt-buff failed");
+
+        assert_eq!(result[0].unwrap_i32(), (buff_a >= buff_b) as i32)
+    };
+
+    // tests with empty buffers
+    test_cmp(&[], &[]);
+    test_cmp(&[], &[0]);
+    test_cmp(&[0], &[]);
+
+    // test with longer equal buffers up to...
+    test_cmp(&[1, 2, 3], &[1, 2, 3]);
+    test_cmp(&[1, 2, 3, 4], &[1, 2, 3]);
+    test_cmp(&[1, 2, 3], &[1, 2, 3, 4]);
+}
+
+#[test]
 fn test_log2_uint() {
     let (instance, mut store) = load_stdlib().unwrap();
     let log2 = instance.get_func(&mut store, "log2-uint").unwrap();

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -1679,14 +1679,13 @@ fn test_ge_int() {
     assert_eq!(result[0].i32(), Some(1));
 }
 
-#[test]
-fn test_lt_buff() {
+fn test_cmp_buff(func_name: &str, reference_func: impl Fn(&[u8], &[u8]) -> bool) {
     let (instance, mut store) = load_stdlib().unwrap();
     let memory = instance
         .get_memory(&mut store, "memory")
         .expect("Could not find memory");
 
-    let lt = instance.get_func(&mut store, "lt-buff").unwrap();
+    let cmp = instance.get_func(&mut store, func_name).unwrap();
     let mut result = [Val::I32(0)];
 
     let mut test_cmp = |buff_a: &[u8], buff_b: &[u8]| {
@@ -1699,7 +1698,7 @@ fn test_lt_buff() {
             .write(&mut store, offset_b, buff_b)
             .expect("could not write to memory");
 
-        lt.call(
+        cmp.call(
             &mut store,
             &[
                 Val::I32(offset_a as i32),
@@ -1711,7 +1710,10 @@ fn test_lt_buff() {
         )
         .expect("call to lt-buff failed");
 
-        assert_eq!(result[0].unwrap_i32(), (buff_a < buff_b) as i32)
+        assert_eq!(
+            result[0].unwrap_i32(),
+            reference_func(buff_a, buff_b) as i32
+        )
     };
 
     // tests with empty buffers
@@ -1723,144 +1725,26 @@ fn test_lt_buff() {
     test_cmp(&[1, 2, 3], &[1, 2, 3]);
     test_cmp(&[1, 2, 3, 4], &[1, 2, 3]);
     test_cmp(&[1, 2, 3], &[1, 2, 3, 4]);
+}
+
+#[test]
+fn test_lt_buff() {
+    test_cmp_buff("lt-buff", |a, b| a < b)
 }
 
 #[test]
 fn test_gt_buff() {
-    let (instance, mut store) = load_stdlib().unwrap();
-    let memory = instance
-        .get_memory(&mut store, "memory")
-        .expect("Could not find memory");
-
-    let gt = instance.get_func(&mut store, "gt-buff").unwrap();
-    let mut result = [Val::I32(0)];
-
-    let mut test_cmp = |buff_a: &[u8], buff_b: &[u8]| {
-        let offset_a = 1000;
-        let offset_b = offset_a + buff_a.len();
-        memory
-            .write(&mut store, offset_a, buff_a)
-            .expect("could not write to memory");
-        memory
-            .write(&mut store, offset_b, buff_b)
-            .expect("could not write to memory");
-
-        gt.call(
-            &mut store,
-            &[
-                Val::I32(offset_a as i32),
-                Val::I32(buff_a.len() as i32),
-                Val::I32(offset_b as i32),
-                Val::I32(buff_b.len() as i32),
-            ],
-            &mut result,
-        )
-        .expect("call to lt-buff failed");
-
-        assert_eq!(result[0].unwrap_i32(), (buff_a > buff_b) as i32)
-    };
-
-    // tests with empty buffers
-    test_cmp(&[], &[]);
-    test_cmp(&[], &[0]);
-    test_cmp(&[0], &[]);
-
-    // test with longer equal buffers up to...
-    test_cmp(&[1, 2, 3], &[1, 2, 3]);
-    test_cmp(&[1, 2, 3, 4], &[1, 2, 3]);
-    test_cmp(&[1, 2, 3], &[1, 2, 3, 4]);
+    test_cmp_buff("gt-buff", |a, b| a > b)
 }
 
 #[test]
 fn test_le_buff() {
-    let (instance, mut store) = load_stdlib().unwrap();
-    let memory = instance
-        .get_memory(&mut store, "memory")
-        .expect("Could not find memory");
-
-    let le = instance.get_func(&mut store, "le-buff").unwrap();
-    let mut result = [Val::I32(0)];
-
-    let mut test_cmp = |buff_a: &[u8], buff_b: &[u8]| {
-        let offset_a = 1000;
-        let offset_b = offset_a + buff_a.len();
-        memory
-            .write(&mut store, offset_a, buff_a)
-            .expect("could not write to memory");
-        memory
-            .write(&mut store, offset_b, buff_b)
-            .expect("could not write to memory");
-
-        le.call(
-            &mut store,
-            &[
-                Val::I32(offset_a as i32),
-                Val::I32(buff_a.len() as i32),
-                Val::I32(offset_b as i32),
-                Val::I32(buff_b.len() as i32),
-            ],
-            &mut result,
-        )
-        .expect("call to lt-buff failed");
-
-        assert_eq!(result[0].unwrap_i32(), (buff_a <= buff_b) as i32)
-    };
-
-    // tests with empty buffers
-    test_cmp(&[], &[]);
-    test_cmp(&[], &[0]);
-    test_cmp(&[0], &[]);
-
-    // test with longer equal buffers up to...
-    test_cmp(&[1, 2, 3], &[1, 2, 3]);
-    test_cmp(&[1, 2, 3, 4], &[1, 2, 3]);
-    test_cmp(&[1, 2, 3], &[1, 2, 3, 4]);
+    test_cmp_buff("le-buff", |a, b| a <= b)
 }
 
 #[test]
 fn test_ge_buff() {
-    let (instance, mut store) = load_stdlib().unwrap();
-    let memory = instance
-        .get_memory(&mut store, "memory")
-        .expect("Could not find memory");
-
-    let ge = instance.get_func(&mut store, "ge-buff").unwrap();
-    let mut result = [Val::I32(0)];
-
-    let mut test_cmp = |buff_a: &[u8], buff_b: &[u8]| {
-        let offset_a = 1000;
-        let offset_b = offset_a + buff_a.len();
-        memory
-            .write(&mut store, offset_a, buff_a)
-            .expect("could not write to memory");
-        memory
-            .write(&mut store, offset_b, buff_b)
-            .expect("could not write to memory");
-
-        ge.call(
-            &mut store,
-            &[
-                Val::I32(offset_a as i32),
-                Val::I32(buff_a.len() as i32),
-                Val::I32(offset_b as i32),
-                Val::I32(buff_b.len() as i32),
-            ],
-            &mut result,
-        )
-        .expect("call to lt-buff failed");
-
-        assert_eq!(result[0].unwrap_i32(), (buff_a >= buff_b) as i32)
-    };
-
-    // tests with empty buffers
-    test_cmp(&[], &[]);
-    test_cmp(&[], &[0]);
-    test_cmp(&[0], &[]);
-
-    // test with longer equal buffers up to...
-    test_cmp(&[1, 2, 3], &[1, 2, 3]);
-    test_cmp(&[1, 2, 3, 4], &[1, 2, 3]);
-    test_cmp(&[1, 2, 3], &[1, 2, 3, 4]);
+    test_cmp_buff("ge-buff", |a, b| a >= b)
 }
 
 #[test]

--- a/tests/contracts/cmp-buffer.clar
+++ b/tests/contracts/cmp-buffer.clar
@@ -1,0 +1,31 @@
+(define-public (less-buffer)
+    (ok (< 0x0102 0x0103))
+)
+
+(define-public (less-string-ascii)
+    (ok (< "hello" "world"))
+)
+
+(define-public (greater-buffer)
+    (ok (> 0x0102 0x0103))
+)
+
+(define-public (greater-string-ascii)
+    (ok (> "hello" "world"))
+)
+
+(define-public (less-or-equal-buffer)
+    (ok (<= 0x0102 0x0103))
+)
+
+(define-public (less-or-equal-string-ascii)
+    (ok (<= "hello" "world"))
+)
+
+(define-public (greater-or-equal-buffer)
+    (ok (>= 0x0102 0x0103))
+)
+
+(define-public (greater-or-equal-string-ascii)
+    (ok (>= "hello" "world"))
+)

--- a/tests/contracts/cmp-buffer.clar
+++ b/tests/contracts/cmp-buffer.clar
@@ -29,3 +29,67 @@
 (define-public (greater-or-equal-string-ascii)
     (ok (>= "hello" "world"))
 )
+
+(define-public (less-buffer-diff-len)
+    (ok (< 0x01 0x010203))
+)
+
+(define-public (less-string-ascii-diff-len)
+    (ok (< "Lorem ipsum" "Lorem ipsum dolor sit amet"))
+)
+
+(define-public (greater-buffer-diff-len)
+    (ok (> 0x01 0x010203))
+)
+
+(define-public (greater-string-ascii-diff-len)
+    (ok (> "Lorem ipsum" "Lorem ipsum dolor sit amet"))
+)
+
+(define-public (less-or-equal-buffer-diff-len)
+    (ok (<= 0x01 0x010203))
+)
+
+(define-public (less-or-equal-string-ascii-diff-len)
+    (ok (<= "Lorem ipsum" "Lorem ipsum dolor sit amet"))
+)
+
+(define-public (greater-or-equal-buffer-diff-len)
+    (ok (>= 0x01 0x010203))
+)
+
+(define-public (greater-or-equal-string-ascii-diff-len)
+    (ok (>= "Lorem ipsum" "Lorem ipsum dolor sit amet"))
+)
+
+(define-public (less-same-buffer)
+    (ok (< 0x01 0x01))
+)
+
+(define-public (less-same-string-ascii)
+    (ok (< "Lorem ipsum" "Lorem ipsum"))
+)
+
+(define-public (greater-same-buffer)
+    (ok (> 0x01 0x01))
+)
+
+(define-public (greater-same-string-ascii)
+    (ok (> "Lorem ipsum" "Lorem ipsum"))
+)
+
+(define-public (less-or-equal-same-buffer)
+    (ok (<= 0x01 0x01))
+)
+
+(define-public (less-or-equal-same-string-ascii)
+    (ok (<= "Lorem ipsum" "Lorem ipsum"))
+)
+
+(define-public (greater-or-equal-same-buffer)
+    (ok (>= 0x01 0x01))
+)
+
+(define-public (greater-or-equal-same-string-ascii)
+    (ok (>= "Lorem ipsum" "Lorem ipsum"))
+)

--- a/tests/src/lib_tests.rs
+++ b/tests/src/lib_tests.rs
@@ -3634,3 +3634,163 @@ test_contract_call_response!(
         assert_eq!(*response.data, Value::Bool(false));
     }
 );
+
+test_contract_call_response!(
+    test_less_than_buffer_diff_len,
+    "cmp-buffer",
+    "less-buffer-diff-len",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
+    test_greater_than_buffer_diff_len,
+    "cmp-buffer",
+    "greater-buffer-diff-len",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_less_or_equal_buffer_diff_len,
+    "cmp-buffer",
+    "less-or-equal-buffer-diff-len",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
+    test_greater_or_equal_buffer_diff_len,
+    "cmp-buffer",
+    "greater-or-equal-buffer-diff-len",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_less_than_string_ascii_diff_len,
+    "cmp-buffer",
+    "less-string-ascii-diff-len",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
+    test_greater_than_string_ascii_diff_len,
+    "cmp-buffer",
+    "greater-string-ascii-diff-len",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_less_or_equal_string_ascii_diff_len,
+    "cmp-buffer",
+    "less-or-equal-string-ascii-diff-len",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
+    test_greater_or_equal_string_ascii_diff_len,
+    "cmp-buffer",
+    "greater-or-equal-string-ascii-diff-len",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_less_than_same_buffer,
+    "cmp-buffer",
+    "less-same-buffer",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_greater_than_same_buffer,
+    "cmp-buffer",
+    "greater-same-buffer",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_less_or_equal_same_buffer,
+    "cmp-buffer",
+    "less-or-equal-same-buffer",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
+    test_greater_or_equal_same_buffer,
+    "cmp-buffer",
+    "greater-or-equal-same-buffer",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
+    test_less_than_same_string_ascii,
+    "cmp-buffer",
+    "less-same-string-ascii",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_greater_than_same_string_ascii,
+    "cmp-buffer",
+    "greater-same-string-ascii",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_less_or_equal_same_string_ascii,
+    "cmp-buffer",
+    "less-or-equal-same-string-ascii",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
+    test_greater_or_equal_same_string_ascii,
+    "cmp-buffer",
+    "greater-or-equal-same-string-ascii",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);

--- a/tests/src/lib_tests.rs
+++ b/tests/src/lib_tests.rs
@@ -3554,3 +3554,83 @@ test_contract_call_response!(
         );
     }
 );
+
+test_contract_call_response!(
+    test_less_than_buffer,
+    "cmp-buffer",
+    "less-buffer",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
+    test_greater_than_buffer,
+    "cmp-buffer",
+    "greater-buffer",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_less_or_equal_buffer,
+    "cmp-buffer",
+    "less-or-equal-buffer",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
+    test_greater_or_equal_buffer,
+    "cmp-buffer",
+    "greater-or-equal-buffer",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_less_than_string_ascii,
+    "cmp-buffer",
+    "less-string-ascii",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
+    test_greater_than_string_ascii,
+    "cmp-buffer",
+    "greater-string-ascii",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_less_or_equal_string_ascii,
+    "cmp-buffer",
+    "less-or-equal-string-ascii",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
+    test_greater_or_equal_string_ascii,
+    "cmp-buffer",
+    "greater-or-equal-string-ascii",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);


### PR DESCRIPTION
This PR adds the comparison operators for `buff` and `string-ascii`.

This is part of #118, leaving this issue with the implementation for `string-utf8`.