### PR TITLE
Use stacks-core branch rebased on latest `next` branch

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,3 @@
 [alias]
 clar2wasm-install = "install --path . --locked --force"
+fmt-stacks = "fmt -- --config group_imports=StdExternalCrate,imports_granularity=Module"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,10 +30,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
-      - run: cargo fmt -- --check
+      - run: cargo fmt -- --config group_imports=StdExternalCrate,imports_granularity=Module --check
 
   clippy:
     name: Clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,17 +19,6 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom 0.2.10",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
@@ -48,6 +37,12 @@ checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "android-tzdata"
@@ -723,7 +718,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset",
+ "memoffset 0.9.0",
  "scopeguard",
 ]
 
@@ -956,6 +951,101 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.33",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
+
+[[package]]
+name = "futures-task"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
+name = "futures-util"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1072,15 +1162,6 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash 0.7.6",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
@@ -1091,7 +1172,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.3",
+ "ahash",
 ]
 
 [[package]]
@@ -1100,16 +1181,17 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 dependencies = [
- "ahash 0.8.3",
+ "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
 name = "hashlink"
-version = "0.7.0"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
- "hashbrown 0.11.2",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -1231,7 +1313,7 @@ version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abfb2e51b23c338595ae0b6bdaaa7a4a8b860b8d788a4331cb07b50fe5dea71b"
 dependencies = [
- "ahash 0.8.3",
+ "ahash",
  "indexmap 2.0.0",
  "is-terminal",
  "itoa",
@@ -1362,9 +1444,9 @@ checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.24.2"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898745e570c7d0453cc1fbc4a701eb6c662ed54e8fec8b7d14be137ebeeb9d14"
+checksum = "29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1434,6 +1516,15 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
@@ -1448,6 +1539,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "nix"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
+dependencies = [
+ "bitflags 1.3.2",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset 0.6.5",
 ]
 
 [[package]]
@@ -1582,15 +1686,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
-name = "pest"
-version = "2.7.3"
+name = "pin-project-lite"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a4d085fd991ac8d5b05a147b437791b4260b76326baf0fc60cf7c9c27ecd33"
-dependencies = [
- "memchr",
- "thiserror",
- "ucd-trie",
-]
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -1639,7 +1744,7 @@ dependencies = [
  "inferno",
  "libc",
  "log",
- "nix",
+ "nix 0.26.4",
  "once_cell",
  "parking_lot",
  "protobuf",
@@ -1999,40 +2104,53 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.11.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2288c66aeafe3b2ed227c981f364f9968fa952ef0b30e84ada4486e7ee24d00a"
+checksum = "de1bb486a691878cd320c2f0d319ba91eeaa2e894066d8b5f8f117c000e9d962"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version 0.4.0",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290ca1a1c8ca7edb7c3283bd44dc35dd54fdec6253a3912e201ba1072018fca8"
 dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
  "rustc_version 0.4.0",
  "syn 1.0.109",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "rstest_reuse"
-version = "0.1.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c6cfaae58c048728261723a72b80a0aa9f3768e9a7da3b302a24d262525219"
+checksum = "45f80dcc84beab3a327bbe161f77db25f336a1452428176787c8c79ac79d7073"
 dependencies = [
  "quote",
- "rustc_version 0.3.3",
+ "rand 0.8.5",
+ "rustc_version 0.4.0",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "rusqlite"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85127183a999f7db96d1a976a309eebbfb6ea3b0b400ddd8340190129de6eb7a"
+checksum = "01e213bc3ecb39ac32e81e51ebe31fd888a940515173e3a18a35f8c6e896422a"
 dependencies = [
  "bitflags 1.3.2",
  "fallible-iterator 0.2.0",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
- "memchr",
  "serde_json",
  "smallvec",
 ]
@@ -2056,15 +2174,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver 0.9.0",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
 ]
 
 [[package]]
@@ -2167,16 +2276,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser 0.7.0",
-]
-
-[[package]]
-name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser 0.10.2",
+ "semver-parser",
 ]
 
 [[package]]
@@ -2190,15 +2290,6 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "serde"
@@ -2299,6 +2390,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "slice-group-by"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2375,6 +2475,7 @@ dependencies = [
  "ed25519-dalek",
  "lazy_static",
  "libc",
+ "nix 0.23.2",
  "percent-encoding",
  "rand 0.7.3",
  "ripemd",
@@ -2389,6 +2490,7 @@ dependencies = [
  "slog-json",
  "slog-term",
  "time 0.2.27",
+ "winapi",
 ]
 
 [[package]]
@@ -2685,12 +2787,6 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unarray"
@@ -3173,7 +3269,7 @@ dependencies = [
  "log",
  "mach",
  "memfd",
- "memoffset",
+ "memoffset 0.9.0",
  "paste",
  "rand 0.8.5",
  "rustix 0.38.25",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,7 +438,7 @@ dependencies = [
  "rusqlite",
  "sha2 0.10.7",
  "walrus",
- "wasmtime 13.0.0",
+ "wasmtime",
  "wat",
 ]
 
@@ -454,7 +454,7 @@ dependencies = [
  "hex",
  "predicates",
  "wasmparser 0.110.0",
- "wasmtime 13.0.0",
+ "wasmtime",
 ]
 
 [[package]]
@@ -477,7 +477,7 @@ dependencies = [
  "slog",
  "stacks-common",
  "time 0.2.27",
- "wasmtime 15.0.0",
+ "wasmtime",
 ]
 
 [[package]]
@@ -536,41 +536,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.100.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b9d1a9e776c27ad55d7792a380785d1fe8c2d7b099eed8dbd8f4af2b598192"
-dependencies = [
- "cranelift-entity 0.100.0",
-]
-
-[[package]]
-name = "cranelift-bforest"
 version = "0.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76eb38f2af690b5a4411d9a8782b6d77dabff3ca939e0518453ab9f9a4392d41"
 dependencies = [
- "cranelift-entity 0.102.0",
-]
-
-[[package]]
-name = "cranelift-codegen"
-version = "0.100.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5528483314c2dd5da438576cd8a9d0b3cedad66fb8a4727f90cd319a81950038"
-dependencies = [
- "bumpalo",
- "cranelift-bforest 0.100.0",
- "cranelift-codegen-meta 0.100.0",
- "cranelift-codegen-shared 0.100.0",
- "cranelift-control 0.100.0",
- "cranelift-entity 0.100.0",
- "cranelift-isle 0.100.0",
- "gimli 0.28.0",
- "hashbrown 0.14.0",
- "log",
- "regalloc2",
- "smallvec",
- "target-lexicon",
+ "cranelift-entity",
 ]
 
 [[package]]
@@ -580,12 +550,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39526c036b92912417e8931f52c1e235796688068d3efdbbd8b164f299d19156"
 dependencies = [
  "bumpalo",
- "cranelift-bforest 0.102.0",
- "cranelift-codegen-meta 0.102.0",
- "cranelift-codegen-shared 0.102.0",
- "cranelift-control 0.102.0",
- "cranelift-entity 0.102.0",
- "cranelift-isle 0.102.0",
+ "cranelift-bforest",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
  "gimli 0.28.0",
  "hashbrown 0.14.0",
  "log",
@@ -596,27 +566,12 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.100.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f46a8318163f7682e35b8730ba93c1b586a2da8ce12a0ed545efc1218550f70"
-dependencies = [
- "cranelift-codegen-shared 0.100.0",
-]
-
-[[package]]
-name = "cranelift-codegen-meta"
 version = "0.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb0deedc9fccf2db53a5a3c9c9d0163e44143b0d004dca9bf6ab6a0024cd79a"
 dependencies = [
- "cranelift-codegen-shared 0.102.0",
+ "cranelift-codegen-shared",
 ]
-
-[[package]]
-name = "cranelift-codegen-shared"
-version = "0.100.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d1239cfd50eecfaed468d46943f8650e32969591868ad50111613704da6c70"
 
 [[package]]
 name = "cranelift-codegen-shared"
@@ -626,30 +581,11 @@ checksum = "cea2d1b274e45aa8e61e9103efa1ba82d4b5a19d12bd1fd10744c3b7380ba3ff"
 
 [[package]]
 name = "cranelift-control"
-version = "0.100.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc530560c8f16cc1d4dd7ea000c56f519c60d1a914977abe849ce555c35a61d"
-dependencies = [
- "arbitrary",
-]
-
-[[package]]
-name = "cranelift-control"
 version = "0.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea5977559a71e63db79a263f0e81a89b996e8a38212c4281e37dd1dbaa8b65c"
 dependencies = [
  "arbitrary",
-]
-
-[[package]]
-name = "cranelift-entity"
-version = "0.100.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f333fa641a9ad2bff0b107767dcb972c18c2bfab7969805a1d7e42449ccb0408"
-dependencies = [
- "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -664,33 +600,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.100.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abf6563015a80f03f8bc4df307d0a81363f4eb73108df3a34f6e66fb6d5307"
-dependencies = [
- "cranelift-codegen 0.100.0",
- "log",
- "smallvec",
- "target-lexicon",
-]
-
-[[package]]
-name = "cranelift-frontend"
 version = "0.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8e6890f587ef59824b3debe577e68fdf9b307b3808c54b8d93a18fd0b70941b"
 dependencies = [
- "cranelift-codegen 0.102.0",
+ "cranelift-codegen",
  "log",
  "smallvec",
  "target-lexicon",
 ]
-
-[[package]]
-name = "cranelift-isle"
-version = "0.100.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eb29d0edc8a5c029ed0f7ca77501f272738e3c410020b4a00f42ffe8ad2a8aa"
 
 [[package]]
 name = "cranelift-isle"
@@ -700,40 +618,13 @@ checksum = "a8d5fc6d5d3b52d1917002b17a8ecce448c2621b5bf394bb4e77e2f676893537"
 
 [[package]]
 name = "cranelift-native"
-version = "0.100.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006056a7fa920870bad06bf8e1b3033d70cbb7ee625b035efa9d90882a931868"
-dependencies = [
- "cranelift-codegen 0.100.0",
- "libc",
- "target-lexicon",
-]
-
-[[package]]
-name = "cranelift-native"
 version = "0.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e10c2e7faa65d4ae7de9a83b44f2c31aca7dc638e17d0a79572fdf8103d720b"
 dependencies = [
- "cranelift-codegen 0.102.0",
+ "cranelift-codegen",
  "libc",
  "target-lexicon",
-]
-
-[[package]]
-name = "cranelift-wasm"
-version = "0.100.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b3d08c05f82903a1f6a04d89c4b9ecb47a4035710f89a39a21a147a80214672"
-dependencies = [
- "cranelift-codegen 0.100.0",
- "cranelift-entity 0.100.0",
- "cranelift-frontend 0.100.0",
- "itertools",
- "log",
- "smallvec",
- "wasmparser 0.112.0",
- "wasmtime-types 13.0.0",
 ]
 
 [[package]]
@@ -742,14 +633,14 @@ version = "0.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2755807efc7ec80d1cc0b6815e70f10cedf968889f0469091dbff9c5c0741c48"
 dependencies = [
- "cranelift-codegen 0.102.0",
- "cranelift-entity 0.102.0",
- "cranelift-frontend 0.102.0",
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-frontend",
  "itertools",
  "log",
  "smallvec",
  "wasmparser 0.116.1",
- "wasmtime-types 15.0.0",
+ "wasmtime-types",
 ]
 
 [[package]]
@@ -1049,15 +940,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "form_urlencoded"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
-dependencies = [
- "percent-encoding",
-]
 
 [[package]]
 name = "futures"
@@ -1369,16 +1251,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
-name = "idna"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
 name = "ignore"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,33 +1354,13 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "ittapi"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41e0d0b7b3b53d92a7e8b80ede3400112a6b8b4c98d1f5b8b16bb787c780582c"
-dependencies = [
- "anyhow",
- "ittapi-sys 0.3.4",
- "log",
-]
-
-[[package]]
-name = "ittapi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b996fe614c41395cdaedf3cf408a9534851090959d90d54a535f675550b64b1"
 dependencies = [
  "anyhow",
- "ittapi-sys 0.4.0",
+ "ittapi-sys",
  "log",
-]
-
-[[package]]
-name = "ittapi-sys"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f8763c96e54e6d6a0dccc2990d8b5e33e3313aaeae6185921a3f4c1614a77c"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1988,17 +1840,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "pulldown-cmark"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a1a2f1f0a7ecff9c31abbe177637be0e97a0aef46cf8738ece09327985d998"
-dependencies = [
- "bitflags 1.3.2",
- "memchr",
- "unicase",
 ]
 
 [[package]]
@@ -2888,21 +2729,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "toml"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2924,34 +2750,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
-name = "unicase"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
-
-[[package]]
-name = "unicode-bidi"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-segmentation"
@@ -2970,17 +2772,6 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
-name = "url"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
-]
 
 [[package]]
 name = "utf8parse"
@@ -3130,15 +2921,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba64e81215916eaeb48fee292f29401d69235d62d8b8fd92a7b2844ec5ae5f7"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "822b645bf4f2446b949776ffca47e2af60b167209ffb70814ef8779d299cd421"
@@ -3164,59 +2946,12 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.112.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e986b010f47fcce49cf8ea5d5f9e5d2737832f12b53ae8ae785bbe895d0877bf"
-dependencies = [
- "indexmap 2.0.0",
- "semver 1.0.18",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
 dependencies = [
  "indexmap 2.0.0",
  "semver 1.0.18",
-]
-
-[[package]]
-name = "wasmtime"
-version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16ed7db409c1acf60d33128b2a38bee25aaf38c4bd955ab98a5b623c8294593c"
-dependencies = [
- "anyhow",
- "async-trait",
- "bincode",
- "bumpalo",
- "cfg-if",
- "fxprof-processed-profile",
- "indexmap 2.0.0",
- "libc",
- "log",
- "object",
- "once_cell",
- "paste",
- "psm",
- "rayon",
- "serde",
- "serde_derive",
- "serde_json",
- "target-lexicon",
- "wasm-encoder 0.32.0",
- "wasmparser 0.112.0",
- "wasmtime-cache 13.0.0",
- "wasmtime-component-macro 13.0.0",
- "wasmtime-cranelift 13.0.0",
- "wasmtime-environ 13.0.0",
- "wasmtime-fiber 13.0.0",
- "wasmtime-jit 13.0.0",
- "wasmtime-runtime 13.0.0",
- "wat",
- "windows-sys",
 ]
 
 [[package]]
@@ -3245,24 +2980,15 @@ dependencies = [
  "target-lexicon",
  "wasm-encoder 0.36.2",
  "wasmparser 0.116.1",
- "wasmtime-cache 15.0.0",
- "wasmtime-component-macro 15.0.0",
- "wasmtime-cranelift 15.0.0",
- "wasmtime-environ 15.0.0",
- "wasmtime-fiber 15.0.0",
- "wasmtime-jit 15.0.0",
- "wasmtime-runtime 15.0.0",
+ "wasmtime-cache",
+ "wasmtime-component-macro",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
+ "wasmtime-fiber",
+ "wasmtime-jit",
+ "wasmtime-runtime",
  "wat",
  "windows-sys",
-]
-
-[[package]]
-name = "wasmtime-asm-macros"
-version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53af0f8f6271bd687fe5632c8fe0a0f061d0aa1b99a0cd4e1df8e4cbeb809d2f"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -3272,26 +2998,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c981d0e87bb3e98e08e76644e7ae5dfdef7f1d4105145853f3d677bb4535d65f"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "wasmtime-cache"
-version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41376a7c094335ee08abe6a4eff79a32510cc805a249eff1b5e7adf0a42e7cdf"
-dependencies = [
- "anyhow",
- "base64",
- "bincode",
- "directories-next",
- "log",
- "rustix 0.38.25",
- "serde",
- "serde_derive",
- "sha2 0.10.7",
- "toml",
- "windows-sys",
- "zstd",
 ]
 
 [[package]]
@@ -3316,21 +3022,6 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ab5b291f2dad56f1e6929cc61fb7cac68845766ca77c3838b5d05d82c33976"
-dependencies = [
- "anyhow",
- "proc-macro2",
- "quote",
- "syn 2.0.33",
- "wasmtime-component-util 13.0.0",
- "wasmtime-wit-bindgen 13.0.0",
- "wit-parser 0.11.3",
-]
-
-[[package]]
-name = "wasmtime-component-macro"
 version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c91dcbbd0e1f094351d1ae0e53463c63ba53ec8f8e0e21d17567c1979a8c3758"
@@ -3339,16 +3030,10 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.33",
- "wasmtime-component-util 15.0.0",
- "wasmtime-wit-bindgen 15.0.0",
- "wit-parser 0.13.0",
+ "wasmtime-component-util",
+ "wasmtime-wit-bindgen",
+ "wit-parser",
 ]
-
-[[package]]
-name = "wasmtime-component-util"
-version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21436177bf19f6b60dc0b83ad5872e849892a4a90c3572785e1a28c0e2e1132c"
 
 [[package]]
 name = "wasmtime-component-util"
@@ -3358,68 +3043,27 @@ checksum = "3e85f1319a7ed36aa59446ab7e967d0c2fb0cd179bf56913633190b44572023e"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "920e42058862d1f7a3dd3fca73cb495a20d7506e3ada4bbc0a9780cd636da7ca"
-dependencies = [
- "anyhow",
- "cfg-if",
- "cranelift-codegen 0.100.0",
- "cranelift-control 0.100.0",
- "cranelift-entity 0.100.0",
- "cranelift-frontend 0.100.0",
- "cranelift-native 0.100.0",
- "cranelift-wasm 0.100.0",
- "gimli 0.28.0",
- "log",
- "object",
- "target-lexicon",
- "thiserror",
- "wasmparser 0.112.0",
- "wasmtime-cranelift-shared 13.0.0",
- "wasmtime-environ 13.0.0",
- "wasmtime-versioned-export-macros 13.0.0",
-]
-
-[[package]]
-name = "wasmtime-cranelift"
 version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1453665878e16245b9a25405e550c4a36c6731c6e34ea804edc002a38c3e6741"
 dependencies = [
  "anyhow",
  "cfg-if",
- "cranelift-codegen 0.102.0",
- "cranelift-control 0.102.0",
- "cranelift-entity 0.102.0",
- "cranelift-frontend 0.102.0",
- "cranelift-native 0.102.0",
- "cranelift-wasm 0.102.0",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "cranelift-wasm",
  "gimli 0.28.0",
  "log",
  "object",
  "target-lexicon",
  "thiserror",
  "wasmparser 0.116.1",
- "wasmtime-cranelift-shared 15.0.0",
- "wasmtime-environ 15.0.0",
- "wasmtime-versioned-export-macros 15.0.0",
-]
-
-[[package]]
-name = "wasmtime-cranelift-shared"
-version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516d63bbe18219e64a9705cf3a2c865afe1fb711454ea03091dc85a1d708194d"
-dependencies = [
- "anyhow",
- "cranelift-codegen 0.100.0",
- "cranelift-control 0.100.0",
- "cranelift-native 0.100.0",
- "gimli 0.28.0",
- "object",
- "target-lexicon",
- "wasmtime-environ 13.0.0",
+ "wasmtime-cranelift-shared",
+ "wasmtime-environ",
+ "wasmtime-versioned-export-macros",
 ]
 
 [[package]]
@@ -3429,33 +3073,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dface3d9b72b4670781ff72675eabb291e2836b5dded6bb312b577d2bb561f"
 dependencies = [
  "anyhow",
- "cranelift-codegen 0.102.0",
- "cranelift-control 0.102.0",
- "cranelift-native 0.102.0",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-native",
  "gimli 0.28.0",
  "object",
  "target-lexicon",
- "wasmtime-environ 15.0.0",
-]
-
-[[package]]
-name = "wasmtime-environ"
-version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cef239d663885f1427f8b8f4fde7be6075249c282580d94b480f11953ca194"
-dependencies = [
- "anyhow",
- "cranelift-entity 0.100.0",
- "gimli 0.28.0",
- "indexmap 2.0.0",
- "log",
- "object",
- "serde",
- "serde_derive",
- "target-lexicon",
- "thiserror",
- "wasmparser 0.112.0",
- "wasmtime-types 13.0.0",
+ "wasmtime-environ",
 ]
 
 [[package]]
@@ -3465,7 +3089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0116108e7d231cce15fe7dd642c66c3abb14dbcf169b0130e11f223ce8d1ad7"
 dependencies = [
  "anyhow",
- "cranelift-entity 0.102.0",
+ "cranelift-entity",
  "gimli 0.28.0",
  "indexmap 2.0.0",
  "log",
@@ -3475,21 +3099,7 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "wasmparser 0.116.1",
- "wasmtime-types 15.0.0",
-]
-
-[[package]]
-name = "wasmtime-fiber"
-version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef118b557df6193cd82cfb45ab57cd12388fedfe2bb76f090b2d77c96c1b56e"
-dependencies = [
- "cc",
- "cfg-if",
- "rustix 0.38.25",
- "wasmtime-asm-macros 13.0.0",
- "wasmtime-versioned-export-macros 13.0.0",
- "windows-sys",
+ "wasmtime-types",
 ]
 
 [[package]]
@@ -3502,35 +3112,8 @@ dependencies = [
  "cc",
  "cfg-if",
  "rustix 0.38.25",
- "wasmtime-asm-macros 15.0.0",
- "wasmtime-versioned-export-macros 15.0.0",
- "windows-sys",
-]
-
-[[package]]
-name = "wasmtime-jit"
-version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8089d5909b8f923aad57702ebaacb7b662aa9e43a3f71e83e025c5379a1205f"
-dependencies = [
- "addr2line",
- "anyhow",
- "bincode",
- "cfg-if",
- "cpp_demangle 0.3.5",
- "gimli 0.28.0",
- "ittapi 0.3.4",
- "log",
- "object",
- "rustc-demangle",
- "rustix 0.38.25",
- "serde",
- "serde_derive",
- "target-lexicon",
- "wasmtime-environ 13.0.0",
- "wasmtime-jit-debug 13.0.0",
- "wasmtime-jit-icache-coherence 13.0.0",
- "wasmtime-runtime 13.0.0",
+ "wasmtime-asm-macros",
+ "wasmtime-versioned-export-macros",
  "windows-sys",
 ]
 
@@ -3546,7 +3129,7 @@ dependencies = [
  "cfg-if",
  "cpp_demangle 0.3.5",
  "gimli 0.28.0",
- "ittapi 0.4.0",
+ "ittapi",
  "log",
  "object",
  "rustc-demangle",
@@ -3554,23 +3137,11 @@ dependencies = [
  "serde",
  "serde_derive",
  "target-lexicon",
- "wasmtime-environ 15.0.0",
- "wasmtime-jit-debug 15.0.0",
- "wasmtime-jit-icache-coherence 15.0.0",
- "wasmtime-runtime 15.0.0",
+ "wasmtime-environ",
+ "wasmtime-jit-debug",
+ "wasmtime-jit-icache-coherence",
+ "wasmtime-runtime",
  "windows-sys",
-]
-
-[[package]]
-name = "wasmtime-jit-debug"
-version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b13924aedf6799ad66edb25500a20e3226629978b30a958c55285352bad130a"
-dependencies = [
- "object",
- "once_cell",
- "rustix 0.38.25",
- "wasmtime-versioned-export-macros 13.0.0",
 ]
 
 [[package]]
@@ -3582,18 +3153,7 @@ dependencies = [
  "object",
  "once_cell",
  "rustix 0.38.25",
- "wasmtime-versioned-export-macros 15.0.0",
-]
-
-[[package]]
-name = "wasmtime-jit-icache-coherence"
-version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6ff5f3707a5e3797deeeeac6ac26b2e1dd32dbc06693c0ab52e8ac4d18ec706"
-dependencies = [
- "cfg-if",
- "libc",
- "windows-sys",
+ "wasmtime-versioned-export-macros",
 ]
 
 [[package]]
@@ -3604,35 +3164,6 @@ checksum = "b73ad1395eda136baec5ece7e079e0536a82ef73488e345456cc9b89858ad0ec"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "wasmtime-runtime"
-version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ab4ce04ac05342edfa7f42895f2a5d8b16ee914330869acb865cd1facf265f"
-dependencies = [
- "anyhow",
- "cc",
- "cfg-if",
- "indexmap 2.0.0",
- "libc",
- "log",
- "mach",
- "memfd",
- "memoffset 0.9.0",
- "paste",
- "rand 0.8.5",
- "rustix 0.38.25",
- "sptr",
- "wasm-encoder 0.32.0",
- "wasmtime-asm-macros 13.0.0",
- "wasmtime-environ 13.0.0",
- "wasmtime-fiber 13.0.0",
- "wasmtime-jit-debug 13.0.0",
- "wasmtime-versioned-export-macros 13.0.0",
- "wasmtime-wmemcheck 13.0.0",
  "windows-sys",
 ]
 
@@ -3656,26 +3187,13 @@ dependencies = [
  "rustix 0.38.25",
  "sptr",
  "wasm-encoder 0.36.2",
- "wasmtime-asm-macros 15.0.0",
- "wasmtime-environ 15.0.0",
- "wasmtime-fiber 15.0.0",
- "wasmtime-jit-debug 15.0.0",
- "wasmtime-versioned-export-macros 15.0.0",
- "wasmtime-wmemcheck 15.0.0",
+ "wasmtime-asm-macros",
+ "wasmtime-environ",
+ "wasmtime-fiber",
+ "wasmtime-jit-debug",
+ "wasmtime-versioned-export-macros",
+ "wasmtime-wmemcheck",
  "windows-sys",
-]
-
-[[package]]
-name = "wasmtime-types"
-version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecf61e21d5bd95e1ad7fa42b7bdabe21220682d6a6046d376edca29760849222"
-dependencies = [
- "cranelift-entity 0.100.0",
- "serde",
- "serde_derive",
- "thiserror",
- "wasmparser 0.112.0",
 ]
 
 [[package]]
@@ -3684,22 +3202,11 @@ version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447973db3dc5c24db14130ab0922795c58790aec296d198ad9d253b82ec67471"
 dependencies = [
- "cranelift-entity 0.102.0",
+ "cranelift-entity",
  "serde",
  "serde_derive",
  "thiserror",
  "wasmparser 0.116.1",
-]
-
-[[package]]
-name = "wasmtime-versioned-export-macros"
-version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe877472cbdd6d96b4ecdc112af764e3b9d58c2e4175a87828f892ab94c60643"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.33",
 ]
 
 [[package]]
@@ -3715,18 +3222,6 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62003d48822f89cc393e93643366ddbee1766779c0874353b8ba2ede4679fbf9"
-dependencies = [
- "anyhow",
- "heck 0.4.1",
- "indexmap 2.0.0",
- "wit-parser 0.11.3",
-]
-
-[[package]]
-name = "wasmtime-wit-bindgen"
 version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41786c7bbbf250c0e685b291323b50c6bb65f0505a2c0b4f0b598c740f13f185"
@@ -3734,14 +3229,8 @@ dependencies = [
  "anyhow",
  "heck 0.4.1",
  "indexmap 2.0.0",
- "wit-parser 0.13.0",
+ "wit-parser",
 ]
-
-[[package]]
-name = "wasmtime-wmemcheck"
-version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5412bb464066d64c3398c96e6974348f90fa2a55110ad7da3f9295438cd4de84"
 
 [[package]]
 name = "wasmtime-wmemcheck"
@@ -3885,24 +3374,6 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "wit-parser"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a39edca9abb16309def3843af73b58d47d243fe33a9ceee572446bcc57556b9a"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.0.0",
- "log",
- "pulldown-cmark",
- "semver 1.0.18",
- "serde",
- "serde_json",
- "unicode-xid",
- "url",
-]
 
 [[package]]
 name = "wit-parser"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,7 +438,7 @@ dependencies = [
  "rusqlite",
  "sha2 0.10.7",
  "walrus",
- "wasmtime",
+ "wasmtime 13.0.0",
  "wat",
 ]
 
@@ -454,7 +454,7 @@ dependencies = [
  "hex",
  "predicates",
  "wasmparser 0.110.0",
- "wasmtime",
+ "wasmtime 13.0.0",
 ]
 
 [[package]]
@@ -477,7 +477,7 @@ dependencies = [
  "slog",
  "stacks-common",
  "time 0.2.27",
- "wasmtime",
+ "wasmtime 15.0.0",
 ]
 
 [[package]]
@@ -540,7 +540,16 @@ version = "0.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03b9d1a9e776c27ad55d7792a380785d1fe8c2d7b099eed8dbd8f4af2b598192"
 dependencies = [
- "cranelift-entity",
+ "cranelift-entity 0.100.0",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76eb38f2af690b5a4411d9a8782b6d77dabff3ca939e0518453ab9f9a4392d41"
+dependencies = [
+ "cranelift-entity 0.102.0",
 ]
 
 [[package]]
@@ -550,12 +559,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5528483314c2dd5da438576cd8a9d0b3cedad66fb8a4727f90cd319a81950038"
 dependencies = [
  "bumpalo",
- "cranelift-bforest",
- "cranelift-codegen-meta",
- "cranelift-codegen-shared",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-isle",
+ "cranelift-bforest 0.100.0",
+ "cranelift-codegen-meta 0.100.0",
+ "cranelift-codegen-shared 0.100.0",
+ "cranelift-control 0.100.0",
+ "cranelift-entity 0.100.0",
+ "cranelift-isle 0.100.0",
+ "gimli 0.28.0",
+ "hashbrown 0.14.0",
+ "log",
+ "regalloc2",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39526c036b92912417e8931f52c1e235796688068d3efdbbd8b164f299d19156"
+dependencies = [
+ "bumpalo",
+ "cranelift-bforest 0.102.0",
+ "cranelift-codegen-meta 0.102.0",
+ "cranelift-codegen-shared 0.102.0",
+ "cranelift-control 0.102.0",
+ "cranelift-entity 0.102.0",
+ "cranelift-isle 0.102.0",
  "gimli 0.28.0",
  "hashbrown 0.14.0",
  "log",
@@ -570,7 +600,16 @@ version = "0.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f46a8318163f7682e35b8730ba93c1b586a2da8ce12a0ed545efc1218550f70"
 dependencies = [
- "cranelift-codegen-shared",
+ "cranelift-codegen-shared 0.100.0",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb0deedc9fccf2db53a5a3c9c9d0163e44143b0d004dca9bf6ab6a0024cd79a"
+dependencies = [
+ "cranelift-codegen-shared 0.102.0",
 ]
 
 [[package]]
@@ -580,10 +619,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37d1239cfd50eecfaed468d46943f8650e32969591868ad50111613704da6c70"
 
 [[package]]
+name = "cranelift-codegen-shared"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea2d1b274e45aa8e61e9103efa1ba82d4b5a19d12bd1fd10744c3b7380ba3ff"
+
+[[package]]
 name = "cranelift-control"
 version = "0.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc530560c8f16cc1d4dd7ea000c56f519c60d1a914977abe849ce555c35a61d"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-control"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea5977559a71e63db79a263f0e81a89b996e8a38212c4281e37dd1dbaa8b65c"
 dependencies = [
  "arbitrary",
 ]
@@ -599,12 +653,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "cranelift-entity"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f871ada808b58158d84dfc43a6a2e2d2756baaf4ed1c51fd969ca8330e6ca5c"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "cranelift-frontend"
 version = "0.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abf6563015a80f03f8bc4df307d0a81363f4eb73108df3a34f6e66fb6d5307"
 dependencies = [
- "cranelift-codegen",
+ "cranelift-codegen 0.100.0",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e6890f587ef59824b3debe577e68fdf9b307b3808c54b8d93a18fd0b70941b"
+dependencies = [
+ "cranelift-codegen 0.102.0",
  "log",
  "smallvec",
  "target-lexicon",
@@ -617,12 +693,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eb29d0edc8a5c029ed0f7ca77501f272738e3c410020b4a00f42ffe8ad2a8aa"
 
 [[package]]
+name = "cranelift-isle"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d5fc6d5d3b52d1917002b17a8ecce448c2621b5bf394bb4e77e2f676893537"
+
+[[package]]
 name = "cranelift-native"
 version = "0.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "006056a7fa920870bad06bf8e1b3033d70cbb7ee625b035efa9d90882a931868"
 dependencies = [
- "cranelift-codegen",
+ "cranelift-codegen 0.100.0",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-native"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e10c2e7faa65d4ae7de9a83b44f2c31aca7dc638e17d0a79572fdf8103d720b"
+dependencies = [
+ "cranelift-codegen 0.102.0",
  "libc",
  "target-lexicon",
 ]
@@ -633,14 +726,30 @@ version = "0.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b3d08c05f82903a1f6a04d89c4b9ecb47a4035710f89a39a21a147a80214672"
 dependencies = [
- "cranelift-codegen",
- "cranelift-entity",
- "cranelift-frontend",
+ "cranelift-codegen 0.100.0",
+ "cranelift-entity 0.100.0",
+ "cranelift-frontend 0.100.0",
  "itertools",
  "log",
  "smallvec",
  "wasmparser 0.112.0",
- "wasmtime-types",
+ "wasmtime-types 13.0.0",
+]
+
+[[package]]
+name = "cranelift-wasm"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2755807efc7ec80d1cc0b6815e70f10cedf968889f0469091dbff9c5c0741c48"
+dependencies = [
+ "cranelift-codegen 0.102.0",
+ "cranelift-entity 0.102.0",
+ "cranelift-frontend 0.102.0",
+ "itertools",
+ "log",
+ "smallvec",
+ "wasmparser 0.116.1",
+ "wasmtime-types 15.0.0",
 ]
 
 [[package]]
@@ -1378,7 +1487,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41e0d0b7b3b53d92a7e8b80ede3400112a6b8b4c98d1f5b8b16bb787c780582c"
 dependencies = [
  "anyhow",
- "ittapi-sys",
+ "ittapi-sys 0.3.4",
+ "log",
+]
+
+[[package]]
+name = "ittapi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b996fe614c41395cdaedf3cf408a9534851090959d90d54a535f675550b64b1"
+dependencies = [
+ "anyhow",
+ "ittapi-sys 0.4.0",
  "log",
 ]
 
@@ -1387,6 +1507,15 @@ name = "ittapi-sys"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f8763c96e54e6d6a0dccc2990d8b5e33e3313aaeae6185921a3f4c1614a77c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "ittapi-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5385394064fa2c886205dba02598013ce83d3e92d33dbdc0c52fe0e7bf4fc"
 dependencies = [
  "cc",
 ]
@@ -3044,6 +3173,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmparser"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
+dependencies = [
+ "indexmap 2.0.0",
+ "semver 1.0.18",
+]
+
+[[package]]
 name = "wasmtime"
 version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3069,13 +3208,50 @@ dependencies = [
  "target-lexicon",
  "wasm-encoder 0.32.0",
  "wasmparser 0.112.0",
- "wasmtime-cache",
- "wasmtime-component-macro",
- "wasmtime-cranelift",
- "wasmtime-environ",
- "wasmtime-fiber",
- "wasmtime-jit",
- "wasmtime-runtime",
+ "wasmtime-cache 13.0.0",
+ "wasmtime-component-macro 13.0.0",
+ "wasmtime-cranelift 13.0.0",
+ "wasmtime-environ 13.0.0",
+ "wasmtime-fiber 13.0.0",
+ "wasmtime-jit 13.0.0",
+ "wasmtime-runtime 13.0.0",
+ "wat",
+ "windows-sys",
+]
+
+[[package]]
+name = "wasmtime"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae4b1702ef55144d6f594085f4989dc71fb71a791be1c8354ecc8e489b81199b"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bincode",
+ "bumpalo",
+ "cfg-if",
+ "fxprof-processed-profile",
+ "indexmap 2.0.0",
+ "libc",
+ "log",
+ "object",
+ "once_cell",
+ "paste",
+ "psm",
+ "rayon",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-lexicon",
+ "wasm-encoder 0.36.2",
+ "wasmparser 0.116.1",
+ "wasmtime-cache 15.0.0",
+ "wasmtime-component-macro 15.0.0",
+ "wasmtime-cranelift 15.0.0",
+ "wasmtime-environ 15.0.0",
+ "wasmtime-fiber 15.0.0",
+ "wasmtime-jit 15.0.0",
+ "wasmtime-runtime 15.0.0",
  "wat",
  "windows-sys",
 ]
@@ -3085,6 +3261,15 @@ name = "wasmtime-asm-macros"
 version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53af0f8f6271bd687fe5632c8fe0a0f061d0aa1b99a0cd4e1df8e4cbeb809d2f"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-asm-macros"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c981d0e87bb3e98e08e76644e7ae5dfdef7f1d4105145853f3d677bb4535d65f"
 dependencies = [
  "cfg-if",
 ]
@@ -3110,6 +3295,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-cache"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7ba8adaa84fdb9dd659275edcf7fc5282c44b9c9f829986c71d44fd52ea80a"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bincode",
+ "directories-next",
+ "log",
+ "rustix 0.38.25",
+ "serde",
+ "serde_derive",
+ "sha2 0.10.7",
+ "toml",
+ "windows-sys",
+ "zstd",
+]
+
+[[package]]
 name = "wasmtime-component-macro"
 version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3119,9 +3324,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.33",
- "wasmtime-component-util",
- "wasmtime-wit-bindgen",
- "wit-parser",
+ "wasmtime-component-util 13.0.0",
+ "wasmtime-wit-bindgen 13.0.0",
+ "wit-parser 0.11.3",
+]
+
+[[package]]
+name = "wasmtime-component-macro"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91dcbbd0e1f094351d1ae0e53463c63ba53ec8f8e0e21d17567c1979a8c3758"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.33",
+ "wasmtime-component-util 15.0.0",
+ "wasmtime-wit-bindgen 15.0.0",
+ "wit-parser 0.13.0",
 ]
 
 [[package]]
@@ -3131,6 +3351,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21436177bf19f6b60dc0b83ad5872e849892a4a90c3572785e1a28c0e2e1132c"
 
 [[package]]
+name = "wasmtime-component-util"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e85f1319a7ed36aa59446ab7e967d0c2fb0cd179bf56913633190b44572023e"
+
+[[package]]
 name = "wasmtime-cranelift"
 version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3138,21 +3364,46 @@ checksum = "920e42058862d1f7a3dd3fca73cb495a20d7506e3ada4bbc0a9780cd636da7ca"
 dependencies = [
  "anyhow",
  "cfg-if",
- "cranelift-codegen",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-frontend",
- "cranelift-native",
- "cranelift-wasm",
+ "cranelift-codegen 0.100.0",
+ "cranelift-control 0.100.0",
+ "cranelift-entity 0.100.0",
+ "cranelift-frontend 0.100.0",
+ "cranelift-native 0.100.0",
+ "cranelift-wasm 0.100.0",
  "gimli 0.28.0",
  "log",
  "object",
  "target-lexicon",
  "thiserror",
  "wasmparser 0.112.0",
- "wasmtime-cranelift-shared",
- "wasmtime-environ",
- "wasmtime-versioned-export-macros",
+ "wasmtime-cranelift-shared 13.0.0",
+ "wasmtime-environ 13.0.0",
+ "wasmtime-versioned-export-macros 13.0.0",
+]
+
+[[package]]
+name = "wasmtime-cranelift"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1453665878e16245b9a25405e550c4a36c6731c6e34ea804edc002a38c3e6741"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen 0.102.0",
+ "cranelift-control 0.102.0",
+ "cranelift-entity 0.102.0",
+ "cranelift-frontend 0.102.0",
+ "cranelift-native 0.102.0",
+ "cranelift-wasm 0.102.0",
+ "gimli 0.28.0",
+ "log",
+ "object",
+ "target-lexicon",
+ "thiserror",
+ "wasmparser 0.116.1",
+ "wasmtime-cranelift-shared 15.0.0",
+ "wasmtime-environ 15.0.0",
+ "wasmtime-versioned-export-macros 15.0.0",
 ]
 
 [[package]]
@@ -3162,13 +3413,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "516d63bbe18219e64a9705cf3a2c865afe1fb711454ea03091dc85a1d708194d"
 dependencies = [
  "anyhow",
- "cranelift-codegen",
- "cranelift-control",
- "cranelift-native",
+ "cranelift-codegen 0.100.0",
+ "cranelift-control 0.100.0",
+ "cranelift-native 0.100.0",
  "gimli 0.28.0",
  "object",
  "target-lexicon",
- "wasmtime-environ",
+ "wasmtime-environ 13.0.0",
+]
+
+[[package]]
+name = "wasmtime-cranelift-shared"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dface3d9b72b4670781ff72675eabb291e2836b5dded6bb312b577d2bb561f"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen 0.102.0",
+ "cranelift-control 0.102.0",
+ "cranelift-native 0.102.0",
+ "gimli 0.28.0",
+ "object",
+ "target-lexicon",
+ "wasmtime-environ 15.0.0",
 ]
 
 [[package]]
@@ -3178,7 +3445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59cef239d663885f1427f8b8f4fde7be6075249c282580d94b480f11953ca194"
 dependencies = [
  "anyhow",
- "cranelift-entity",
+ "cranelift-entity 0.100.0",
  "gimli 0.28.0",
  "indexmap 2.0.0",
  "log",
@@ -3188,7 +3455,27 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "wasmparser 0.112.0",
- "wasmtime-types",
+ "wasmtime-types 13.0.0",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0116108e7d231cce15fe7dd642c66c3abb14dbcf169b0130e11f223ce8d1ad7"
+dependencies = [
+ "anyhow",
+ "cranelift-entity 0.102.0",
+ "gimli 0.28.0",
+ "indexmap 2.0.0",
+ "log",
+ "object",
+ "serde",
+ "serde_derive",
+ "target-lexicon",
+ "thiserror",
+ "wasmparser 0.116.1",
+ "wasmtime-types 15.0.0",
 ]
 
 [[package]]
@@ -3200,8 +3487,23 @@ dependencies = [
  "cc",
  "cfg-if",
  "rustix 0.38.25",
- "wasmtime-asm-macros",
- "wasmtime-versioned-export-macros",
+ "wasmtime-asm-macros 13.0.0",
+ "wasmtime-versioned-export-macros 13.0.0",
+ "windows-sys",
+]
+
+[[package]]
+name = "wasmtime-fiber"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a5896355c37bf0f9feb4f1299142ef4bed8c92576aa3a41d150fed0cafa056"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if",
+ "rustix 0.38.25",
+ "wasmtime-asm-macros 15.0.0",
+ "wasmtime-versioned-export-macros 15.0.0",
  "windows-sys",
 ]
 
@@ -3217,7 +3519,7 @@ dependencies = [
  "cfg-if",
  "cpp_demangle 0.3.5",
  "gimli 0.28.0",
- "ittapi",
+ "ittapi 0.3.4",
  "log",
  "object",
  "rustc-demangle",
@@ -3225,10 +3527,37 @@ dependencies = [
  "serde",
  "serde_derive",
  "target-lexicon",
- "wasmtime-environ",
- "wasmtime-jit-debug",
- "wasmtime-jit-icache-coherence",
- "wasmtime-runtime",
+ "wasmtime-environ 13.0.0",
+ "wasmtime-jit-debug 13.0.0",
+ "wasmtime-jit-icache-coherence 13.0.0",
+ "wasmtime-runtime 13.0.0",
+ "windows-sys",
+]
+
+[[package]]
+name = "wasmtime-jit"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e32b210767452f6b20157bb7c7d98295b92cc47aaad2a8aa31652f4469813a5d"
+dependencies = [
+ "addr2line",
+ "anyhow",
+ "bincode",
+ "cfg-if",
+ "cpp_demangle 0.3.5",
+ "gimli 0.28.0",
+ "ittapi 0.4.0",
+ "log",
+ "object",
+ "rustc-demangle",
+ "rustix 0.38.25",
+ "serde",
+ "serde_derive",
+ "target-lexicon",
+ "wasmtime-environ 15.0.0",
+ "wasmtime-jit-debug 15.0.0",
+ "wasmtime-jit-icache-coherence 15.0.0",
+ "wasmtime-runtime 15.0.0",
  "windows-sys",
 ]
 
@@ -3241,7 +3570,19 @@ dependencies = [
  "object",
  "once_cell",
  "rustix 0.38.25",
- "wasmtime-versioned-export-macros",
+ "wasmtime-versioned-export-macros 13.0.0",
+]
+
+[[package]]
+name = "wasmtime-jit-debug"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bffd2785a16c55ac77565613ebda625f5850d4014af0499df750e8de97c04547"
+dependencies = [
+ "object",
+ "once_cell",
+ "rustix 0.38.25",
+ "wasmtime-versioned-export-macros 15.0.0",
 ]
 
 [[package]]
@@ -3249,6 +3590,17 @@ name = "wasmtime-jit-icache-coherence"
 version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6ff5f3707a5e3797deeeeac6ac26b2e1dd32dbc06693c0ab52e8ac4d18ec706"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "wasmtime-jit-icache-coherence"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73ad1395eda136baec5ece7e079e0536a82ef73488e345456cc9b89858ad0ec"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3275,12 +3627,41 @@ dependencies = [
  "rustix 0.38.25",
  "sptr",
  "wasm-encoder 0.32.0",
- "wasmtime-asm-macros",
- "wasmtime-environ",
- "wasmtime-fiber",
- "wasmtime-jit-debug",
- "wasmtime-versioned-export-macros",
- "wasmtime-wmemcheck",
+ "wasmtime-asm-macros 13.0.0",
+ "wasmtime-environ 13.0.0",
+ "wasmtime-fiber 13.0.0",
+ "wasmtime-jit-debug 13.0.0",
+ "wasmtime-versioned-export-macros 13.0.0",
+ "wasmtime-wmemcheck 13.0.0",
+ "windows-sys",
+]
+
+[[package]]
+name = "wasmtime-runtime"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77b50f7f3c1a8dabb2607f32a81242917bd77cee75f3dec66e04b02ccbb8ba07"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if",
+ "indexmap 2.0.0",
+ "libc",
+ "log",
+ "mach",
+ "memfd",
+ "memoffset 0.9.0",
+ "paste",
+ "rand 0.8.5",
+ "rustix 0.38.25",
+ "sptr",
+ "wasm-encoder 0.36.2",
+ "wasmtime-asm-macros 15.0.0",
+ "wasmtime-environ 15.0.0",
+ "wasmtime-fiber 15.0.0",
+ "wasmtime-jit-debug 15.0.0",
+ "wasmtime-versioned-export-macros 15.0.0",
+ "wasmtime-wmemcheck 15.0.0",
  "windows-sys",
 ]
 
@@ -3290,7 +3671,7 @@ version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecf61e21d5bd95e1ad7fa42b7bdabe21220682d6a6046d376edca29760849222"
 dependencies = [
- "cranelift-entity",
+ "cranelift-entity 0.100.0",
  "serde",
  "serde_derive",
  "thiserror",
@@ -3298,10 +3679,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-types"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447973db3dc5c24db14130ab0922795c58790aec296d198ad9d253b82ec67471"
+dependencies = [
+ "cranelift-entity 0.102.0",
+ "serde",
+ "serde_derive",
+ "thiserror",
+ "wasmparser 0.116.1",
+]
+
+[[package]]
 name = "wasmtime-versioned-export-macros"
 version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe877472cbdd6d96b4ecdc112af764e3b9d58c2e4175a87828f892ab94c60643"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.33",
+]
+
+[[package]]
+name = "wasmtime-versioned-export-macros"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a347bb8ecf12275fb180afb1b1c85c9e186553c43109737bffed4f54c2aa365"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3317,7 +3722,19 @@ dependencies = [
  "anyhow",
  "heck 0.4.1",
  "indexmap 2.0.0",
- "wit-parser",
+ "wit-parser 0.11.3",
+]
+
+[[package]]
+name = "wasmtime-wit-bindgen"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41786c7bbbf250c0e685b291323b50c6bb65f0505a2c0b4f0b598c740f13f185"
+dependencies = [
+ "anyhow",
+ "heck 0.4.1",
+ "indexmap 2.0.0",
+ "wit-parser 0.13.0",
 ]
 
 [[package]]
@@ -3325,6 +3742,12 @@ name = "wasmtime-wmemcheck"
 version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5412bb464066d64c3398c96e6974348f90fa2a55110ad7da3f9295438cd4de84"
+
+[[package]]
+name = "wasmtime-wmemcheck"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47907bdd67500c66fa308acbce7387c7bfb63b5505ef81be7fc897709afcca60"
 
 [[package]]
 name = "wast"
@@ -3479,6 +3902,23 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "url",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15df6b7b28ce94b8be39d8df5cb21a08a4f3b9f33b631aedb4aa5776f785ead3"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.0.0",
+ "log",
+ "semver 1.0.18",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -193,3 +193,11 @@ Output `profile001.svg` preview:
 ![bench-protobuf-graph](docs/images/bench-protobuf-graph-example.png?raw=true)
 
 ## Contribute
+
+### Formatting
+
+To standardize the formatting of the code, we use rustfmt. To format your changes using the standard options, run:
+
+```sh
+cargo +nightly fmt-stacks
+```

--- a/clar2wasm/Cargo.toml
+++ b/clar2wasm/Cargo.toml
@@ -25,7 +25,7 @@ flamegraph = []
 pb = []
 
 [dev-dependencies]
-wasmtime = "13.0.0"
+wasmtime = "15.0.0"
 criterion = "0.5.1"
 proptest = "1.2.0"
 num-integer = { version = "0.1.45", default-features = false }

--- a/clar2wasm/Cargo.toml
+++ b/clar2wasm/Cargo.toml
@@ -14,7 +14,7 @@ lazy_static = "1.4.0"
 # For developer mode
 sha2 = { version = "0.10.7", optional = true }
 chrono = { version = "0.4.20", optional = true }
-rusqlite = { version = "0.27.0", optional = true }
+rusqlite = { version = "0.28.0", optional = true }
 
 [build-dependencies]
 wat = "1.0.74"

--- a/clar2wasm/benches/benchmark.rs
+++ b/clar2wasm/benches/benchmark.rs
@@ -1,21 +1,19 @@
+use std::borrow::BorrowMut;
+
 use clar2wasm::datastore::{BurnDatastore, Datastore, StacksConstants};
-use clarity::{
-    consts::CHAIN_ID_TESTNET,
-    types::StacksEpochId,
-    vm::{
-        analysis::{run_analysis, AnalysisDatabase},
-        ast::build_ast_with_diagnostics,
-        contexts::GlobalContext,
-        costs::LimitedCostTracker,
-        database::{ClarityDatabase, MemoryBackingStore},
-        eval_all,
-        types::{QualifiedContractIdentifier, StandardPrincipalData},
-        CallStack, ClarityVersion, ContractContext, ContractName, Environment, Value,
-    },
+use clarity::consts::CHAIN_ID_TESTNET;
+use clarity::types::StacksEpochId;
+use clarity::vm::analysis::{run_analysis, AnalysisDatabase};
+use clarity::vm::ast::build_ast_with_diagnostics;
+use clarity::vm::contexts::GlobalContext;
+use clarity::vm::costs::LimitedCostTracker;
+use clarity::vm::database::{ClarityDatabase, MemoryBackingStore};
+use clarity::vm::types::{QualifiedContractIdentifier, StandardPrincipalData};
+use clarity::vm::{
+    eval_all, CallStack, ClarityVersion, ContractContext, ContractName, Environment, Value,
 };
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use pprof::criterion::{Output, PProfProfiler};
-use std::borrow::BorrowMut;
 use wasmtime::{
     AsContextMut, Caller, Config, Engine, Extern, ExternRef, Func, Instance, Linker, Module, Store,
     Val,

--- a/clar2wasm/src/bin/main.rs
+++ b/clar2wasm/src/bin/main.rs
@@ -1,13 +1,12 @@
+use std::fs;
+
 use clap::Parser;
 use clar2wasm::CompileError;
-use clarity::{
-    types::StacksEpochId,
-    vm::{
-        costs::LimitedCostTracker, database::MemoryBackingStore,
-        types::QualifiedContractIdentifier, ClarityVersion,
-    },
-};
-use std::fs;
+use clarity::types::StacksEpochId;
+use clarity::vm::costs::LimitedCostTracker;
+use clarity::vm::database::MemoryBackingStore;
+use clarity::vm::types::QualifiedContractIdentifier;
+use clarity::vm::ClarityVersion;
 
 /// clar2wasm is a compiler for generating WebAssembly from Clarity.
 #[derive(Parser)]

--- a/clar2wasm/src/datastore.rs
+++ b/clar2wasm/src/datastore.rs
@@ -5,26 +5,21 @@
 //! `developer-mode` feature is enabled. Many of these methods are just
 //! mock implementations that do nothing.
 
-use clarity::types::chainstate::BlockHeaderHash;
-use clarity::types::chainstate::BurnchainHeaderHash;
-use clarity::types::chainstate::ConsensusHash;
-use clarity::types::chainstate::SortitionId;
-use clarity::types::chainstate::StacksAddress;
-use clarity::types::chainstate::StacksBlockId;
-use clarity::types::chainstate::VRFSeed;
+use std::collections::HashMap;
+
+use clarity::types::chainstate::{
+    BlockHeaderHash, BurnchainHeaderHash, ConsensusHash, SortitionId, StacksAddress, StacksBlockId,
+    VRFSeed,
+};
 use clarity::types::StacksEpochId;
 use clarity::util::hash::Sha512Trunc256Sum;
 use clarity::vm::analysis::AnalysisDatabase;
-use clarity::vm::database::BurnStateDB;
-use clarity::vm::database::{ClarityBackingStore, HeadersDB};
+use clarity::vm::database::{BurnStateDB, ClarityBackingStore, HeadersDB};
 use clarity::vm::errors::InterpreterResult as Result;
-use clarity::vm::types::QualifiedContractIdentifier;
-use clarity::vm::types::TupleData;
-use clarity::vm::StacksEpoch;
-use clarity::vm::Value;
+use clarity::vm::types::{QualifiedContractIdentifier, TupleData};
+use clarity::vm::{StacksEpoch, Value};
 use rusqlite::Connection;
 use sha2::{Digest, Sha512_256};
-use std::collections::HashMap;
 
 #[derive(Clone, Debug)]
 pub struct Datastore {

--- a/clar2wasm/src/datastore.rs
+++ b/clar2wasm/src/datastore.rs
@@ -22,6 +22,7 @@ use clarity::vm::types::QualifiedContractIdentifier;
 use clarity::vm::types::TupleData;
 use clarity::vm::StacksEpoch;
 use clarity::vm::Value;
+use rusqlite::Connection;
 use sha2::{Digest, Sha512_256};
 use std::collections::HashMap;
 
@@ -301,7 +302,7 @@ impl ClarityBackingStore for Datastore {
     }
 
     #[cfg(not(feature = "wasm"))]
-    fn get_side_store(&mut self) -> &::clarity::rusqlite::Connection {
+    fn get_side_store(&mut self) -> &Connection {
         panic!("Datastore cannot get_side_store")
     }
 }
@@ -465,6 +466,14 @@ impl BurnStateDB for BurnDatastore {
 
     /// Returns the height of the burnchain when the Stacks chain started running.
     fn get_burn_start_height(&self) -> u32 {
+        0
+    }
+
+    fn get_v3_unlock_height(&self) -> u32 {
+        0
+    }
+
+    fn get_pox_4_activation_height(&self) -> u32 {
         0
     }
 

--- a/clar2wasm/src/lib.rs
+++ b/clar2wasm/src/lib.rs
@@ -1,12 +1,12 @@
 extern crate lazy_static;
 
+use clarity::types::StacksEpochId;
 use clarity::vm::analysis::{run_analysis, AnalysisDatabase, ContractAnalysis};
+use clarity::vm::ast::build_ast_with_diagnostics;
 use clarity::vm::costs::{ExecutionCost, LimitedCostTracker};
 use clarity::vm::diagnostic::Diagnostic;
-use clarity::{
-    types::StacksEpochId,
-    vm::{ast::build_ast_with_diagnostics, types::QualifiedContractIdentifier, ClarityVersion},
-};
+use clarity::vm::types::QualifiedContractIdentifier;
+use clarity::vm::ClarityVersion;
 use walrus::Module;
 use wasm_generator::{GeneratorError, WasmGenerator};
 

--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -3,23 +3,21 @@
 //! in production. The `tools` module is only available when the
 //! `developer-mode` feature is enabled.
 
+use std::collections::HashMap;
+
+use clarity::consts::CHAIN_ID_TESTNET;
+use clarity::types::StacksEpochId;
+use clarity::vm::clarity_wasm::initialize_contract;
+use clarity::vm::contexts::GlobalContext;
+use clarity::vm::contracts::Contract;
+use clarity::vm::costs::LimitedCostTracker;
+use clarity::vm::database::ClarityDatabase;
+use clarity::vm::errors::Error;
+use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier, StandardPrincipalData};
+use clarity::vm::{ClarityVersion, ContractContext, Value};
+
 use crate::compile;
 use crate::datastore::{BurnDatastore, Datastore, StacksConstants};
-use clarity::vm::errors::Error;
-use clarity::{
-    consts::CHAIN_ID_TESTNET,
-    types::StacksEpochId,
-    vm::{
-        clarity_wasm::initialize_contract,
-        contexts::GlobalContext,
-        contracts::Contract,
-        costs::LimitedCostTracker,
-        database::ClarityDatabase,
-        types::{PrincipalData, QualifiedContractIdentifier, StandardPrincipalData},
-        ClarityVersion, ContractContext, Value,
-    },
-};
-use std::collections::HashMap;
 
 pub struct TestEnvironment {
     contract_contexts: HashMap<String, ContractContext>,

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -1,25 +1,23 @@
-use crate::words;
-use clarity::vm::clarity_wasm::{PRINCIPAL_BYTES, STANDARD_PRINCIPAL_BYTES};
-use clarity::vm::types::serialization::TypePrefix;
-use clarity::vm::types::{ListTypeData, TupleTypeSignature};
-use clarity::vm::{
-    analysis::ContractAnalysis,
-    clarity_wasm::{get_type_in_memory_size, get_type_size, is_in_memory_type},
-    diagnostic::DiagnosableError,
-    types::{
-        CharType, FunctionType, PrincipalData, SequenceData, SequenceSubtype, StringSubtype,
-        TypeSignature,
-    },
-    variables::NativeVariables,
-    ClarityName, SymbolicExpression, SymbolicExpressionType,
+use clarity::vm::analysis::ContractAnalysis;
+use clarity::vm::clarity_wasm::{
+    get_type_in_memory_size, get_type_size, is_in_memory_type, PRINCIPAL_BYTES,
+    STANDARD_PRINCIPAL_BYTES,
 };
-use std::{borrow::BorrowMut, collections::HashMap};
-use walrus::MemoryId;
+use clarity::vm::diagnostic::DiagnosableError;
+use clarity::vm::types::serialization::TypePrefix;
+use clarity::vm::types::{
+    CharType, FunctionType, ListTypeData, PrincipalData, SequenceData, SequenceSubtype,
+    StringSubtype, TupleTypeSignature, TypeSignature,
+};
+use clarity::vm::variables::NativeVariables;
+use clarity::vm::{ClarityName, SymbolicExpression, SymbolicExpressionType};
+use walrus::ir::{BinaryOp, IfElse, InstrSeqId, InstrSeqType, LoadKind, Loop, MemArg, StoreKind};
 use walrus::{
-    ir::{BinaryOp, IfElse, InstrSeqId, InstrSeqType, LoadKind, Loop, MemArg, StoreKind},
     ActiveData, DataKind, FunctionBuilder, FunctionId, GlobalId, InstrSeqBuilder, LocalId, Module,
     ValType,
 };
+
+use crate::words;
 
 /// First free position after data directly defined in standard.wat
 pub const END_OF_STANDARD_DATA: u32 = 648;

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -1,3 +1,6 @@
+use std::borrow::BorrowMut;
+use std::collections::HashMap;
+
 use clarity::vm::analysis::ContractAnalysis;
 use clarity::vm::clarity_wasm::{
     get_type_in_memory_size, get_type_size, is_in_memory_type, PRINCIPAL_BYTES,
@@ -13,8 +16,8 @@ use clarity::vm::variables::NativeVariables;
 use clarity::vm::{ClarityName, SymbolicExpression, SymbolicExpressionType};
 use walrus::ir::{BinaryOp, IfElse, InstrSeqId, InstrSeqType, LoadKind, Loop, MemArg, StoreKind};
 use walrus::{
-    ActiveData, DataKind, FunctionBuilder, FunctionId, GlobalId, InstrSeqBuilder, LocalId, Module,
-    ValType,
+    ActiveData, DataKind, FunctionBuilder, FunctionId, GlobalId, InstrSeqBuilder, LocalId,
+    MemoryId, Module, ValType,
 };
 
 use crate::words;

--- a/clar2wasm/src/words/arithmetic.rs
+++ b/clar2wasm/src/words/arithmetic.rs
@@ -1,7 +1,8 @@
-use crate::wasm_generator::{GeneratorError, WasmGenerator};
-use clarity::vm::{types::TypeSignature, ClarityName, SymbolicExpression};
+use clarity::vm::types::TypeSignature;
+use clarity::vm::{ClarityName, SymbolicExpression};
 
 use super::Word;
+use crate::wasm_generator::{GeneratorError, WasmGenerator};
 
 // Wrapper function for multi-value typed functions, such as +, - etc
 pub fn traverse_typed_multi_value(

--- a/clar2wasm/src/words/bindings.rs
+++ b/clar2wasm/src/words/bindings.rs
@@ -1,7 +1,7 @@
-use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 use clarity::vm::{ClarityName, SymbolicExpression};
 
 use super::Word;
+use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 
 #[derive(Debug)]
 pub struct Let;

--- a/clar2wasm/src/words/bitwise.rs
+++ b/clar2wasm/src/words/bitwise.rs
@@ -1,8 +1,9 @@
-use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
-use clarity::vm::{types::TypeSignature, ClarityName, SymbolicExpression};
+use clarity::vm::types::TypeSignature;
+use clarity::vm::{ClarityName, SymbolicExpression};
 use walrus::InstrSeqBuilder;
 
 use super::Word;
+use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 
 #[derive(Debug)]
 pub struct BitwiseNot;

--- a/clar2wasm/src/words/blockinfo.rs
+++ b/clar2wasm/src/words/blockinfo.rs
@@ -310,7 +310,7 @@ mod tests {
                     TupleData::from_data(vec![
                         (
                             "addrs".into(),
-                            Value::list_from(vec![TupleData::from_data(vec![
+                            Value::cons_list_unsanitized(vec![TupleData::from_data(vec![
                                 (
                                     "hashbytes".into(),
                                     Value::buff_from([0; 32].to_vec()).unwrap()

--- a/clar2wasm/src/words/blockinfo.rs
+++ b/clar2wasm/src/words/blockinfo.rs
@@ -1,8 +1,7 @@
-use crate::wasm_generator::ArgumentsExt;
-use crate::wasm_generator::{GeneratorError, WasmGenerator};
 use clarity::vm::{ClarityName, SymbolicExpression};
 
 use super::Word;
+use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 
 #[derive(Debug)]
 pub struct GetBlockInfo;
@@ -140,10 +139,8 @@ impl Word for AtBlock {
 
 #[cfg(test)]
 mod tests {
-    use clarity::vm::{
-        types::{OptionalData, PrincipalData, TupleData},
-        Value,
-    };
+    use clarity::vm::types::{OptionalData, PrincipalData, TupleData};
+    use clarity::vm::Value;
 
     use crate::tools::{evaluate, TestEnvironment};
 

--- a/clar2wasm/src/words/comparison.rs
+++ b/clar2wasm/src/words/comparison.rs
@@ -1,10 +1,8 @@
-use crate::wasm_generator::{GeneratorError, WasmGenerator};
-use clarity::vm::{
-    types::{SequenceSubtype, StringSubtype, TypeSignature},
-    ClarityName, SymbolicExpression,
-};
+use clarity::vm::types::{SequenceSubtype, StringSubtype, TypeSignature};
+use clarity::vm::{ClarityName, SymbolicExpression};
 
 use super::Word;
+use crate::wasm_generator::{GeneratorError, WasmGenerator};
 
 fn traverse_comparison(
     name: &str,

--- a/clar2wasm/src/words/conditionals.rs
+++ b/clar2wasm/src/words/conditionals.rs
@@ -1,17 +1,12 @@
+use clarity::vm::types::{SequenceSubtype, TypeSignature};
+use clarity::vm::{ClarityName, SymbolicExpression};
+use walrus::ir::{self, InstrSeqType};
+use walrus::ValType;
+
+use super::Word;
 use crate::wasm_generator::{
     clar2wasm_ty, drop_value, ArgumentsExt, GeneratorError, WasmGenerator,
 };
-
-use clarity::vm::{
-    types::{SequenceSubtype, TypeSignature},
-    ClarityName, SymbolicExpression,
-};
-use walrus::{
-    ir::{self, InstrSeqType},
-    ValType,
-};
-
-use super::Word;
 
 #[derive(Debug)]
 pub struct If;
@@ -442,8 +437,9 @@ impl Word for Unwrap {
 
 #[cfg(test)]
 mod tests {
-    use crate::tools::evaluate as eval;
     use clarity::vm::Value;
+
+    use crate::tools::evaluate as eval;
 
     #[test]
     fn trivial() {

--- a/clar2wasm/src/words/consensus_buff.rs
+++ b/clar2wasm/src/words/consensus_buff.rs
@@ -1,9 +1,8 @@
 use clarity::vm::types::MAX_VALUE_SIZE;
 use walrus::ir::InstrSeqType;
 
-use crate::wasm_generator::ArgumentsExt;
-
 use super::Word;
+use crate::wasm_generator::ArgumentsExt;
 
 #[derive(Debug)]
 pub struct ToConsensusBuf;
@@ -74,10 +73,8 @@ impl Word for ToConsensusBuf {
 
 #[cfg(test)]
 mod tests {
-    use clarity::vm::{
-        types::{BuffData, SequenceData},
-        Value,
-    };
+    use clarity::vm::types::{BuffData, SequenceData};
+    use clarity::vm::Value;
     use hex::FromHex as _;
 
     use crate::tools::evaluate;

--- a/clar2wasm/src/words/constants.rs
+++ b/clar2wasm/src/words/constants.rs
@@ -1,11 +1,9 @@
-use crate::wasm_generator::ArgumentsExt;
-use crate::wasm_generator::{GeneratorError, WasmGenerator};
-use clarity::vm::{
-    clarity_wasm::get_type_in_memory_size, ClarityName, SymbolicExpression, SymbolicExpressionType,
-};
+use clarity::vm::clarity_wasm::get_type_in_memory_size;
+use clarity::vm::{ClarityName, SymbolicExpression, SymbolicExpressionType};
 use walrus::ValType;
 
 use super::Word;
+use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 
 #[derive(Debug)]
 pub struct DefineConstant;

--- a/clar2wasm/src/words/contract.rs
+++ b/clar2wasm/src/words/contract.rs
@@ -1,10 +1,9 @@
-use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
-use clarity::vm::{
-    types::PrincipalData, ClarityName, SymbolicExpression, SymbolicExpressionType, Value,
-};
+use clarity::vm::types::PrincipalData;
+use clarity::vm::{ClarityName, SymbolicExpression, SymbolicExpressionType, Value};
 use walrus::ValType;
 
 use super::Word;
+use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 
 #[derive(Debug)]
 pub struct AsContract;

--- a/clar2wasm/src/words/control_flow.rs
+++ b/clar2wasm/src/words/control_flow.rs
@@ -1,8 +1,9 @@
-use crate::wasm_generator::{drop_value, ArgumentsExt, GeneratorError, WasmGenerator};
-use clarity::vm::{types::TypeSignature, ClarityName, SymbolicExpression};
+use clarity::vm::types::TypeSignature;
+use clarity::vm::{ClarityName, SymbolicExpression};
 use walrus::ir::{InstrSeqType, UnaryOp};
 
 use super::Word;
+use crate::wasm_generator::{drop_value, ArgumentsExt, GeneratorError, WasmGenerator};
 
 /// `Trap` should match the values used in the standard library and is used to
 /// indicate the reason for a runtime error from the Clarity code.

--- a/clar2wasm/src/words/conversion.rs
+++ b/clar2wasm/src/words/conversion.rs
@@ -1,8 +1,7 @@
 use clarity::vm::types::TypeSignature;
 
-use crate::wasm_generator::{ArgumentsExt, GeneratorError};
-
 use super::Word;
+use crate::wasm_generator::{ArgumentsExt, GeneratorError};
 
 #[derive(Debug)]
 pub struct StringToInt;
@@ -93,10 +92,8 @@ impl Word for IntToAscii {
 
 #[cfg(test)]
 mod tests {
-    use clarity::vm::{
-        types::{ASCIIData, CharType, SequenceData},
-        Value,
-    };
+    use clarity::vm::types::{ASCIIData, CharType, SequenceData};
+    use clarity::vm::Value;
 
     use crate::tools::evaluate;
 

--- a/clar2wasm/src/words/data_vars.rs
+++ b/clar2wasm/src/words/data_vars.rs
@@ -1,9 +1,8 @@
-use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 use clarity::vm::{ClarityName, SymbolicExpression};
-
 use walrus::ValType;
 
 use super::Word;
+use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 
 #[derive(Debug)]
 pub struct DefineDataVar;

--- a/clar2wasm/src/words/default_to.rs
+++ b/clar2wasm/src/words/default_to.rs
@@ -1,11 +1,12 @@
+use clarity::vm::types::TypeSignature;
+use clarity::vm::{ClarityName, SymbolicExpression};
+use walrus::ir::InstrSeqType;
+
+use super::Word;
 use crate::wasm_generator::{
     add_placeholder_for_clarity_type, clar2wasm_ty, drop_value, ArgumentsExt, GeneratorError,
     WasmGenerator,
 };
-use clarity::vm::{types::TypeSignature, ClarityName, SymbolicExpression};
-use walrus::ir::InstrSeqType;
-
-use super::Word;
 
 #[derive(Debug)]
 pub struct DefaultTo;

--- a/clar2wasm/src/words/enums.rs
+++ b/clar2wasm/src/words/enums.rs
@@ -1,9 +1,10 @@
+use clarity::vm::types::TypeSignature;
+use clarity::vm::{ClarityName, SymbolicExpression};
+
+use super::Word;
 use crate::wasm_generator::{
     add_placeholder_for_type, clar2wasm_ty, ArgumentsExt, GeneratorError, WasmGenerator,
 };
-use clarity::vm::{types::TypeSignature, ClarityName, SymbolicExpression};
-
-use super::Word;
 
 #[derive(Debug)]
 pub struct ClaritySome;

--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -1,19 +1,13 @@
+use clarity::vm::types::signatures::CallableSubtype;
+use clarity::vm::types::{SequenceSubtype, StringSubtype, TupleTypeSignature, TypeSignature};
+use clarity::vm::{ClarityName, SymbolicExpression};
+use walrus::ir::{BinaryOp, IfElse, Loop, UnaryOp};
+use walrus::{InstrSeqBuilder, LocalId, ValType};
+
+use super::Word;
 use crate::wasm_generator::{
     clar2wasm_ty, drop_value, ArgumentsExt, GeneratorError, WasmGenerator,
 };
-use clarity::vm::{
-    types::{
-        signatures::CallableSubtype, SequenceSubtype, StringSubtype, TupleTypeSignature,
-        TypeSignature,
-    },
-    ClarityName, SymbolicExpression,
-};
-use walrus::{
-    ir::{BinaryOp, IfElse, Loop, UnaryOp},
-    InstrSeqBuilder, LocalId, ValType,
-};
-
-use super::Word;
 
 #[derive(Debug)]
 pub struct IsEq;

--- a/clar2wasm/src/words/functions.rs
+++ b/clar2wasm/src/words/functions.rs
@@ -1,7 +1,8 @@
-use crate::wasm_generator::{ArgumentsExt, FunctionKind, GeneratorError, WasmGenerator};
-use clarity::vm::{representations::Span, ClarityName, SymbolicExpression};
+use clarity::vm::representations::Span;
+use clarity::vm::{ClarityName, SymbolicExpression};
 
 use super::Word;
+use crate::wasm_generator::{ArgumentsExt, FunctionKind, GeneratorError, WasmGenerator};
 
 #[derive(Clone)]
 pub struct TypedVar<'a> {

--- a/clar2wasm/src/words/hashing.rs
+++ b/clar2wasm/src/words/hashing.rs
@@ -1,10 +1,8 @@
-use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
-use clarity::vm::{
-    types::{SequenceSubtype, TypeSignature, BUFF_32, BUFF_64},
-    ClarityName, SymbolicExpression,
-};
+use clarity::vm::types::{SequenceSubtype, TypeSignature, BUFF_32, BUFF_64};
+use clarity::vm::{ClarityName, SymbolicExpression};
 
 use super::Word;
+use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 
 pub fn traverse_hash(
     name: &'static str,

--- a/clar2wasm/src/words/logical.rs
+++ b/clar2wasm/src/words/logical.rs
@@ -1,7 +1,7 @@
-use crate::wasm_generator::{GeneratorError, WasmGenerator};
 use clarity::vm::{ClarityName, SymbolicExpression};
 
 use super::Word;
+use crate::wasm_generator::{GeneratorError, WasmGenerator};
 
 #[derive(Debug)]
 pub struct Not;

--- a/clar2wasm/src/words/maps.rs
+++ b/clar2wasm/src/words/maps.rs
@@ -1,7 +1,7 @@
-use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 use clarity::vm::{ClarityName, SymbolicExpression};
 
 use super::Word;
+use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 
 #[derive(Debug)]
 pub struct MapDefinition;

--- a/clar2wasm/src/words/mod.rs
+++ b/clar2wasm/src/words/mod.rs
@@ -1,10 +1,10 @@
+use std::collections::HashMap;
+
+use clarity::vm::{ClarityName, SymbolicExpression};
+use lazy_static::lazy_static;
 use walrus::InstrSeqBuilder;
 
 use crate::{GeneratorError, WasmGenerator};
-use clarity::vm::{ClarityName, SymbolicExpression};
-
-use lazy_static::lazy_static;
-use std::collections::HashMap;
 
 pub mod arithmetic;
 pub mod bindings;
@@ -180,10 +180,9 @@ pub fn lookup(name: &str) -> Option<&'static dyn Word> {
 
 #[cfg(test)]
 mod tests {
-    use clarity::vm::{
-        functions::{define::DefineFunctions, NativeFunctions},
-        variables::NativeVariables,
-    };
+    use clarity::vm::functions::define::DefineFunctions;
+    use clarity::vm::functions::NativeFunctions;
+    use clarity::vm::variables::NativeVariables;
 
     #[test]
     fn check_for_duplicates() {

--- a/clar2wasm/src/words/noop.rs
+++ b/clar2wasm/src/words/noop.rs
@@ -1,7 +1,7 @@
-use crate::wasm_generator::{GeneratorError, WasmGenerator};
 use clarity::vm::{ClarityName, SymbolicExpression};
 
 use super::Word;
+use crate::wasm_generator::{GeneratorError, WasmGenerator};
 
 // Functions below are considered no-op's because they are instructions that does nothing
 // or has no effect when executed.
@@ -78,12 +78,10 @@ impl Word for ContractOf {
 
 #[cfg(test)]
 mod tests {
-    use crate::tools::evaluate as eval;
-    use crate::tools::TestEnvironment;
-    use clarity::vm::{
-        types::{PrincipalData, QualifiedContractIdentifier},
-        Value,
-    };
+    use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier};
+    use clarity::vm::Value;
+
+    use crate::tools::{evaluate as eval, TestEnvironment};
 
     #[test]
     #[should_panic]

--- a/clar2wasm/src/words/options.rs
+++ b/clar2wasm/src/words/options.rs
@@ -1,8 +1,9 @@
-use crate::wasm_generator::{drop_value, ArgumentsExt, GeneratorError, WasmGenerator};
-use clarity::vm::{types::TypeSignature, ClarityName, SymbolicExpression};
+use clarity::vm::types::TypeSignature;
+use clarity::vm::{ClarityName, SymbolicExpression};
 use walrus::ir::BinaryOp;
 
 use super::Word;
+use crate::wasm_generator::{drop_value, ArgumentsExt, GeneratorError, WasmGenerator};
 
 pub fn traverse_optional(
     generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/principal.rs
+++ b/clar2wasm/src/words/principal.rs
@@ -1,13 +1,11 @@
 use clarity::{
-    address::{
-        C32_ADDRESS_VERSION_MAINNET_MULTISIG, C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
-        C32_ADDRESS_VERSION_TESTNET_MULTISIG, C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
-    },
     vm::{
         clarity_wasm::STANDARD_PRINCIPAL_BYTES,
         types::{signatures::ASCII_40, TypeSignature, BUFF_1, BUFF_20},
         ClarityName, SymbolicExpression,
     },
+    C32_ADDRESS_VERSION_MAINNET_MULTISIG, C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
+    C32_ADDRESS_VERSION_TESTNET_MULTISIG, C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
 };
 use walrus::{
     ir::{BinaryOp, ExtendedLoad, InstrSeqType, LoadKind, MemArg},

--- a/clar2wasm/src/words/principal.rs
+++ b/clar2wasm/src/words/principal.rs
@@ -1,22 +1,18 @@
+use clarity::vm::clarity_wasm::STANDARD_PRINCIPAL_BYTES;
+use clarity::vm::types::signatures::ASCII_40;
+use clarity::vm::types::{TypeSignature, BUFF_1, BUFF_20};
+use clarity::vm::{ClarityName, SymbolicExpression};
 use clarity::{
-    vm::{
-        clarity_wasm::STANDARD_PRINCIPAL_BYTES,
-        types::{signatures::ASCII_40, TypeSignature, BUFF_1, BUFF_20},
-        ClarityName, SymbolicExpression,
-    },
     C32_ADDRESS_VERSION_MAINNET_MULTISIG, C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
     C32_ADDRESS_VERSION_TESTNET_MULTISIG, C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
 };
-use walrus::{
-    ir::{BinaryOp, ExtendedLoad, InstrSeqType, LoadKind, MemArg},
-    LocalId, ValType,
-};
+use walrus::ir::{BinaryOp, ExtendedLoad, InstrSeqType, LoadKind, MemArg};
+use walrus::{LocalId, ValType};
 
+use super::Word;
 use crate::wasm_generator::{
     add_placeholder_for_clarity_type, clar2wasm_ty, ArgumentsExt, GeneratorError, WasmGenerator,
 };
-
-use super::Word;
 
 #[derive(Debug)]
 pub struct IsStandard;
@@ -306,13 +302,9 @@ impl Word for PrincipalOf {
 
 #[cfg(test)]
 mod tests {
-    use clarity::{
-        types::StacksEpochId,
-        vm::{
-            types::{PrincipalData, TupleData},
-            ClarityVersion, Value,
-        },
-    };
+    use clarity::types::StacksEpochId;
+    use clarity::vm::types::{PrincipalData, TupleData};
+    use clarity::vm::{ClarityVersion, Value};
 
     use crate::tools::{evaluate, TestEnvironment};
 

--- a/clar2wasm/src/words/print.rs
+++ b/clar2wasm/src/words/print.rs
@@ -1,8 +1,8 @@
-use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 use clarity::vm::{ClarityName, SymbolicExpression};
 use walrus::ValType;
 
 use super::Word;
+use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 
 #[derive(Debug)]
 pub struct Print;

--- a/clar2wasm/src/words/responses.rs
+++ b/clar2wasm/src/words/responses.rs
@@ -1,8 +1,9 @@
-use crate::wasm_generator::{drop_value, ArgumentsExt, GeneratorError, WasmGenerator};
-use clarity::vm::{types::TypeSignature, ClarityName, SymbolicExpression};
+use clarity::vm::types::TypeSignature;
+use clarity::vm::{ClarityName, SymbolicExpression};
 use walrus::ir::BinaryOp;
 
 use super::Word;
+use crate::wasm_generator::{drop_value, ArgumentsExt, GeneratorError, WasmGenerator};
 
 pub fn traverse_response(
     generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/secp256k1.rs
+++ b/clar2wasm/src/words/secp256k1.rs
@@ -1,8 +1,7 @@
 use clarity::vm::{ClarityName, SymbolicExpression};
 
-use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
-
 use super::Word;
+use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 
 #[derive(Debug)]
 pub struct Recover;

--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -1,19 +1,14 @@
-use clarity::vm::{
-    clarity_wasm::get_type_size,
-    types::{SequenceSubtype, StringSubtype, TypeSignature},
-    ClarityName, SymbolicExpression,
-};
-use walrus::{
-    ir::{BinaryOp, InstrSeqType, UnaryOp},
-    ValType,
-};
+use clarity::vm::clarity_wasm::get_type_size;
+use clarity::vm::types::{SequenceSubtype, StringSubtype, TypeSignature};
+use clarity::vm::{ClarityName, SymbolicExpression};
+use walrus::ir::{BinaryOp, InstrSeqType, UnaryOp};
+use walrus::ValType;
 
+use super::Word;
 use crate::wasm_generator::{
     add_placeholder_for_clarity_type, clar2wasm_ty, drop_value, ArgumentsExt, GeneratorError,
     WasmGenerator,
 };
-
-use super::Word;
 
 #[derive(Debug)]
 pub struct ListCons;

--- a/clar2wasm/src/words/stx.rs
+++ b/clar2wasm/src/words/stx.rs
@@ -1,7 +1,7 @@
-use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 use clarity::vm::{ClarityName, SymbolicExpression};
 
 use super::Word;
+use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 
 #[derive(Debug)]
 pub struct StxBurn;

--- a/clar2wasm/src/words/tokens.rs
+++ b/clar2wasm/src/words/tokens.rs
@@ -1,7 +1,8 @@
-use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
-use clarity::vm::{types::TypeSignature, ClarityName, SymbolicExpression};
+use clarity::vm::types::TypeSignature;
+use clarity::vm::{ClarityName, SymbolicExpression};
 
 use super::Word;
+use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 
 #[derive(Debug)]
 pub struct DefineFungibleToken;

--- a/clar2wasm/src/words/traits.rs
+++ b/clar2wasm/src/words/traits.rs
@@ -1,7 +1,7 @@
-use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 use clarity::vm::{ClarityName, SymbolicExpression, SymbolicExpressionType};
 
 use super::Word;
+use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 
 #[derive(Debug)]
 pub struct DefineTrait;
@@ -105,10 +105,8 @@ impl Word for ImplTrait {
 
 #[cfg(test)]
 mod tests {
-    use clarity::vm::{
-        types::{StandardPrincipalData, TraitIdentifier},
-        Value,
-    };
+    use clarity::vm::types::{StandardPrincipalData, TraitIdentifier};
+    use clarity::vm::Value;
 
     use crate::tools::{evaluate, TestEnvironment};
 

--- a/clar2wasm/src/words/tuples.rs
+++ b/clar2wasm/src/words/tuples.rs
@@ -1,5 +1,7 @@
-use clarity::vm::{types::TypeSignature, ClarityName, SymbolicExpression};
 use std::collections::{BTreeMap, HashMap};
+
+use clarity::vm::types::TypeSignature;
+use clarity::vm::{ClarityName, SymbolicExpression};
 
 use super::Word;
 use crate::wasm_generator::{clar2wasm_ty, drop_value, GeneratorError, WasmGenerator};

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -1,4 +1,5 @@
-use std::{cell::RefCell, ops::DerefMut};
+use std::cell::RefCell;
+use std::ops::DerefMut;
 
 use clar2wasm::wasm_generator::END_OF_STANDARD_DATA;
 use clarity::util::hash::{Hash160, Sha256Sum};

--- a/clar2wasm/tests/standard/utils.rs
+++ b/clar2wasm/tests/standard/utils.rs
@@ -1,10 +1,10 @@
+use std::cell::RefCell;
+use std::ops::{Deref, DerefMut};
+
 use clar2wasm::wasm_generator::END_OF_STANDARD_DATA;
 use hex::ToHex;
 use proptest::prelude::*;
-use std::ops::Deref;
-use std::{cell::RefCell, ops::DerefMut};
-use wasmtime::Val;
-use wasmtime::{Caller, Engine, Instance, Linker, Module, Store};
+use wasmtime::{Caller, Engine, Instance, Linker, Module, Store, Val};
 
 /// Load the standard library into a Wasmtime instance. This is used to load in
 /// the standard.wat file and link in all of the host interface functions.

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -8,8 +8,8 @@ path = "./src/lib.rs"
 
 [dependencies]
 clarity = { path = "../stacks-blockchain/clarity" }
-clar2wasm = { path = "../clar2wasm", features = ["developer-mode"]}
-wasmtime = "13.0.0"
+clar2wasm = { path = "../clar2wasm", features = ["developer-mode"] }
+wasmtime = "15.0.0"
 
 [[bench]]
 name = "benchmark"

--- a/tests/benches/benchmark.rs
+++ b/tests/benches/benchmark.rs
@@ -1,20 +1,16 @@
 use clar2wasm::compile;
 use clar2wasm::datastore::{BurnDatastore, Datastore, StacksConstants};
+use clarity::consts::CHAIN_ID_TESTNET;
+use clarity::types::StacksEpochId;
 use clarity::vm::analysis::{run_analysis, AnalysisDatabase};
 use clarity::vm::ast::build_ast_with_diagnostics;
 use clarity::vm::clarity_wasm::{call_function, initialize_contract};
-use clarity::vm::database::MemoryBackingStore;
-use clarity::vm::{eval_all, CallStack, Environment, Value};
-use clarity::{
-    consts::CHAIN_ID_TESTNET,
-    types::StacksEpochId,
-    vm::{
-        contexts::GlobalContext,
-        costs::LimitedCostTracker,
-        database::ClarityDatabase,
-        types::{QualifiedContractIdentifier, StandardPrincipalData},
-        ClarityVersion, ContractContext, ContractName,
-    },
+use clarity::vm::contexts::GlobalContext;
+use clarity::vm::costs::LimitedCostTracker;
+use clarity::vm::database::{ClarityDatabase, MemoryBackingStore};
+use clarity::vm::types::{QualifiedContractIdentifier, StandardPrincipalData};
+use clarity::vm::{
+    eval_all, CallStack, ClarityVersion, ContractContext, ContractName, Environment, Value,
 };
 use criterion::{criterion_group, criterion_main, Criterion};
 

--- a/tests/benches/benchmark.rs
+++ b/tests/benches/benchmark.rs
@@ -67,7 +67,7 @@ fn wasm_fold_add_square(c: &mut Criterion) {
 
         let mut call_stack = CallStack::new();
 
-        let list = Value::list_from((1..=8192).map(Value::Int).collect())
+        let list = Value::cons_list_unsanitized((1..=8192).map(Value::Int).collect())
             .expect("failed to construct list argument");
 
         let result = call_function(
@@ -183,7 +183,7 @@ fn interp_fold_add_square(c: &mut Criterion) {
             None,
         );
 
-        let list = Value::list_from((1..=8192).map(Value::Int).collect())
+        let list = Value::cons_list_unsanitized((1..=8192).map(Value::Int).collect())
             .expect("failed to construct list argument");
 
         // Run once outside of benchmark to test the result

--- a/tests/src/lib_tests.rs
+++ b/tests/src/lib_tests.rs
@@ -1,27 +1,23 @@
+use std::collections::HashMap;
+
 use clar2wasm::compile;
 use clar2wasm::datastore::{BurnDatastore, StacksConstants};
-use clarity::vm::types::TupleData;
-use clarity::{
-    consts::CHAIN_ID_TESTNET,
-    types::StacksEpochId,
-    vm::{
-        callables::DefineType,
-        clarity_wasm::{call_function, initialize_contract},
-        contexts::{CallStack, EventBatch, GlobalContext},
-        contracts::Contract,
-        costs::LimitedCostTracker,
-        database::{ClarityDatabase, MemoryBackingStore},
-        errors::{Error, WasmError},
-        events::StacksTransactionEvent,
-        types::{
-            PrincipalData, QualifiedContractIdentifier, ResponseData, StandardPrincipalData,
-            TypeSignature,
-        },
-        ClarityVersion, ContractContext, Value,
-    },
+use clarity::consts::CHAIN_ID_TESTNET;
+use clarity::types::StacksEpochId;
+use clarity::vm::callables::DefineType;
+use clarity::vm::clarity_wasm::{call_function, initialize_contract};
+use clarity::vm::contexts::{CallStack, EventBatch, GlobalContext};
+use clarity::vm::contracts::Contract;
+use clarity::vm::costs::LimitedCostTracker;
+use clarity::vm::database::{ClarityDatabase, MemoryBackingStore};
+use clarity::vm::errors::{Error, WasmError};
+use clarity::vm::events::StacksTransactionEvent;
+use clarity::vm::types::{
+    PrincipalData, QualifiedContractIdentifier, ResponseData, StandardPrincipalData, TupleData,
+    TypeSignature,
 };
+use clarity::vm::{ClarityVersion, ContractContext, Value};
 use hex::FromHex;
-use std::collections::HashMap;
 
 /// This macro provides a convenient way to test contract initialization.
 /// In order, it takes as parameters:

--- a/tests/src/lib_tests.rs
+++ b/tests/src/lib_tests.rs
@@ -777,7 +777,7 @@ test_contract_call_response!(
     "fold-bench",
     "fold-add-square",
     &[
-        Value::list_from((1..=8192).map(Value::Int).collect())
+        Value::cons_list_unsanitized((1..=8192).map(Value::Int).collect())
             .expect("failed to construct list argument"),
         Value::Int(1)
     ],
@@ -2299,7 +2299,8 @@ test_contract_call_response_events!(
         assert!(response.committed);
         assert_eq!(
             *response.data,
-            Value::list_from(vec![Value::Int(1), Value::Int(2), Value::Int(3)]).unwrap()
+            Value::cons_list_unsanitized(vec![Value::Int(1), Value::Int(2), Value::Int(3)])
+                .unwrap()
         );
     },
     |event_batches: &Vec<EventBatch>| {
@@ -2314,7 +2315,8 @@ test_contract_call_response_events!(
             assert_eq!(label, "print");
             assert_eq!(
                 event.value,
-                Value::list_from(vec![Value::Int(1), Value::Int(2), Value::Int(3)]).unwrap()
+                Value::cons_list_unsanitized(vec![Value::Int(1), Value::Int(2), Value::Int(3)])
+                    .unwrap()
             );
         } else {
             panic!("Unexpected event received from Wasm function call.");
@@ -2330,7 +2332,7 @@ test_contract_call_response_events!(
         assert!(response.committed);
         assert_eq!(
             *response.data,
-            Value::list_from(vec![
+            Value::cons_list_unsanitized(vec![
                 Value::Principal(
                     PrincipalData::parse("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM").unwrap()
                 ),
@@ -2354,7 +2356,7 @@ test_contract_call_response_events!(
             assert_eq!(label, "print");
             assert_eq!(
                 event.value,
-                Value::list_from(vec![
+                Value::cons_list_unsanitized(vec![
                     Value::Principal(
                         PrincipalData::parse("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM").unwrap()
                     ),
@@ -2377,7 +2379,10 @@ test_contract_call_response_events!(
     "print-list-empty",
     |response: ResponseData| {
         assert!(response.committed);
-        assert_eq!(*response.data, Value::list_from(vec![]).unwrap());
+        assert_eq!(
+            *response.data,
+            Value::cons_list_unsanitized(vec![]).unwrap()
+        );
     },
     |event_batches: &Vec<EventBatch>| {
         assert_eq!(event_batches.len(), 1);
@@ -2389,7 +2394,7 @@ test_contract_call_response_events!(
                 &QualifiedContractIdentifier::local("print").unwrap()
             );
             assert_eq!(label, "print");
-            assert_eq!(event.value, Value::list_from(vec![]).unwrap());
+            assert_eq!(event.value, Value::cons_list_unsanitized(vec![]).unwrap());
         } else {
             panic!("Unexpected event received from Wasm function call.");
         }
@@ -3429,7 +3434,8 @@ test_contract_call_response!(
         assert!(response.committed);
         assert_eq!(
             *response.data,
-            Value::list_from(vec![Value::Int(1), Value::Int(2), Value::Int(3)]).unwrap()
+            Value::cons_list_unsanitized(vec![Value::Int(1), Value::Int(2), Value::Int(3)])
+                .unwrap()
         );
     }
 );
@@ -3442,7 +3448,7 @@ test_contract_call_response!(
         assert!(response.committed);
         assert_eq!(
             *response.data,
-            Value::list_from(vec![
+            Value::cons_list_unsanitized(vec![
                 Value::string_ascii_from_bytes("hello".to_string().into_bytes()).unwrap(),
                 Value::string_ascii_from_bytes("world".to_string().into_bytes()).unwrap(),
                 Value::string_ascii_from_bytes("!".to_string().into_bytes()).unwrap(),
@@ -3460,7 +3466,7 @@ test_contract_call_response!(
         assert!(response.committed);
         assert_eq!(
             *response.data,
-            Value::list_from(vec![Value::Bool(true)]).unwrap()
+            Value::cons_list_unsanitized(vec![Value::Bool(true)]).unwrap()
         );
     }
 );
@@ -3473,7 +3479,8 @@ test_contract_call_response!(
         assert!(response.committed);
         assert_eq!(
             *response.data,
-            Value::some(Value::list_from(vec![Value::Int(1), Value::Int(2)]).unwrap()).unwrap()
+            Value::some(Value::cons_list_unsanitized(vec![Value::Int(1), Value::Int(2)]).unwrap())
+                .unwrap()
         );
     }
 );
@@ -3496,7 +3503,7 @@ test_contract_call_response!(
         assert!(response.committed);
         assert_eq!(
             *response.data,
-            Value::some(Value::list_from(vec![]).unwrap()).unwrap()
+            Value::some(Value::cons_list_unsanitized(vec![]).unwrap()).unwrap()
         );
     }
 );
@@ -3536,7 +3543,7 @@ test_contract_call_response!(
         assert!(response.committed);
         assert_eq!(
             *response.data,
-            Value::list_from(vec![
+            Value::cons_list_unsanitized(vec![
                 Value::Int(1),
                 Value::Int(2),
                 Value::Int(3),
@@ -3754,7 +3761,8 @@ test_contract_call_response!(
         assert_eq!(
             *response.data,
             Value::some(
-                Value::list_from(vec![Value::Int(1), Value::Int(4), Value::Int(3)]).unwrap()
+                Value::cons_list_unsanitized(vec![Value::Int(1), Value::Int(4), Value::Int(3)])
+                    .unwrap()
             )
             .unwrap()
         );
@@ -3843,7 +3851,8 @@ test_contract_call_response!(
         assert_eq!(
             *response.data,
             Value::some(
-                Value::list_from(vec![Value::Int(2), Value::Int(3), Value::Int(4)]).unwrap()
+                Value::cons_list_unsanitized(vec![Value::Int(2), Value::Int(3), Value::Int(4)])
+                    .unwrap()
             )
             .unwrap()
         );
@@ -3914,7 +3923,7 @@ test_contract_call_response!(
         assert!(response.committed);
         assert_eq!(
             *response.data,
-            Value::some(Value::list_from(vec![]).unwrap()).unwrap()
+            Value::some(Value::cons_list_unsanitized(vec![]).unwrap()).unwrap()
         );
     }
 );
@@ -4336,7 +4345,8 @@ test_contract_call_response!(
         assert!(response.committed);
         assert_eq!(
             *response.data,
-            Value::list_from(vec![Value::Int(1), Value::Int(2), Value::Int(3)]).unwrap()
+            Value::cons_list_unsanitized(vec![Value::Int(1), Value::Int(2), Value::Int(3)])
+                .unwrap()
         );
     }
 );


### PR DESCRIPTION
Use the `feat/clarity-wasm-next` branch of the stacks-core submodule and resolve the new issues that this causes.

The last commit reformats all files using the options that are now standard
in stacks-core:

```sh
cargo +nightly fmt -- --config group_imports=StdExternalCrate,imports_granularity=Module
```

A cargo alias is added so that developers can instead run:

```sh
cargo fmt-stacks
```
