### PR TITLE
feat: return ast in compile

### DIFF
--- a/clar2wasm/src/bin/main.rs
+++ b/clar2wasm/src/bin/main.rs
@@ -58,6 +58,7 @@ fn main() {
     .unwrap_or_else(|err| match err {
         CompileError::Generic {
             diagnostics,
+            ast: _,
             cost_tracker: _,
         } => {
             for diagnostic in diagnostics.iter() {


### PR DESCRIPTION
## Description

Expose to things I was needing in clarinet:

- Re-export `walrus::Module`
- Export ast in `CompileResult` and `CompileErr`

## Does this introduce a breaking change?

New `compile` output signature

## Checklist

- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `cargo test` passes
- [ ] Changelog is updated
