### PR TITLE
Add is-eq implementation for nearly all types

### DIFF
--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -1980,6 +1980,22 @@
         )
     )
 
+    (func $stdlib.is-eq-bytes (param $offset_a i32) (param $length_a i32) (param $offset_b i32) (param $length_b i32) (result i32)
+        (if (i32.ne (local.get $length_a) (local.get $length_b)) (then (return (i32.const 0))))
+        (if (i32.eqz (local.get $length_a)) (then (return (i32.const 1))))
+
+        (loop $loop
+            (if (i32.eq (i32.load8_u (local.get $offset_a)) (i32.load8_u (local.get $offset_b)))
+                (then 
+                    (local.set $offset_a (i32.add (local.get $offset_a) (i32.const 1)))
+                    (local.set $offset_b (i32.add (local.get $offset_b) (i32.const 1)))
+                    (br_if $loop (local.tee $length_a (i32.sub (local.get $length_a) (i32.const 1))))
+                )
+            )
+        )
+        (i32.eqz (local.get $length_a))
+    )
+
     ;;
     ;; `(principal-construct? version pkhash)` implementation
     ;; `version` is a `(buff 1)` and `pkhash` is a `(buff 20)`.
@@ -2405,6 +2421,7 @@
     (export "stdlib.buff-to-uint-le" (func $stdlib.buff-to-uint-le))
     (export "stdlib.not" (func $stdlib.not))
     (export "stdlib.is-eq-int" (func $stdlib.is-eq-int))
+    (export "stdlib.is-eq-bytes" (func $stdlib.is-eq-bytes))
     (export "stdlib.principal-construct" (func $stdlib.principal-construct))
     (export "stdlib.is-valid-contract-name" (func $stdlib.is-valid-contract-name))
     (export "stdlib.is-alpha" (func $stdlib.is-alpha))

--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -1,9 +1,11 @@
+use std::cell::OnceCell;
+
 use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 use clarity::vm::{
     types::{signatures::CallableSubtype, SequenceSubtype, StringSubtype, TypeSignature},
     ClarityName, SymbolicExpression,
 };
-use walrus::ir::BinaryOp;
+use walrus::{ir::BinaryOp, InstrSeqBuilder, LocalId};
 
 use super::Word;
 
@@ -35,39 +37,26 @@ impl Word for IsEq {
             .clone();
         let val_locals = generator.save_to_locals(builder, &ty, true);
 
-        // Equals expression needs to handle different types.
-        let type_suffix = match ty {
-            // is-eq-int function can be reused to both int and uint types.
-            TypeSignature::IntType | TypeSignature::UIntType => "int",
-            // is-eq-bytes function can be used for types with (offset, length)
-            TypeSignature::SequenceType(SequenceSubtype::BufferType(_))
-            | TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::ASCII(_)))
-            | TypeSignature::PrincipalType
-            | TypeSignature::CallableType(CallableSubtype::Principal(_)) => "bytes",
-            _ => {
-                dbg!(ty);
-                return Err(GeneratorError::NotImplemented);
-            }
-        };
-        let func = generator.func_by_name(&format!("stdlib.is-eq-{}", type_suffix));
-
         // Explicitly set to true.
         // Shortcut for a case with only one operand.
         builder.i32_const(1);
 
         // Loop through remainder operands, if the case.
-        // First operand will be reused from a local var.
         for operand in args.iter().skip(1) {
-            // Get first operand from the local and put it onto stack.
-            for val in &val_locals {
-                builder.local_get(*val);
-            }
-
-            // Traverse the next operand and put in onto stack.
+            // push the new operand on the stack
             generator.traverse_expr(builder, operand)?;
 
-            // Call the function with the operands on the stack.
-            builder.call(func);
+            // insert the new operand into locals
+            let mut nth_locals = Vec::with_capacity(wasm_types.len());
+            for local_ty in wasm_types.iter().rev() {
+                let local = generator.module.locals.add(*local_ty);
+                nth_locals.push(local);
+                builder.local_set(local);
+            }
+            nth_locals.reverse();
+
+            // check equality
+            wasm_equal(&ty, generator, builder, &val_locals, &nth_locals)?;
 
             // Do an "and" operation with the result from the previous function call.
             builder.binop(BinaryOp::I32And);
@@ -75,4 +64,76 @@ impl Word for IsEq {
 
         Ok(())
     }
+}
+
+fn wasm_equal(
+    ty: &TypeSignature,
+    generator: &mut WasmGenerator,
+    builder: &mut InstrSeqBuilder,
+    first_op: &[LocalId],
+    nth_op: &[LocalId],
+) -> Result<(), GeneratorError> {
+    match ty {
+        // is-eq-int function can be reused to both int and uint types.
+        TypeSignature::IntType | TypeSignature::UIntType => {
+            wasm_equal_int128(generator, builder, first_op, nth_op)
+        }
+        // is-eq-bytes function can be used for types with (offset, length)
+        TypeSignature::SequenceType(SequenceSubtype::BufferType(_))
+        | TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::ASCII(_)))
+        | TypeSignature::PrincipalType
+        | TypeSignature::CallableType(CallableSubtype::Principal(_)) => {
+            wasm_equal_bytes(generator, builder, first_op, nth_op)
+        }
+        _ => {
+            dbg!(ty);
+            Err(GeneratorError::NotImplemented)
+        }
+    }
+}
+
+fn wasm_equal_int128(
+    generator: &mut WasmGenerator,
+    builder: &mut InstrSeqBuilder,
+    first_op: &[LocalId],
+    nth_op: &[LocalId],
+) -> Result<(), GeneratorError> {
+    // Get first operand from the local and put it onto stack.
+    for val in first_op {
+        builder.local_get(*val);
+    }
+
+    // Get second operand from the local and put it onto stack.
+    for val in nth_op {
+        builder.local_get(*val);
+    }
+
+    // Call the function with the operands on the stack.
+    let func = OnceCell::new();
+    builder.call(*func.get_or_init(|| generator.func_by_name("stdlib.is-eq-int")));
+
+    Ok(())
+}
+
+fn wasm_equal_bytes(
+    generator: &mut WasmGenerator,
+    builder: &mut InstrSeqBuilder,
+    first_op: &[LocalId],
+    nth_op: &[LocalId],
+) -> Result<(), GeneratorError> {
+    // Get first operand from the local and put it onto stack.
+    for val in first_op {
+        builder.local_get(*val);
+    }
+
+    // Get second operand from the local and put it onto stack.
+    for val in nth_op {
+        builder.local_get(*val);
+    }
+
+    // Call the function with the operands on the stack.
+    let func = OnceCell::new();
+    builder.call(*func.get_or_init(|| generator.func_by_name("stdlib.is-eq-bytes")));
+
+    Ok(())
 }

--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -1,5 +1,8 @@
 use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
-use clarity::vm::{types::TypeSignature, ClarityName, SymbolicExpression};
+use clarity::vm::{
+    types::{SequenceSubtype, StringSubtype, TypeSignature},
+    ClarityName, SymbolicExpression,
+};
 use walrus::ir::BinaryOp;
 
 use super::Word;
@@ -36,6 +39,11 @@ impl Word for IsEq {
         let type_suffix = match ty {
             // is-eq-int function can be reused to both int and uint types.
             TypeSignature::IntType | TypeSignature::UIntType => "int",
+            // is-eq-bytes function can be used for types with (offset, length)
+            TypeSignature::SequenceType(SequenceSubtype::BufferType(_))
+            | TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::ASCII(_))) => {
+                "bytes"
+            }
             _ => {
                 return Err(GeneratorError::NotImplemented);
             }

--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -184,8 +184,7 @@ fn wasm_equal(
             builder,
             first_op,
             nth_op,
-            &ok_err_ty.0,
-            &ok_err_ty.1,
+            (&ok_err_ty.0, &ok_err_ty.1),
         ),
         TypeSignature::TupleType(tuple_ty) => {
             wasm_equal_tuple(generator, builder, first_op, nth_op, tuple_ty)
@@ -296,10 +295,9 @@ fn wasm_equal_response(
     builder: &mut InstrSeqBuilder,
     first_op: &[LocalId],
     nth_op: &[LocalId],
-    ok_ty: &TypeSignature,
-    err_ty: &TypeSignature,
+    ok_err_ty: (&TypeSignature, &TypeSignature),
 ) -> Result<(), GeneratorError> {
-    let split_ok_err_idx = dbg!(clar2wasm_ty(ok_ty)).len();
+    let split_ok_err_idx = dbg!(clar2wasm_ty(ok_err_ty.0)).len();
     let Some((first_variant, first_ok, first_err)) =
         first_op.split_first().map(|(variant, rest)| {
             let (ok, err) = dbg!(rest.split_at(split_ok_err_idx));
@@ -326,13 +324,13 @@ fn wasm_equal_response(
 
     let ok_id = {
         let mut ok_case = builder.dangling_instr_seq(ValType::I32);
-        wasm_equal(ok_ty, generator, &mut ok_case, first_ok, nth_ok)?;
+        wasm_equal(ok_err_ty.0, generator, &mut ok_case, first_ok, nth_ok)?;
         ok_case.id()
     };
 
     let err_id = {
         let mut err_case = builder.dangling_instr_seq(ValType::I32);
-        wasm_equal(err_ty, generator, &mut err_case, first_err, nth_err)?;
+        wasm_equal(ok_err_ty.1, generator, &mut err_case, first_err, nth_err)?;
         err_case.id()
     };
 

--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -1,5 +1,3 @@
-use std::cell::OnceCell;
-
 use crate::wasm_generator::{
     clar2wasm_ty, drop_value, ArgumentsExt, GeneratorError, WasmGenerator,
 };

--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -182,6 +182,13 @@ fn wasm_equal(
             builder.unreachable();
             Ok(())
         }
+        TypeSignature::BoolType => {
+            builder
+                .local_get(first_op[0])
+                .local_get(nth_op[0])
+                .binop(BinaryOp::I32Eq);
+            Ok(())
+        }
         // is-eq-int function can be reused to both int and uint types.
         TypeSignature::IntType | TypeSignature::UIntType => {
             if ty == nth_ty {

--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -263,8 +263,8 @@ fn wasm_equal_int128(
     }
 
     // Call the function with the operands on the stack.
-    let func = OnceCell::new();
-    builder.call(*func.get_or_init(|| generator.func_by_name("stdlib.is-eq-int")));
+    let func = generator.func_by_name("stdlib.is-eq-int");
+    builder.call(func);
 
     Ok(())
 }
@@ -286,8 +286,8 @@ fn wasm_equal_bytes(
     }
 
     // Call the function with the operands on the stack.
-    let func = OnceCell::new();
-    builder.call(*func.get_or_init(|| generator.func_by_name("stdlib.is-eq-bytes")));
+    let func = generator.func_by_name("stdlib.is-eq-bytes");
+    builder.call(func);
 
     Ok(())
 }

--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -41,7 +41,7 @@ impl Word for IsEq {
             .clone();
 
         // No need to go further if there is only one argument
-        if args.is_empty() {
+        if args.len() == 1 {
             drop_value(builder, &ty);
             builder.i32_const(1); // TRUE
             return Ok(());

--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -1,6 +1,6 @@
 use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 use clarity::vm::{
-    types::{SequenceSubtype, StringSubtype, TypeSignature},
+    types::{signatures::CallableSubtype, SequenceSubtype, StringSubtype, TypeSignature},
     ClarityName, SymbolicExpression,
 };
 use walrus::ir::BinaryOp;
@@ -41,10 +41,11 @@ impl Word for IsEq {
             TypeSignature::IntType | TypeSignature::UIntType => "int",
             // is-eq-bytes function can be used for types with (offset, length)
             TypeSignature::SequenceType(SequenceSubtype::BufferType(_))
-            | TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::ASCII(_))) => {
-                "bytes"
-            }
+            | TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::ASCII(_)))
+            | TypeSignature::PrincipalType
+            | TypeSignature::CallableType(CallableSubtype::Principal(_)) => "bytes",
             _ => {
+                dbg!(ty);
                 return Err(GeneratorError::NotImplemented);
             }
         };

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -625,3 +625,8 @@ fn prop_le_buff() {
 fn prop_ge_buff() {
     test_buff_comparison("stdlib.ge-buff", |a, b| a >= b)
 }
+
+#[test]
+fn prop_is_eq_bytes() {
+    test_buff_comparison("is-eq-bytes", |a, b| a == b)
+}

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -628,5 +628,5 @@ fn prop_ge_buff() {
 
 #[test]
 fn prop_is_eq_bytes() {
-    test_buff_comparison("is-eq-bytes", |a, b| a == b)
+    test_buff_comparison("stdlib.is-eq-bytes", |a, b| a == b)
 }

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -1725,6 +1725,10 @@ fn test_cmp_buff(func_name: &str, reference_func: impl Fn(&[u8], &[u8]) -> bool)
     test_cmp(&[1, 2, 3], &[1, 2, 3]);
     test_cmp(&[1, 2, 3, 4], &[1, 2, 3]);
     test_cmp(&[1, 2, 3], &[1, 2, 3, 4]);
+
+    // test different end
+    test_cmp(&[1, 2, 3], &[1, 2, 4]);
+    test_cmp(&[1, 2, 3], &[1, 2, 2]);
 }
 
 #[test]
@@ -1745,6 +1749,11 @@ fn test_le_buff() {
 #[test]
 fn test_ge_buff() {
     test_cmp_buff("stdlib.ge-buff", |a, b| a >= b)
+}
+
+#[test]
+fn test_is_eq_bytes() {
+    test_cmp_buff("is-eq-bytes", |a, b| a == b)
 }
 
 #[test]

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -1753,7 +1753,7 @@ fn test_ge_buff() {
 
 #[test]
 fn test_is_eq_bytes() {
-    test_cmp_buff("is-eq-bytes", |a, b| a == b)
+    test_cmp_buff("stdlib.is-eq-bytes", |a, b| a == b)
 }
 
 #[test]

--- a/clar2wasm/tests/standard/utils.rs
+++ b/clar2wasm/tests/standard/utils.rs
@@ -1201,7 +1201,7 @@ pub(crate) fn test_buff_comparison(
         .get_func(store.borrow_mut().deref_mut(), func_name)
         .unwrap();
 
-    proptest!(ProptestConfig::with_cases(1000), |(buff_a in buffer(1500, 100), buff_b in buffer(2000, 100))| {
+    proptest!(ProptestConfig::with_cases(500), |(buff_a in buffer(1500, 100), buff_b in buffer(2000, 100))| {
         let expected_result = reference_function(&buff_a, &buff_b) as i32;
 
         let mut result = [Val::I32(0)];
@@ -1209,6 +1209,26 @@ pub(crate) fn test_buff_comparison(
             .write_to_memory(memory, store.borrow_mut().deref_mut())
             .expect("Could not write to memory");
         let (offset_b, length_b) = buff_b
+            .write_to_memory(memory, store.borrow_mut().deref_mut())
+            .expect("Could not write to memory");
+        cmp
+            .call(
+                store.borrow_mut().deref_mut(),
+                &[offset_a.into(), length_a.into(), offset_b.into(), length_b.into()],
+                &mut result,
+            )
+            .unwrap_or_else(|_| panic!("call to {func_name} failed"));
+        prop_assert_eq!(result[0].unwrap_i32(), expected_result);
+    });
+
+    proptest!(ProptestConfig::with_cases(500), |(buff in buffer(1500, 100))| {
+        let expected_result = reference_function(&buff, &buff) as i32;
+
+        let mut result = [Val::I32(0)];
+        let (offset_a, length_a) = buff
+            .write_to_memory(memory, store.borrow_mut().deref_mut())
+            .expect("Could not write to memory");
+        let (offset_b, length_b) = buff
             .write_to_memory(memory, store.borrow_mut().deref_mut())
             .expect("Could not write to memory");
         cmp

--- a/tests/contracts/equal.clar
+++ b/tests/contracts/equal.clar
@@ -110,7 +110,7 @@
     (ok (is-eq (some 0x01) (some 0x02)))
 )
 
-(define-public (call-optional-some-and-err-unequal)
+(define-public (call-optional-some-and-none-unequal)
     (ok (is-eq (some "a value here") none))
 )
 
@@ -134,7 +134,7 @@
     (ok (is-eq (err 0x123456) (err 0xabcdef)))
 )
 
-(define-public (call-response-some-err-same-value-unequal)
+(define-public (call-response-ok-err-same-value-unequal)
     (ok (is-eq (ok 42) (err 42)))
 )
 

--- a/tests/contracts/equal.clar
+++ b/tests/contracts/equal.clar
@@ -81,3 +81,23 @@
 (define-public (str-ascii-unequal)
     (ok (is-eq "hello" "world"))
 )
+
+(define-public (principal-equal)
+    (ok (is-eq 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM))
+)
+
+(define-public (principal-unequal)
+    (ok (is-eq 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR))
+)
+
+(define-public (call-principal-equal)
+    (ok (is-eq 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.foo 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.foo))
+)
+
+(define-public (call-principal-unequal)
+    (ok (is-eq 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.foo 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.bar))
+)
+
+(define-public (call-principal-unequal-2)
+    (ok (is-eq 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.foo 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR.foo))
+)

--- a/tests/contracts/equal.clar
+++ b/tests/contracts/equal.clar
@@ -53,3 +53,31 @@
 (define-public (uint-unequal-2)
     (ok (is-eq u43 u43 u54 u56 u43 u43))
 )
+
+(define-public (buf-equal)
+    (ok (is-eq 0x0102 0x0102))
+)
+
+(define-public (buf-equal-2)
+    (ok (is-eq 0x0102 0x0102 0x0102))
+)
+
+(define-public (buf-unequal)
+    (ok (is-eq 0x0102 0x0103))
+)
+
+(define-public (buf-unequal-2)
+    (ok (is-eq 0x0102 0x010203))
+)
+
+(define-public (buf-unequal-3)
+    (ok (is-eq 0x01 0x01 0x02))
+)
+
+(define-public (str-ascii-equal)
+    (ok (is-eq "hello" "hello"))
+)
+
+(define-public (str-ascii-unequal)
+    (ok (is-eq "hello" "world"))
+)

--- a/tests/contracts/equal.clar
+++ b/tests/contracts/equal.clar
@@ -110,6 +110,10 @@
     (ok (is-eq (some 0x01) (some 0x02)))
 )
 
+(define-public (call-optional-some-and-err-unequal)
+    (ok (is-eq (some "a value here") none))
+)
+
 (define-public (call-response-ok-equal)
     (ok (is-eq (ok 0) (ok 0)))
 )
@@ -128,6 +132,10 @@
 
 (define-public (call-response-err-unequal)
     (ok (is-eq (err 0x123456) (err 0xabcdef)))
+)
+
+(define-public (call-response-some-err-same-value-unequal)
+    (ok (is-eq (ok 42) (err 42)))
 )
 
 (define-public (call-one-tuple-equal)
@@ -176,6 +184,10 @@
 
 (define-public (call-list-unequal-length)
     (ok (is-eq (list 1 2 3 4 5) (list 1 2 3 4)))
+)
+
+(define-public (call-list-unequal-length-2)
+    (ok (is-eq (list 1 2 3 4) (list 1 2 3 4 5)))
 )
 
 (define-public (call-list-unequal-first-element)

--- a/tests/contracts/equal.clar
+++ b/tests/contracts/equal.clar
@@ -109,3 +109,23 @@
 (define-public (call-optional-unequal)
     (ok (is-eq (some 0x01) (some 0x02)))
 )
+
+(define-public (call-response-ok-equal)
+    (ok (is-eq (ok 0) (ok 0)))
+)
+
+(define-public (call-response-err-equal)
+    (ok (is-eq (err 0x010203) (err 0x010203)))
+)
+
+(define-public (call-response-ok-err-unequal)
+    (ok (is-eq (ok 42) (err "forty-two")))
+)
+
+(define-public (call-response-ok-unequal)
+    (ok (is-eq (ok u5) (ok u55)))
+)
+
+(define-public (call-response-err-unequal)
+    (ok (is-eq (err 0x123456) (err 0xabcdef)))
+)

--- a/tests/contracts/equal.clar
+++ b/tests/contracts/equal.clar
@@ -189,3 +189,11 @@
 (define-public (call-list-unequal-last-element)
     (ok (is-eq (list 1 2 3 4 5) (list 1 2 3 4 42)))
 )
+
+(define-public (call-bool-equal)
+    (ok (is-eq true true))
+)
+
+(define-public (call-bool-unequal)
+    (ok (is-eq false true))
+)

--- a/tests/contracts/equal.clar
+++ b/tests/contracts/equal.clar
@@ -165,3 +165,27 @@
 (define-public (call-tuple-recursive-unequal)
     (ok (is-eq {name: "James Bond", creator: {name: "Ian Fleming", date: (some 1953)}} {name: "James Bond", creator: {name: "Ian Fleming", date: none}}))
 )
+
+(define-public (call-list-int-equal)
+    (ok (is-eq (list 1 2 3 4 5) (list 1 2 3 4 5)))
+)
+
+(define-public (call-list-str-equal)
+    (ok (is-eq (list "hello" "world" "goodbye" "mars") (list "hello" "world" "goodbye" "mars")))
+)
+
+(define-public (call-list-unequal-length)
+    (ok (is-eq (list 1 2 3 4 5) (list 1 2 3 4)))
+)
+
+(define-public (call-list-unequal-first-element)
+    (ok (is-eq (list 1 2 3 4 5) (list 0 2 3 4 5)))
+)
+
+(define-public (call-list-unequal-mid-element)
+    (ok (is-eq (list 1 2 3 4 5) (list 1 2 7 4 5)))
+)
+
+(define-public (call-list-unequal-last-element)
+    (ok (is-eq (list 1 2 3 4 5) (list 1 2 3 4 42)))
+)

--- a/tests/contracts/equal.clar
+++ b/tests/contracts/equal.clar
@@ -101,3 +101,11 @@
 (define-public (call-principal-unequal-2)
     (ok (is-eq 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.foo 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR.foo))
 )
+
+(define-public (call-optional-equal)
+    (ok (is-eq (some 1) (some 1)))
+)
+
+(define-public (call-optional-unequal)
+    (ok (is-eq (some 0x01) (some 0x02)))
+)

--- a/tests/contracts/equal.clar
+++ b/tests/contracts/equal.clar
@@ -129,3 +129,39 @@
 (define-public (call-response-err-unequal)
     (ok (is-eq (err 0x123456) (err 0xabcdef)))
 )
+
+(define-public (call-one-tuple-equal)
+    (ok (is-eq {name: "James Bond"} {name: "James Bond"}))
+)
+
+(define-public (call-one-tuple-unequal)
+    (ok (is-eq {name: "James Bond"} {name: "Austin Powers"}))
+)
+
+(define-public (call-tuple-equal)
+    (ok (is-eq {name: "James Bond", alias: "007"} {name: "James Bond", alias: "007"}))
+)
+
+(define-public (call-tuple-unequal)
+    (ok (is-eq {name: "James Bond", alias: "007"} {name: "James Bond", alias: "008"}))
+)
+
+(define-public (call-big-tuple-equal)
+    (ok (is-eq {name: "Hubert Bonisseur de la Bath", alias: "OSS 117", creation: 1949} {name: "Hubert Bonisseur de la Bath", alias: "OSS 117", creation: 1949}))
+)
+
+(define-public (call-big-tuple-slightly-unequal)
+    (ok (is-eq {name: "Hubert Bonisseur de La Bath", alias: "OSS 117", creation: 1949} {name: "Hubert Bonisseur de la Bath", alias: "OSS 117", creation: 1949}))
+)
+
+(define-public (call-big-tuple-unequal)
+    (ok (is-eq {name: "Hubert Bonisseur de la Bath", alias: "OSS 117", creation: 1949} {name: "James Bond", alias: "007", creation: 1953}))
+)
+
+(define-public (call-tuple-recursive-equal)
+    (ok (is-eq {name: "James Bond", creator: {name: "Ian Fleming", date: (some 1953)}} {name: "James Bond", creator: {name: "Ian Fleming", date: (some 1953)}}))
+)
+
+(define-public (call-tuple-recursive-unequal)
+    (ok (is-eq {name: "James Bond", creator: {name: "Ian Fleming", date: (some 1953)}} {name: "James Bond", creator: {name: "Ian Fleming", date: none}}))
+)

--- a/tests/src/lib_tests.rs
+++ b/tests/src/lib_tests.rs
@@ -3172,9 +3172,9 @@ test_contract_call_response!(
 );
 
 test_contract_call_response!(
-    test_call_optional_some_and_err_unequal,
+    test_call_optional_some_and_none_unequal,
     "equal",
-    "call-optional-some-and-err-unequal",
+    "call-optional-some-and-none-unequal",
     |response: ResponseData| {
         assert!(response.committed);
         assert_eq!(*response.data, Value::Bool(false));
@@ -3232,9 +3232,9 @@ test_contract_call_response!(
 );
 
 test_contract_call_response!(
-    test_call_response_some_err_same_value_unequal,
+    test_call_response_ok_err_same_value_unequal,
     "equal",
-    "call-response-some-err-same-value-unequal",
+    "call-response-ok-err-same-value-unequal",
     |response: ResponseData| {
         assert!(response.committed);
         assert_eq!(*response.data, Value::Bool(false));

--- a/tests/src/lib_tests.rs
+++ b/tests/src/lib_tests.rs
@@ -3222,6 +3222,96 @@ test_contract_call_response!(
 );
 
 test_contract_call_response!(
+    test_call_one_tuple_equal,
+    "equal",
+    "call-one-tuple-equal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
+    test_call_one_tuple_unequal,
+    "equal",
+    "call-one-tuple-unequal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_call_tuple_equal,
+    "equal",
+    "call-tuple-equal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
+    test_call_tuple_unequal,
+    "equal",
+    "call-tuple-unequal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_call_big_tuple_equal,
+    "equal",
+    "call-big-tuple-equal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
+    test_call_big_tuple_slightly_unequal,
+    "equal",
+    "call-big-tuple-slightly-unequal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_call_big_tuple_unequal,
+    "equal",
+    "call-big-tuple-unequal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_call_tuple_recursive_equal,
+    "equal",
+    "call-tuple-recursive-equal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
+    test_call_tuple_recursive_unequal,
+    "equal",
+    "call-tuple-recursive-unequal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
     test_append,
     "sequences",
     "list-append",

--- a/tests/src/lib_tests.rs
+++ b/tests/src/lib_tests.rs
@@ -3172,6 +3172,56 @@ test_contract_call_response!(
 );
 
 test_contract_call_response!(
+    test_call_response_ok_equal,
+    "equal",
+    "call-response-ok-equal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
+    test_call_response_err_equal,
+    "equal",
+    "call-response-err-equal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
+    test_call_response_ok_err_unequal,
+    "equal",
+    "call-response-ok-err-unequal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_call_response_ok_unequal,
+    "equal",
+    "call-response-ok-unequal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_call_response_err_unequal,
+    "equal",
+    "call-response-err-unequal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
     test_append,
     "sequences",
     "list-append",

--- a/tests/src/lib_tests.rs
+++ b/tests/src/lib_tests.rs
@@ -3152,6 +3152,26 @@ test_contract_call_response!(
 );
 
 test_contract_call_response!(
+    test_call_optional_equal,
+    "equal",
+    "call-optional-equal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
+    test_call_optional_unequal,
+    "equal",
+    "call-optional-unequal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
     test_append,
     "sequences",
     "list-append",

--- a/tests/src/lib_tests.rs
+++ b/tests/src/lib_tests.rs
@@ -3102,6 +3102,56 @@ test_contract_call_response!(
 );
 
 test_contract_call_response!(
+    test_principal_equal,
+    "equal",
+    "principal-equal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
+    test_principal_unequal,
+    "equal",
+    "principal-unequal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_call_principal_equal,
+    "equal",
+    "call-principal-equal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
+    test_call_principal_unequal,
+    "equal",
+    "call-principal-unequal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_call_principal_unequal_2,
+    "equal",
+    "call-principal-unequal-2",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
     test_append,
     "sequences",
     "list-append",

--- a/tests/src/lib_tests.rs
+++ b/tests/src/lib_tests.rs
@@ -3172,6 +3172,16 @@ test_contract_call_response!(
 );
 
 test_contract_call_response!(
+    test_call_optional_some_and_err_unequal,
+    "equal",
+    "call-optional-some-and-err-unequal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
     test_call_response_ok_equal,
     "equal",
     "call-response-ok-equal",
@@ -3215,6 +3225,16 @@ test_contract_call_response!(
     test_call_response_err_unequal,
     "equal",
     "call-response-err-unequal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_call_response_some_err_same_value_unequal,
+    "equal",
+    "call-response-some-err-same-value-unequal",
     |response: ResponseData| {
         assert!(response.committed);
         assert_eq!(*response.data, Value::Bool(false));
@@ -3335,6 +3355,16 @@ test_contract_call_response!(
     test_call_list_unequal_length,
     "equal",
     "call-list-unequal-length",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_call_list_unequal_length_2,
+    "equal",
+    "call-list-unequal-length-2",
     |response: ResponseData| {
         assert!(response.committed);
         assert_eq!(*response.data, Value::Bool(false));

--- a/tests/src/lib_tests.rs
+++ b/tests/src/lib_tests.rs
@@ -3312,6 +3312,66 @@ test_contract_call_response!(
 );
 
 test_contract_call_response!(
+    test_call_list_int_equal,
+    "equal",
+    "call-list-int-equal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
+    test_call_list_str_equal,
+    "equal",
+    "call-list-str-equal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
+    test_call_list_unequal_length,
+    "equal",
+    "call-list-unequal-length",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_call_list_unequal_first_element,
+    "equal",
+    "call-list-unequal-first-element",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_call_list_unequal_mid_element,
+    "equal",
+    "call-list-unequal-mid-element",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_call_list_unequal_last_element,
+    "equal",
+    "call-list-unequal-last-element",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
     test_append,
     "sequences",
     "list-append",

--- a/tests/src/lib_tests.rs
+++ b/tests/src/lib_tests.rs
@@ -3032,6 +3032,76 @@ test_contract_call_response!(
 );
 
 test_contract_call_response!(
+    test_buffer_equal,
+    "equal",
+    "buf-equal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
+    test_buffer_equal_2,
+    "equal",
+    "buf-equal-2",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
+    test_buffer_unequal,
+    "equal",
+    "buf-unequal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_buffer_unequal_2,
+    "equal",
+    "buf-unequal-2",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_buffer_unequal_3,
+    "equal",
+    "buf-unequal-3",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_str_ascii_equal,
+    "equal",
+    "str-ascii-equal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
+    test_str_ascii_unequal,
+    "equal",
+    "str-ascii-unequal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
     test_append,
     "sequences",
     "list-append",

--- a/tests/src/lib_tests.rs
+++ b/tests/src/lib_tests.rs
@@ -3372,6 +3372,26 @@ test_contract_call_response!(
 );
 
 test_contract_call_response!(
+    test_call_bool_equal,
+    "equal",
+    "call-bool-equal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
+    test_call_bool_unequal,
+    "equal",
+    "call-bool-unequal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
     test_append,
     "sequences",
     "list-append",


### PR DESCRIPTION
We had an implementation of `is-eq` for int types. This PR adds nearly all the remaining types (this implementation still lacks equality for `string-utf8` due to #127, and `ListUnionType` and `TraitReferenceType` due to my lack of knowledge about them).

This PR is "quite big". I tried to document as much as possible my code, but there might still be parts that don't make total sense. Please tell me if everything is understandable.

I am really sorry about the size of this PR. It went out of control when I realized that the types of the operands in a `is-eq` expression could be different, depending on the appearance or not of the infamous `NoType`. At that moment, a simple algorithm that just needed to check equality recursively had to become much more complex, and the number of rewrites went out of control.
Once again, I'm very sorry about this, and I'll try to do better next time.

I still wanted to submit the PR now, even if I believe it is not yet complete. I want to add property tests here that will generate many complex types and check that it can create valid Wasm code.
But this will be for another PR :)