### PR TITLE
add to-consensus-buff?

### DIFF
--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -1067,14 +1067,14 @@ impl WasmGenerator {
         Ok(())
     }
 
-    /// Serialize an `optional` to memory using consensus serialization. Leaves
+    /// Serialize a `list` to memory using consensus serialization. Leaves
     /// the length of the data written on the top of the data stack. See
     /// SIP-005 for details.
     /// Representation:
-    ///   None:
-    ///    | 0x09 |
-    ///   Some:
-    ///    | 0x0a | serialized value |
+    ///    | 0x0b | number of elements: 4-bytes (big-endian)
+    ///         | serialized representation of element 0
+    ///         | serialized representation of element 1
+    ///         | ...
     fn serialize_list(
         &mut self,
         builder: &mut InstrSeqBuilder,

--- a/clar2wasm/src/words/consensus_buff.rs
+++ b/clar2wasm/src/words/consensus_buff.rs
@@ -20,6 +20,8 @@ impl Word for ToConsensusBuf {
         _expr: &clarity::vm::SymbolicExpression,
         args: &[clarity::vm::SymbolicExpression],
     ) -> Result<(), crate::wasm_generator::GeneratorError> {
+        generator.traverse_args(builder, args)?;
+
         let ty = generator
             .get_expr_type(args.get_expr(0)?)
             .expect("to-consensus-buff? value exprission must be typed")
@@ -31,8 +33,6 @@ impl Word for ToConsensusBuf {
         builder
             .global_get(generator.stack_pointer)
             .local_set(offset);
-
-        generator.traverse_args(builder, args)?;
 
         generator.serialize_to_memory(builder, offset, 0, &ty)?;
 

--- a/clar2wasm/src/words/consensus_buff.rs
+++ b/clar2wasm/src/words/consensus_buff.rs
@@ -1,0 +1,70 @@
+use clarity::vm::types::MAX_VALUE_SIZE;
+use walrus::ir::InstrSeqType;
+
+use crate::wasm_generator::ArgumentsExt;
+
+use super::Word;
+
+#[derive(Debug)]
+pub struct ToConsensusBuf;
+
+impl Word for ToConsensusBuf {
+    fn name(&self) -> clarity::vm::ClarityName {
+        "to-consensus-buff?".into()
+    }
+
+    fn traverse(
+        &self,
+        generator: &mut crate::wasm_generator::WasmGenerator,
+        builder: &mut walrus::InstrSeqBuilder,
+        _expr: &clarity::vm::SymbolicExpression,
+        args: &[clarity::vm::SymbolicExpression],
+    ) -> Result<(), crate::wasm_generator::GeneratorError> {
+        let ty = generator
+            .get_expr_type(args.get_expr(0)?)
+            .expect("to-consensus-buff? value exprission must be typed")
+            .clone();
+
+        let offset = generator.module.locals.add(walrus::ValType::I32);
+        let length = generator.module.locals.add(walrus::ValType::I32);
+
+        builder
+            .global_get(generator.stack_pointer)
+            .local_set(offset);
+
+        generator.traverse_args(builder, args)?;
+
+        generator.serialize_to_memory(builder, offset, 0, &ty)?;
+
+        builder.local_set(length);
+
+        builder
+            .local_get(length)
+            .i32_const(MAX_VALUE_SIZE as i32)
+            .binop(walrus::ir::BinaryOp::I32LeU)
+            .if_else(
+                InstrSeqType::new(
+                    &mut generator.module.types,
+                    &[],
+                    &[
+                        walrus::ValType::I32,
+                        walrus::ValType::I32,
+                        walrus::ValType::I32,
+                    ],
+                ),
+                |then| {
+                    then.local_get(offset)
+                        .local_get(length)
+                        .binop(walrus::ir::BinaryOp::I32Add)
+                        .global_set(generator.stack_pointer);
+
+                    then.i32_const(1).local_get(offset).local_get(length);
+                },
+                |else_| {
+                    else_.i32_const(0).i32_const(0).i32_const(0);
+                },
+            );
+
+        Ok(())
+    }
+}

--- a/clar2wasm/src/words/consensus_buff.rs
+++ b/clar2wasm/src/words/consensus_buff.rs
@@ -68,3 +68,158 @@ impl Word for ToConsensusBuf {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use clarity::vm::{
+        types::{BuffData, SequenceData},
+        Value,
+    };
+    use hex::FromHex as _;
+
+    use crate::tools::evaluate;
+
+    #[test]
+    fn to_consensus_buff_int() {
+        assert_eq!(
+            evaluate(r#"(to-consensus-buff? 42)"#),
+            Some(
+                Value::some(Value::Sequence(SequenceData::Buffer(BuffData {
+                    data: Vec::from_hex("000000000000000000000000000000002a").unwrap()
+                })))
+                .unwrap()
+            )
+        );
+    }
+
+    #[test]
+    fn to_consensus_buff_uint() {
+        assert_eq!(
+            evaluate(r#"(to-consensus-buff? u42)"#),
+            Some(
+                Value::some(Value::Sequence(SequenceData::Buffer(BuffData {
+                    data: Vec::from_hex("010000000000000000000000000000002a").unwrap()
+                })))
+                .unwrap()
+            )
+        );
+    }
+
+    #[test]
+    fn to_consensus_buff_bool() {
+        assert_eq!(
+            evaluate(r#"(to-consensus-buff? true)"#),
+            Some(
+                Value::some(Value::Sequence(SequenceData::Buffer(BuffData {
+                    data: Vec::from_hex("03").unwrap()
+                })))
+                .unwrap()
+            )
+        );
+        assert_eq!(
+            evaluate(r#"(to-consensus-buff? false)"#),
+            Some(
+                Value::some(Value::Sequence(SequenceData::Buffer(BuffData {
+                    data: Vec::from_hex("04").unwrap()
+                })))
+                .unwrap()
+            )
+        );
+    }
+
+    #[test]
+    fn to_consensus_buff_optional() {
+        assert_eq!(
+            evaluate(r#"(to-consensus-buff? none)"#),
+            Some(
+                Value::some(Value::Sequence(SequenceData::Buffer(BuffData {
+                    data: Vec::from_hex("09").unwrap()
+                })))
+                .unwrap()
+            )
+        );
+        assert_eq!(
+            evaluate(r#"(to-consensus-buff? (some 42))"#),
+            Some(
+                Value::some(Value::Sequence(SequenceData::Buffer(BuffData {
+                    data: Vec::from_hex("0a000000000000000000000000000000002a").unwrap()
+                })))
+                .unwrap()
+            )
+        );
+    }
+
+    #[test]
+    fn to_consensus_buff_response() {
+        assert_eq!(
+            evaluate(r#"(to-consensus-buff? (ok 42))"#),
+            Some(
+                Value::some(Value::Sequence(SequenceData::Buffer(BuffData {
+                    data: Vec::from_hex("07000000000000000000000000000000002a").unwrap()
+                })))
+                .unwrap()
+            )
+        );
+        assert_eq!(
+            evaluate(r#"(to-consensus-buff? (err u123))"#),
+            Some(
+                Value::some(Value::Sequence(SequenceData::Buffer(BuffData {
+                    data: Vec::from_hex("08010000000000000000000000000000007b").unwrap()
+                })))
+                .unwrap()
+            )
+        );
+    }
+
+    #[test]
+    fn to_consensus_buff_tuple() {
+        assert_eq!(
+            evaluate(r#"(to-consensus-buff? {foo: 123, bar: u789})"#),
+            Some(
+                Value::some(Value::Sequence(SequenceData::Buffer(BuffData {
+                    data: Vec::from_hex("0c0000000203626172010000000000000000000000000000031503666f6f000000000000000000000000000000007b").unwrap()
+                })))
+                .unwrap()
+            )
+        );
+    }
+
+    #[test]
+    fn to_consensus_buff_string_ascii() {
+        assert_eq!(
+            evaluate(r#"(to-consensus-buff? "Hello, World!")"#),
+            Some(
+                Value::some(Value::Sequence(SequenceData::Buffer(BuffData {
+                    data: Vec::from_hex("0d0000000d48656c6c6f2c20576f726c6421").unwrap()
+                })))
+                .unwrap()
+            )
+        );
+    }
+
+    #[test]
+    fn to_consensus_buff_buffer() {
+        assert_eq!(
+            evaluate(r#"(to-consensus-buff? 0x12345678)"#),
+            Some(
+                Value::some(Value::Sequence(SequenceData::Buffer(BuffData {
+                    data: Vec::from_hex("020000000412345678").unwrap()
+                })))
+                .unwrap()
+            )
+        );
+    }
+
+    #[test]
+    fn to_consensus_buff_list() {
+        assert_eq!(
+            evaluate(r#"(to-consensus-buff? (list 1 2 3 4))"#),
+            Some(
+                Value::some(Value::Sequence(SequenceData::Buffer(BuffData {
+                    data: Vec::from_hex("0b000000040000000000000000000000000000000001000000000000000000000000000000000200000000000000000000000000000000030000000000000000000000000000000004").unwrap()
+                })))
+                .unwrap()
+            )
+        );
+    }
+}

--- a/clar2wasm/src/words/consensus_buff.rs
+++ b/clar2wasm/src/words/consensus_buff.rs
@@ -27,17 +27,20 @@ impl Word for ToConsensusBuf {
             .expect("to-consensus-buff? value exprission must be typed")
             .clone();
 
+        // Save the offset (current stack pointer) into a local.
+        // This is where we will serialize the value to.
         let offset = generator.module.locals.add(walrus::ValType::I32);
         let length = generator.module.locals.add(walrus::ValType::I32);
-
         builder
             .global_get(generator.stack_pointer)
             .local_set(offset);
 
+        // Write the serialized value to the top of the call stack
         generator.serialize_to_memory(builder, offset, 0, &ty)?;
 
         builder.local_set(length);
 
+        // Check if the serialized value size < MAX_VALUE_SIZE
         builder
             .local_get(length)
             .i32_const(MAX_VALUE_SIZE as i32)

--- a/clar2wasm/src/words/mod.rs
+++ b/clar2wasm/src/words/mod.rs
@@ -13,6 +13,7 @@ pub mod blockinfo;
 pub mod buff_to_integer;
 pub mod comparison;
 pub mod conditionals;
+pub mod consensus_buff;
 pub mod constants;
 pub mod contract;
 pub mod control_flow;
@@ -68,6 +69,7 @@ pub(crate) static WORDS: &[&'static dyn Word] = &[
     &conditionals::If,
     &conditionals::Match,
     &conditionals::Or,
+    &consensus_buff::ToConsensusBuf,
     &constants::DefineConstant,
     &contract::AsContract,
     &contract::ContractCall,


### PR DESCRIPTION
This is part of #149.

This PR adds `to-consensus-buff?` support. It was fairly easy since the serialization functions already existed.

Due to a mistake on my side, I ended up refactoring `wasmGenerator::serialize_list`.
This refactor brings several benefits:

- No more useless computations (including a division) for an empty list
- No more useless block around the loop
- One less local
- We have two less jmp instructions at the end of the loop
- Less instructions in the loop

Seeing that this refactoring had those benefits, I decided to keep it, even if it does not bring any new feature.