### PR TITLE
Initial `string-utf8` support

### DIFF
--- a/clar2wasm/Cargo.toml
+++ b/clar2wasm/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 build = "build.rs"
 
 [dependencies]
-# clarity = { path = "../stacks-blockchain/clarity" }
-clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-next" }
+clarity = { path = "../stacks-blockchain/clarity" }
+#clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-next" }
 clap = { version = "4.3.17", features = ["derive"] }
 regex = "1.9.1"
 walrus = "0.20.1"

--- a/clar2wasm/src/words/comparison.rs
+++ b/clar2wasm/src/words/comparison.rs
@@ -23,7 +23,10 @@ fn traverse_comparison(
         TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::ASCII(_)))
         | TypeSignature::SequenceType(SequenceSubtype::BufferType(_)) => "buff",
         TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::UTF8(_))) => {
-            todo!()
+            // For `string-utf8`, comparison is done on a codepoint-by-codepoint basis.
+            // Comparing two codepoints is the act of comparing them on a byte-by-byte basis.
+            // Since we already have 32-bit unicode scalars, we can just compare them with buff.
+            "buff"
         }
         _ => {
             return Err(GeneratorError::InternalError(

--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -192,6 +192,7 @@ fn wasm_equal(
         // is-eq-bytes function can be used for types with (offset, length)
         TypeSignature::SequenceType(SequenceSubtype::BufferType(_))
         | TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::ASCII(_)))
+        | TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::UTF8(_)))
         | TypeSignature::PrincipalType
         | TypeSignature::CallableType(CallableSubtype::Principal(_)) => {
             if ty == nth_ty {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 path = "./src/lib.rs"
 
 [dependencies]
-# clarity = { path = "../stacks-blockchain/clarity" }
-clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-next" }
+clarity = { path = "../stacks-blockchain/clarity" }
+# clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-next" }
 clar2wasm = { path = "../clar2wasm", features = ["developer-mode"] }
 wasmtime = "15.0.0"
 

--- a/tests/contracts/cmp-buffer.clar
+++ b/tests/contracts/cmp-buffer.clar
@@ -6,6 +6,14 @@
     (ok (< "hello" "world"))
 )
 
+(define-public (less-string-utf8-a)
+    (ok (< u"\u{0380}" u"Z")) ;; false
+)
+
+(define-public (less-string-utf8-b)
+    (ok (< u"\u{5a}" u"\u{5b}")) ;; true
+)
+
 (define-public (greater-buffer)
     (ok (> 0x0102 0x0103))
 )
@@ -22,6 +30,10 @@
     (ok (<= "hello" "world"))
 )
 
+(define-public (less-or-equal-string-utf8)
+    (ok (<= u"\u{5a}" u"Z")) ;; true
+)
+
 (define-public (greater-or-equal-buffer)
     (ok (>= 0x0102 0x0103))
 )
@@ -30,12 +42,20 @@
     (ok (>= "hello" "world"))
 )
 
+(define-public (greater-or-equal-string-utf8)
+    (ok (>= u"\u{5a}" u"Z")) ;; true
+)
+
 (define-public (less-buffer-diff-len)
     (ok (< 0x01 0x010203))
 )
 
 (define-public (less-string-ascii-diff-len)
     (ok (< "Lorem ipsum" "Lorem ipsum dolor sit amet"))
+)
+
+(define-public (less-string-utf8-diff-len)
+    (ok (< u"stacks" u"st\u{c3a4}cks")) ;; true
 )
 
 (define-public (greater-buffer-diff-len)

--- a/tests/contracts/constant.clar
+++ b/tests/contracts/constant.clar
@@ -13,6 +13,11 @@
   (ok string)
 )
 
+(define-constant string-utf8 u"hello world\u{1F98A}")
+(define-public (get-string-utf8-constant)
+  (ok string-utf8)
+)
+
 (define-constant bytes 0x12345678)
 (define-public (get-bytes-constant)
   (ok bytes)

--- a/tests/contracts/equal.clar
+++ b/tests/contracts/equal.clar
@@ -82,6 +82,14 @@
     (ok (is-eq "hello" "world"))
 )
 
+(define-public (str-utf8-equal)
+    (ok (is-eq u"hello" u"hello"))
+)
+
+(define-public (str-utf8-unequal)
+    (ok (is-eq u"hello" u"world"))
+)
+
 (define-public (principal-equal)
     (ok (is-eq 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM))
 )

--- a/tests/contracts/sequences.clar
+++ b/tests/contracts/sequences.clar
@@ -26,6 +26,10 @@
   (ok (as-max-len? "hello" u8))
 )
 
+(define-public (string-utf8-as-max-len)
+  (ok (as-max-len? u"hello\u{1F98A}" u8))
+)
+
 (define-public (buffer-as-max-len)
   (ok (as-max-len? 0x123456 u4))
 )
@@ -38,6 +42,14 @@
   (ok (concat "hello" " world"))
 )
 
+(define-public (string-utf8-concat)
+  (ok (concat u"hello" u" world"))
+)
+
+(define-public (string-utf8-concat-b)
+  (ok (concat u"hello" u" world\u{1F98A}"))
+)
+
 (define-public (buffer-concat)
   (ok (concat 0x123456 0x789abc))
 )
@@ -48,6 +60,14 @@
 
 (define-public (string-len)
   (ok (len "sup"))
+)
+
+(define-public (string-utf8-len)
+  (ok (len u"sup"))
+)
+
+(define-public (string-utf8-len-b)
+  (ok (len u"sup\u{1F98A}"))
 )
 
 (define-public (buffer-len)
@@ -74,6 +94,10 @@
   (ok (element-at "hello" u4))
 )
 
+(define-public (string-utf8-element-at)
+  (ok (element-at u"hello" u4))
+)
+
 (define-public (buffer-element-at)
   (ok (element-at 0x123456 u2))
 )
@@ -86,6 +110,14 @@
   (ok (element-at? "hello" u4))
 )
 
+(define-public (string-utf8-element-at?)
+  (ok (element-at? u"hello" u4))
+)
+
+(define-public (string-utf8-element-at-b?)
+  (ok (element-at? u"hello\u{1F98A}" u5))
+)
+
 (define-public (buffer-element-at?)
   (ok (element-at? 0x123456 u2))
 )
@@ -96,6 +128,10 @@
 
 (define-public (string-element-at-none)
   (ok (element-at? "hello" u5))
+)
+
+(define-public (string-utf8-element-at-none)
+  (ok (element-at? u"hello" u5))
 )
 
 (define-public (buffer-element-at-none)
@@ -115,6 +151,14 @@
   (ok (replace-at? "hello" u0 "j"))
 )
 
+(define-public (string-utf8-replace-at)
+  (ok (replace-at? u"hello" u0 u"j"))
+)
+
+(define-public (string-utf8-replace-at-b)
+  (ok (replace-at? u"hello\u{1F98A}" u2 u"e"))
+)
+
 (define-public (buffer-replace-at)
   (ok (replace-at? 0xfedcba9876543210 u4 0x67))
 )
@@ -125,6 +169,10 @@
 
 (define-public (string-replace-at-none)
   (ok (replace-at? "hello" u5 "X"))
+)
+
+(define-public (string-utf8-replace-at-none)
+  (ok (replace-at? u"hello" u5 u"X"))
 )
 
 (define-public (buffer-replace-at-none)
@@ -151,6 +199,10 @@
   (ok (slice? "hello" u2 u3))
 )
 
+(define-public (string-utf8-slice)
+  (ok (slice? u"hello" u2 u3))
+)
+
 (define-public (buffer-slice)
   (ok (slice? 0xfedcba9876543210 u4 u7))
 )
@@ -163,6 +215,10 @@
   (ok (slice? "hello" u2 u6))
 )
 
+(define-public (string-utf8-slice-none)
+  (ok (slice? u"hello" u2 u6))
+)
+
 (define-public (buffer-slice-none)
   (ok (slice? 0xfedcba9876543210 u0 u10))
 )
@@ -173,6 +229,10 @@
 
 (define-public (string-slice-empty)
   (ok (slice? "hello" u1 u1))
+)
+
+(define-public (string-utf8-slice-empty)
+  (ok (slice? u"hello" u1 u1))
 )
 
 (define-public (buffer-slice-empty)

--- a/tests/src/lib_tests.rs
+++ b/tests/src/lib_tests.rs
@@ -3116,6 +3116,26 @@ test_contract_call_response!(
 );
 
 test_contract_call_response!(
+    test_str_utf8_equal,
+    "equal",
+    "str-utf8-equal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
+    test_str_utf8_unequal,
+    "equal",
+    "str-utf8-unequal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
     test_principal_equal,
     "equal",
     "principal-equal",

--- a/tests/src/lib_tests.rs
+++ b/tests/src/lib_tests.rs
@@ -3532,6 +3532,19 @@ test_contract_call_response!(
 );
 
 test_contract_call_response!(
+    test_string_utf8_as_max_len,
+    "sequences",
+    "string-utf8-as-max-len",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(
+            *response.data,
+            Value::some(Value::string_utf8_from_bytes("hello🦊".into()).unwrap()).unwrap()
+        );
+    }
+);
+
+test_contract_call_response!(
     test_list_concat,
     "sequences",
     "list-concat",
@@ -3559,6 +3572,32 @@ test_contract_call_response!(
         assert_eq!(
             *response.data,
             Value::string_ascii_from_bytes("hello world".to_string().into_bytes()).unwrap()
+        );
+    }
+);
+
+test_contract_call_response!(
+    test_string_utf8_concat,
+    "sequences",
+    "string-utf8-concat",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(
+            *response.data,
+            Value::string_utf8_from_bytes("hello world".into()).unwrap()
+        );
+    }
+);
+
+test_contract_call_response!(
+    test_string_utf8_concat_b,
+    "sequences",
+    "string-utf8-concat-b",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(
+            *response.data,
+            Value::string_utf8_from_bytes("hello world🦊".into()).unwrap()
         );
     }
 );
@@ -3593,6 +3632,26 @@ test_contract_call_response!(
     |response: ResponseData| {
         assert!(response.committed);
         assert_eq!(*response.data, Value::UInt(3));
+    }
+);
+
+test_contract_call_response!(
+    test_string_utf8_len,
+    "sequences",
+    "string-utf8-len",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::UInt(3));
+    }
+);
+
+test_contract_call_response!(
+    test_string_utf8_len_b,
+    "sequences",
+    "string-utf8-len-b",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::UInt(4));
     }
 );
 
@@ -3660,6 +3719,19 @@ test_contract_call_response!(
 );
 
 test_contract_call_response!(
+    test_string_utf8_element_at,
+    "sequences",
+    "string-utf8-element-at",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(
+            *response.data,
+            Value::some(Value::string_utf8_from_bytes(vec![b'o']).unwrap()).unwrap()
+        );
+    }
+);
+
+test_contract_call_response!(
     test_buffer_element_at,
     "sequences",
     "buffer-element-at",
@@ -3696,6 +3768,32 @@ test_contract_call_response!(
 );
 
 test_contract_call_response!(
+    test_string_utf8_element_at_alias,
+    "sequences",
+    "string-utf8-element-at?",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(
+            *response.data,
+            Value::some(Value::string_utf8_from_bytes(vec![b'o']).unwrap()).unwrap()
+        );
+    }
+);
+
+test_contract_call_response!(
+    test_string_utf8_element_at_alias_b,
+    "sequences",
+    "string-utf8-element-at-b?",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(
+            *response.data,
+            Value::some(Value::string_utf8_from_bytes("🦊".into()).unwrap()).unwrap()
+        );
+    }
+);
+
+test_contract_call_response!(
     test_buffer_element_at_alias,
     "sequences",
     "buffer-element-at?",
@@ -3722,6 +3820,16 @@ test_contract_call_response!(
     test_string_element_at_none,
     "sequences",
     "string-element-at-none",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::none());
+    }
+);
+
+test_contract_call_response!(
+    test_string_utf8_element_at_none,
+    "sequences",
+    "string-utf8-element-at-none",
     |response: ResponseData| {
         assert!(response.committed);
         assert_eq!(*response.data, Value::none());
@@ -3780,6 +3888,32 @@ test_contract_call_response!(
 );
 
 test_contract_call_response!(
+    test_string_utf8_replace_at,
+    "sequences",
+    "string-utf8-replace-at",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(
+            *response.data,
+            Value::some(Value::string_utf8_from_bytes("jello".into()).unwrap()).unwrap()
+        );
+    }
+);
+
+test_contract_call_response!(
+    test_string_utf8_replace_at_b,
+    "sequences",
+    "string-utf8-replace-at-b",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(
+            *response.data,
+            Value::some(Value::string_utf8_from_bytes("heelo🦊".into()).unwrap()).unwrap()
+        );
+    }
+);
+
+test_contract_call_response!(
     test_buffer_replace_at,
     "sequences",
     "buffer-replace-at",
@@ -3809,6 +3943,16 @@ test_contract_call_response!(
     test_string_replace_at_none,
     "sequences",
     "string-replace-at-none",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::none());
+    }
+);
+
+test_contract_call_response!(
+    test_string_utf8_replace_at_none,
+    "sequences",
+    "string-utf8-replace-at-none",
     |response: ResponseData| {
         assert!(response.committed);
         assert_eq!(*response.data, Value::none());
@@ -3869,6 +4013,19 @@ test_contract_call_response!(
 );
 
 test_contract_call_response!(
+    test_string_utf8_slice,
+    "sequences",
+    "string-utf8-slice",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(
+            *response.data,
+            Value::some(Value::string_utf8_from_bytes(b"l".to_vec()).unwrap()).unwrap()
+        );
+    }
+);
+
+test_contract_call_response!(
     test_buffer_slice,
     "sequences",
     "buffer-slice",
@@ -3895,6 +4052,16 @@ test_contract_call_response!(
     test_string_slice_none,
     "sequences",
     "string-slice-none",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::none());
+    }
+);
+
+test_contract_call_response!(
+    test_string_utf8_slice_none,
+    "sequences",
+    "string-utf8-slice-none",
     |response: ResponseData| {
         assert!(response.committed);
         assert_eq!(*response.data, Value::none());
@@ -3933,6 +4100,19 @@ test_contract_call_response!(
         assert_eq!(
             *response.data,
             Value::some(Value::string_ascii_from_bytes(vec![]).unwrap()).unwrap()
+        );
+    }
+);
+
+test_contract_call_response!(
+    test_string_utf8_slice_empty,
+    "sequences",
+    "string-utf8-slice-empty",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(
+            *response.data,
+            Value::some(Value::string_utf8_from_bytes(vec![]).unwrap()).unwrap()
         );
     }
 );

--- a/tests/src/lib_tests.rs
+++ b/tests/src/lib_tests.rs
@@ -4194,6 +4194,26 @@ test_contract_call_response!(
 );
 
 test_contract_call_response!(
+    test_less_than_string_utf8_a,
+    "cmp-buffer",
+    "less-string-utf8-a",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_less_than_string_utf8_b,
+    "cmp-buffer",
+    "less-string-utf8-b",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
     test_greater_than_string_ascii,
     "cmp-buffer",
     "greater-string-ascii",
@@ -4214,12 +4234,32 @@ test_contract_call_response!(
 );
 
 test_contract_call_response!(
+    test_less_or_equal_string_utf8,
+    "cmp-buffer",
+    "less-or-equal-string-utf8",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
     test_greater_or_equal_string_ascii,
     "cmp-buffer",
     "greater-or-equal-string-ascii",
     |response: ResponseData| {
         assert!(response.committed);
         assert_eq!(*response.data, Value::Bool(false));
+    }
+);
+
+test_contract_call_response!(
+    test_greater_or_equal_string_utf8,
+    "cmp-buffer",
+    "greater-or-equal-string-utf8",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
     }
 );
 
@@ -4267,6 +4307,16 @@ test_contract_call_response!(
     test_less_than_string_ascii_diff_len,
     "cmp-buffer",
     "less-string-ascii-diff-len",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
+    test_less_than_string_utf8_diff_len,
+    "cmp-buffer",
+    "less-string-utf8-diff-len",
     |response: ResponseData| {
         assert!(response.committed);
         assert_eq!(*response.data, Value::Bool(true));

--- a/tests/src/lib_tests.rs
+++ b/tests/src/lib_tests.rs
@@ -1154,6 +1154,19 @@ test_contract_call_response!(
 );
 
 test_contract_call_response!(
+    test_string_utf8_constant,
+    "constant",
+    "get-string-utf8-constant",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(
+            *response.data,
+            Value::string_utf8_from_bytes("hello world🦊".into()).unwrap()
+        );
+    }
+);
+
+test_contract_call_response!(
     test_bytes_constant,
     "constant",
     "get-bytes-constant",


### PR DESCRIPTION
Implement support for `string-utf8` https://github.com/stacks-network/clarity-wasm/issues/127

This approach uses 32-bit unicode scalar values to represent utf8 codepoints in wasm. This is an improvement to the approach used by the interpreter where utf8 strings are converted to a `Vec<Vec<u8>>` where the inner vec is 1-4 bytes in length.

All clarity sequence functions already operate on `string-utf8` values as arrays of codepoints, so this approach is less complex than manipulating real variable-length utf8 byte streams in wasm. Clarity sequence functions for `buff` and `string-ascii` operate on arrays of 8-bit ints, so adding utf8 support only required minimal changes to operate on arrays of 32-bit ints.

The following functions are working with utf8:
* as-max-len
* concat
* len
* element-at
* replace-at
* slice
* is-eq
* comparison operators (>, >=, <, <=)

The following are **not** yet working with utf8 strings:
* string/integer conversions
* print
* to/from-consensus-buff
* index-of