### PR TITLE
Add int-to-ascii implementation

### DIFF
--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -2445,6 +2445,39 @@
         ;; final result is already on the stack
     )
 
+    (func $stdlib.int-to-string (param $lo i64) (param $hi i64) (result i32 i32)
+        (local $offset i32) (local $len i32)
+        (local.set $len (local.tee $offset (i64.lt_s (local.get $hi) (i64.const 0))))
+        ;; add a '-' if n < 0
+        (if (local.get $len)
+            (then 
+                (i32.store8 (global.get $stack-pointer) (i32.const 45))
+                (global.set $stack-pointer (i32.add (global.get $stack-pointer) (i32.const 1)))
+            )
+        )
+
+        ;; if (n >= 0 or n == i128::MIN) { uint-to-string(n) } else { uint-to-string(-n) }
+        (if (result i32 i32)
+            (select
+                (i64.eqz (local.get $lo))
+                (i64.ge_s (local.get $hi) (i64.const 0))
+                (i64.eq (local.get $hi) (i64.const 0x8000000000000000))
+            )
+            (then (call $stdlib.uint-to-string (local.get $lo) (local.get $hi)))
+            (else 
+                (call $stdlib.uint-to-string 
+                    (i64.sub (i64.const 0) (local.get $lo))
+                    (i64.sub (i64.const 0) (i64.add (local.get $hi) (i64.extend_i32_u (i64.ne (local.get $lo) (i64.const 0)))))
+                )
+            )
+        )
+
+        ;; we adjust offset and length to account for the '-'
+        (local.set $len (i32.add (local.get $len)))
+        (i32.sub (local.get $offset))
+        (local.get $len)
+    )
+
     ;;
     ;; -- 'to-uint' implementation
     ;;
@@ -2538,6 +2571,7 @@
     (export "stdlib.string-to-uint" (func $stdlib.string-to-uint))
     (export "stdlib.string-to-int" (func $stdlib.string-to-int))
     (export "stdlib.uint-to-string" (func $stdlib.uint-to-string))
+    (export "stdlib.int-to-string" (func $stdlib.int-to-string))
     (export "stdlib.to-uint" (func $stdlib.to-uint))
     (export "stdlib.to-int" (func $stdlib.to-int))
 )

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -2447,6 +2447,7 @@
 
     (func $stdlib.int-to-string (param $lo i64) (param $hi i64) (result i32 i32)
         (local $offset i32) (local $len i32)
+        ;; we use $offset and $len as a delta to add/subtract to the final result if the number is negative.
         (local.set $len (local.tee $offset (i64.lt_s (local.get $hi) (i64.const 0))))
         ;; add a '-' if n < 0
         (if (local.get $len)
@@ -2473,6 +2474,7 @@
         )
 
         ;; we adjust offset and length to account for the '-'
+        ;; we save the length to pop it from the stack and so that we can return it in the right order after the offset
         (local.set $len (i32.add (local.get $len)))
         (i32.sub (local.get $offset))
         (local.get $len)

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -2446,11 +2446,10 @@
     )
 
     (func $stdlib.int-to-string (param $lo i64) (param $hi i64) (result i32 i32)
-        (local $offset i32) (local $len i32)
-        ;; we use $offset and $len as a delta to add/subtract to the final result if the number is negative.
-        (local.set $len (local.tee $offset (i64.lt_s (local.get $hi) (i64.const 0))))
+        (local $negative i32) (local $len i32)
+        (local.set $negative (i64.lt_s (local.get $hi) (i64.const 0)))
         ;; add a '-' if n < 0
-        (if (local.get $len)
+        (if (local.get $negative)
             (then 
                 (i32.store8 (global.get $stack-pointer) (i32.const 45))
                 (global.set $stack-pointer (i32.add (global.get $stack-pointer) (i32.const 1)))
@@ -2474,9 +2473,10 @@
         )
 
         ;; we adjust offset and length to account for the '-'
-        ;; we save the length to pop it from the stack and so that we can return it in the right order after the offset
-        (local.set $len (i32.add (local.get $len)))
-        (i32.sub (local.get $offset))
+        ;; we save the length to pop it from the stack and so that we can update the offset 
+        ;; and return it in the right order after the offset
+        (local.set $len (i32.add (local.get $negative)))
+        (i32.sub (local.get $negative))
         (local.get $len)
     )
 

--- a/clar2wasm/src/words/conversion.rs
+++ b/clar2wasm/src/words/conversion.rs
@@ -93,7 +93,10 @@ impl Word for IntToAscii {
 
 #[cfg(test)]
 mod tests {
-    use clarity::vm::Value;
+    use clarity::vm::{
+        types::{ASCIIData, CharType, SequenceData},
+        Value,
+    };
 
     use crate::tools::evaluate;
 
@@ -134,6 +137,42 @@ mod tests {
         assert_eq!(
             evaluate(r#"(string-to-uint? "0xabcd")"#),
             Some(Value::none())
+        )
+    }
+
+    #[test]
+    fn uint_to_string() {
+        assert_eq!(
+            evaluate(r#"(int-to-ascii u42)"#),
+            Some(Value::Sequence(SequenceData::String(CharType::ASCII(
+                ASCIIData {
+                    data: "42".bytes().collect()
+                }
+            ))))
+        )
+    }
+
+    #[test]
+    fn positive_int_to_string() {
+        assert_eq!(
+            evaluate(r#"(int-to-ascii 2048)"#),
+            Some(Value::Sequence(SequenceData::String(CharType::ASCII(
+                ASCIIData {
+                    data: "2048".bytes().collect()
+                }
+            ))))
+        )
+    }
+
+    #[test]
+    fn negative_int_to_string() {
+        assert_eq!(
+            evaluate(r#"(int-to-ascii -2048)"#),
+            Some(Value::Sequence(SequenceData::String(CharType::ASCII(
+                ASCIIData {
+                    data: "-2048".bytes().collect()
+                }
+            ))))
         )
     }
 }

--- a/clar2wasm/src/words/mod.rs
+++ b/clar2wasm/src/words/mod.rs
@@ -73,6 +73,7 @@ pub(crate) static WORDS: &[&'static dyn Word] = &[
     &control_flow::Begin,
     &control_flow::UnwrapErrPanic,
     &control_flow::UnwrapPanic,
+    &conversion::IntToAscii,
     &conversion::StringToInt,
     &conversion::StringToUint,
     &data_vars::DefineDataVar,

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -3390,3 +3390,69 @@ fn is_version_valid() {
     test_version(42, false);
     test_version(11, false);
 }
+
+#[test]
+fn uint_to_string() {
+    let (instance, mut store) = load_stdlib().unwrap();
+
+    let memory = instance
+        .get_memory(&mut store, "memory")
+        .expect("Could not find memory");
+    // This algo needs space on the stack,
+    // we move the initial value of $stack-pointer
+    // to a random one where it wouldn't matter
+    let stack_pointer = instance.get_global(&mut store, "stack-pointer").unwrap();
+    stack_pointer.set(&mut store, Val::I32(1500)).unwrap();
+
+    let conv = instance
+        .get_func(&mut store, "stdlib.uint-to-string")
+        .unwrap();
+    let mut result = [Val::I32(0), Val::I32(0)];
+
+    let mut test_num = |num: u128| {
+        let lo = num as i64;
+        let hi = (num >> 64) as i64;
+
+        let expected = num.to_string();
+
+        // This algo needs space on the stack,
+        // we move the initial value of $stack-pointer
+        // to a random one where it wouldn't matter
+        let stack_pointer = instance.get_global(&mut store, "stack-pointer").unwrap();
+        stack_pointer.set(&mut store, Val::I32(1500)).unwrap();
+
+        conv.call(&mut store, &[lo.into(), hi.into()], &mut result)
+            .expect("call to uint-to-string failed");
+        assert_eq!(result[0].unwrap_i32(), 1500);
+        assert_eq!(result[1].unwrap_i32(), expected.len() as i32);
+
+        let mut buffer = vec![0u8; expected.len()];
+        memory
+            .read(&mut store, 1500, &mut buffer)
+            .expect("could not read string answer from memory");
+
+        assert_eq!(buffer, expected.as_bytes());
+    };
+
+    // test basic numbers
+    test_num(0);
+    test_num(1);
+    test_num(42);
+    test_num(1024);
+
+    // Basic tests with big numbers
+    test_num(184467440737095516156789);
+    test_num(374467440737095681245698132);
+
+    // Tests with number between 64 and 65 bits
+    let n = u64::MAX as u128;
+    for i in -5..=5 {
+        test_num(n.checked_add_signed(i).unwrap());
+    }
+
+    // Tests with number close to u128::MAX
+    let n = u128::MAX - 10;
+    for i in 0..=10 {
+        test_num(n + i);
+    }
+}

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -3456,3 +3456,63 @@ fn uint_to_string() {
         test_num(n + i);
     }
 }
+
+#[test]
+fn int_to_string() {
+    let (instance, mut store) = load_stdlib().unwrap();
+
+    let memory = instance
+        .get_memory(&mut store, "memory")
+        .expect("Could not find memory");
+
+    let conv = instance
+        .get_func(&mut store, "stdlib.int-to-string")
+        .unwrap();
+    let mut result = [Val::I32(0), Val::I32(0)];
+
+    let mut test_num = |num: i128| {
+        let expected = num.to_string();
+
+        let num = num as u128;
+        let lo = num as i64;
+        let hi = (num >> 64) as i64;
+
+        // This algo needs space on the stack,
+        // we move the initial value of $stack-pointer
+        // to a random one where it wouldn't matter
+        let stack_pointer = instance.get_global(&mut store, "stack-pointer").unwrap();
+        stack_pointer.set(&mut store, Val::I32(1500)).unwrap();
+
+        conv.call(&mut store, &[lo.into(), hi.into()], &mut result)
+            .expect("call to uint-to-string failed");
+        assert_eq!(result[0].unwrap_i32(), 1500);
+        assert_eq!(result[1].unwrap_i32(), expected.len() as i32);
+
+        let mut buffer = vec![0u8; expected.len()];
+        memory
+            .read(&mut store, 1500, &mut buffer)
+            .expect("could not read string answer from memory");
+
+        assert_eq!(buffer, expected.as_bytes());
+    };
+
+    // test basic numbers
+    test_num(0);
+    test_num(1);
+    test_num(42);
+    test_num(1024);
+
+    // Basic tests with big numbers
+    test_num(184467440737095516156789);
+    test_num(374467440737095681245698132);
+
+    // Tests with negative numbers
+    test_num(-1);
+    test_num(-1024);
+    test_num(-184467440737095516156789);
+    test_num(-374467440737095681245698133);
+
+    // Test with biggest ints
+    test_num(i128::MIN);
+    test_num(i128::MAX);
+}


### PR DESCRIPTION
Here is the implementation of `int-to-ascii`.
This is part of #145.

I decided to call the Wasm stdlib function `(u)int-to-string`, since we will certainly reuse it in some way for `int-to-utf8` later.