### PR TITLE
Noop functions implementation

### DIFF
--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -2355,6 +2355,39 @@
         )
     )
 
+    ;;
+    ;; -- 'to-uint' implementation
+    ;;
+    ;; Should raise a runtime error
+    ;; if the argument is < 0.
+    ;;
+    (func $stdlib.to-uint (param $lo i64) (param $hi i64) (result i64 i64)
+        (if (i64.lt_s (local.get $hi) (i64.const 0))
+            (then (call $runtime-error (i32.const 4)))
+        )
+        (local.get $lo)
+        (local.get $hi)
+    )
+
+    ;;
+    ;; -- 'to-int' implementation
+    ;;
+    ;; Should raise a runtime error
+    ;; if the argument is >= 2^127.
+    ;;
+    (func $stdlib.to-int (param $lo i64) (param $hi i64) (result i64 i64)
+        ;; 9223372036854775808 -> 2^63
+        ;; 2^63 is one more than the maximum positive value
+        ;; that can be represented by a signed 64-bit integer.
+        ;; Thus, if $hi >= 2^63 the argument is >= 2^127,
+        ;; no matter what is present in $lo.
+        (if (i64.ge_u (local.get $hi) (i64.const 9223372036854775808))
+            (then (call $runtime-error (i32.const 4)))
+        )
+        (local.get $lo)
+        (local.get $hi)
+    )
+
     (export "stdlib.add-uint" (func $stdlib.add-uint))
     (export "stdlib.add-int" (func $stdlib.add-int))
     (export "stdlib.sub-uint" (func $stdlib.sub-uint))
@@ -2413,4 +2446,6 @@
     (export "stdlib.is-version-valid" (func $stdlib.is-version-valid))
     (export "stdlib.string-to-uint" (func $stdlib.string-to-uint))
     (export "stdlib.string-to-int" (func $stdlib.string-to-int))
+    (export "stdlib.to-uint" (func $stdlib.to-uint))
+    (export "stdlib.to-int" (func $stdlib.to-int))
 )

--- a/clar2wasm/src/words/mod.rs
+++ b/clar2wasm/src/words/mod.rs
@@ -97,6 +97,7 @@ pub(crate) static WORDS: &[&'static dyn Word] = &[
     &maps::MapGet,
     &maps::MapInsert,
     &maps::MapSet,
+    &noop::ContractOf,
     &noop::ToInt,
     &noop::ToUint,
     &options::IsNone,

--- a/clar2wasm/src/words/mod.rs
+++ b/clar2wasm/src/words/mod.rs
@@ -25,6 +25,7 @@ pub mod functions;
 pub mod hashing;
 pub mod logical;
 pub mod maps;
+pub mod noop;
 pub mod options;
 pub mod principal;
 pub mod print;
@@ -96,6 +97,8 @@ pub(crate) static WORDS: &[&'static dyn Word] = &[
     &maps::MapGet,
     &maps::MapInsert,
     &maps::MapSet,
+    &noop::ToInt,
+    &noop::ToUint,
     &options::IsNone,
     &options::IsSome,
     &principal::Construct,

--- a/clar2wasm/src/words/noop.rs
+++ b/clar2wasm/src/words/noop.rs
@@ -50,3 +50,67 @@ impl Word for ToUint {
         traverse_noop(generator, builder, args)
     }
 }
+
+#[derive(Debug)]
+pub struct ContractOf;
+
+impl Word for ContractOf {
+    fn name(&self) -> ClarityName {
+        "contract-of".into()
+    }
+
+    fn traverse(
+        &self,
+        generator: &mut WasmGenerator,
+        builder: &mut walrus::InstrSeqBuilder,
+        _expr: &SymbolicExpression,
+        args: &[SymbolicExpression],
+    ) -> Result<(), GeneratorError> {
+        traverse_noop(generator, builder, args)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clarity::vm::{
+        types::{PrincipalData, QualifiedContractIdentifier},
+        Value,
+    };
+
+    use crate::tools::TestEnvironment;
+
+    #[test]
+    fn contract_of_eval() {
+        let mut env = TestEnvironment::default();
+        env.init_contract_with_snippet(
+            "clar2wasm-trait",
+            r#"
+(define-trait clar2wasm-trait
+  ((add (int int) (response int int))))
+(define-public (add (a int) (b int))
+  (ok (+ a b)))
+"#,
+        );
+
+        let val = env.init_contract_with_snippet(
+            "contract-of",
+            r#"
+(use-trait clar2wasm-trait .clar2wasm-trait.clar2wasm-trait)
+(define-public (test-contract-of (t <clar2wasm-trait>))
+    (ok (contract-of t))) ;; Test subject: contract-of usage
+(test-contract-of .clar2wasm-trait)
+"#,
+        );
+
+        assert_eq!(
+            val.unwrap(),
+            Value::okay(Value::Principal(PrincipalData::Contract(
+                QualifiedContractIdentifier::parse(
+                    "S1G2081040G2081040G2081040G208105NK8PE5.clar2wasm-trait"
+                )
+                .unwrap()
+            )))
+            .unwrap()
+        );
+    }
+}

--- a/clar2wasm/src/words/noop.rs
+++ b/clar2wasm/src/words/noop.rs
@@ -5,7 +5,7 @@ use super::Word;
 
 // Functions below are considered no-op's because they are instructions that does nothing
 // or has no effect when executed.
-// They only affect the types (in case of to-int and to-uint), and not the values.
+// They only affect the types and not the values.
 
 fn traverse_noop(
     generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/noop.rs
+++ b/clar2wasm/src/words/noop.rs
@@ -3,6 +3,10 @@ use clarity::vm::{ClarityName, SymbolicExpression};
 
 use super::Word;
 
+// Functions below are considered no-op's because they are instructions that does nothing
+// or has no effect when executed.
+// They only affect the types (in case of to-int and to-uint), and not the values.
+
 fn traverse_noop(
     generator: &mut WasmGenerator,
     builder: &mut walrus::InstrSeqBuilder,
@@ -72,15 +76,25 @@ impl Word for ContractOf {
 
 #[cfg(test)]
 mod tests {
+    use crate::tools::evaluate as eval;
+    use crate::tools::TestEnvironment;
     use clarity::vm::{
         types::{PrincipalData, QualifiedContractIdentifier},
         Value,
     };
 
-    use crate::tools::TestEnvironment;
+    #[test]
+    fn to_int() {
+        assert_eq!(eval("(to-int u42)"), Some(Value::Int(42)));
+    }
 
     #[test]
-    fn contract_of_eval() {
+    fn to_uint() {
+        assert_eq!(eval("(to-uint 767)"), Some(Value::UInt(767)));
+    }
+
+    #[test]
+    fn contract_of_test() {
         let mut env = TestEnvironment::default();
         env.init_contract_with_snippet(
             "clar2wasm-trait",

--- a/clar2wasm/src/words/noop.rs
+++ b/clar2wasm/src/words/noop.rs
@@ -1,0 +1,52 @@
+use crate::wasm_generator::{GeneratorError, WasmGenerator};
+use clarity::vm::{ClarityName, SymbolicExpression};
+
+use super::Word;
+
+fn traverse_noop(
+    generator: &mut WasmGenerator,
+    builder: &mut walrus::InstrSeqBuilder,
+    args: &[SymbolicExpression],
+) -> Result<(), GeneratorError> {
+    generator.traverse_args(builder, args)?;
+
+    Ok(())
+}
+
+#[derive(Debug)]
+pub struct ToInt;
+
+impl Word for ToInt {
+    fn name(&self) -> ClarityName {
+        "to-int".into()
+    }
+
+    fn traverse(
+        &self,
+        generator: &mut WasmGenerator,
+        builder: &mut walrus::InstrSeqBuilder,
+        _expr: &SymbolicExpression,
+        args: &[SymbolicExpression],
+    ) -> Result<(), GeneratorError> {
+        traverse_noop(generator, builder, args)
+    }
+}
+
+#[derive(Debug)]
+pub struct ToUint;
+
+impl Word for ToUint {
+    fn name(&self) -> ClarityName {
+        "to-uint".into()
+    }
+
+    fn traverse(
+        &self,
+        generator: &mut WasmGenerator,
+        builder: &mut walrus::InstrSeqBuilder,
+        _expr: &SymbolicExpression,
+        args: &[SymbolicExpression],
+    ) -> Result<(), GeneratorError> {
+        traverse_noop(generator, builder, args)
+    }
+}

--- a/clar2wasm/src/words/noop.rs
+++ b/clar2wasm/src/words/noop.rs
@@ -125,7 +125,7 @@ mod tests {
     #[test]
     fn contract_of() {
         let mut env = TestEnvironment::default();
-        env.init_contract_with_snippet(
+        let _ = env.init_contract_with_snippet(
             "clar2wasm-trait",
             r#"
 (define-trait clar2wasm-trait
@@ -147,13 +147,15 @@ mod tests {
 
         assert_eq!(
             val.unwrap(),
-            Value::okay(Value::Principal(PrincipalData::Contract(
-                QualifiedContractIdentifier::parse(
-                    "S1G2081040G2081040G2081040G208105NK8PE5.clar2wasm-trait"
-                )
+            Some(
+                Value::okay(Value::Principal(PrincipalData::Contract(
+                    QualifiedContractIdentifier::parse(
+                        "S1G2081040G2081040G2081040G208105NK8PE5.clar2wasm-trait"
+                    )
+                    .unwrap()
+                )))
                 .unwrap()
-            )))
-            .unwrap()
+            )
         );
     }
 }

--- a/tests/contracts/noop.clar
+++ b/tests/contracts/noop.clar
@@ -1,0 +1,5 @@
+(define-public (test-to-int)
+    (ok (to-int u42)))
+
+(define-public (test-to-uint)
+    (ok (to-uint 767)))

--- a/tests/contracts/noop.clar
+++ b/tests/contracts/noop.clar
@@ -1,5 +1,16 @@
 (define-public (test-to-int)
     (ok (to-int u42)))
 
+;; type `i128` range is
+;; -170141183460469231731687303715884105728 to 170141183460469231731687303715884105727
+(define-public (test-to-int-limit)
+    (ok (to-int u170141183460469231731687303715884105727)))
+
+(define-public (test-to-int-out-of-boundary)
+    (ok (to-int u170141183460469231731687303715884105728)))
+
 (define-public (test-to-uint)
     (ok (to-uint 767)))
+
+(define-public (test-to-uint-error)
+    (ok (to-uint -47)))

--- a/tests/src/lib_tests.rs
+++ b/tests/src/lib_tests.rs
@@ -3967,7 +3967,10 @@ test_contract_call_response!(
     "test-to-int-limit",
     |response: ResponseData| {
         assert!(response.committed);
-        assert_eq!(*response.data, Value::Int(170141183460469231731687303715884105727));
+        assert_eq!(
+            *response.data,
+            Value::Int(170141183460469231731687303715884105727)
+        );
     }
 );
 

--- a/tests/src/lib_tests.rs
+++ b/tests/src/lib_tests.rs
@@ -3962,11 +3962,39 @@ test_contract_call_response!(
 );
 
 test_contract_call_response!(
+    test_to_int_limit,
+    "noop",
+    "test-to-int-limit",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Int(170141183460469231731687303715884105727));
+    }
+);
+
+test_contract_call!(
+    test_to_int_out_of_boundary,
+    "noop",
+    "test-to-int-out-of-boundary",
+    |result: Result<Value, Error>| {
+        assert!(matches!(result, Err(Error::Wasm(WasmError::Runtime(_)))));
+    }
+);
+
+test_contract_call_response!(
     test_to_uint,
     "noop",
     "test-to-uint",
     |response: ResponseData| {
         assert!(response.committed);
         assert_eq!(*response.data, Value::UInt(767));
+    }
+);
+
+test_contract_call!(
+    test_to_uint_error,
+    "noop",
+    "test-to-uint-error",
+    |result: Result<Value, Error>| {
+        assert!(matches!(result, Err(Error::Wasm(WasmError::Runtime(_)))));
     }
 );

--- a/tests/src/lib_tests.rs
+++ b/tests/src/lib_tests.rs
@@ -3950,3 +3950,23 @@ test_contract_call_response!(
         );
     }
 );
+
+test_contract_call_response!(
+    test_to_int,
+    "noop",
+    "test-to-int",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Int(42));
+    }
+);
+
+test_contract_call_response!(
+    test_to_uint,
+    "noop",
+    "test-to-uint",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::UInt(767));
+    }
+);


### PR DESCRIPTION
Noop functions implementation:

`to-int`
`to-uint`
`contract-of`

Related issue: https://github.com/stacks-network/clarity-wasm/issues/144