### PR TITLE
support for ascii, buff and utf-8 in index-of function

### DIFF
--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -1035,6 +1035,21 @@ mod tests {
     }
 
     #[test]
+    fn index_of_ascii_empty() {
+        assert_eq!(eval("(index-of \"\" \"\")"), Some(Value::none()));
+    }
+
+    #[test]
+    fn index_of_ascii_empty_input() {
+        assert_eq!(eval("(index-of \"\" \"a\")"), Some(Value::none()));
+    }
+
+    #[test]
+    fn index_of_ascii_empty_char() {
+        assert_eq!(eval("(index-of \"Stacks\" \"\")"), Some(Value::none()));
+    }
+
+    #[test]
     fn index_of_ascii_first_elem() {
         assert_eq!(
             eval("(index-of \"Stacks\" \"S\")"),
@@ -1048,11 +1063,6 @@ mod tests {
             eval("(index-of \"Stacks\" \"s\")"),
             Some(Value::some(Value::UInt(5)).unwrap())
         );
-    }
-
-    #[test]
-    fn index_of_ascii_zero_len() {
-        assert_eq!(eval("(index-of \"Stacks\" \"\")"), Some(Value::none()));
     }
 
     #[test]

--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -553,7 +553,7 @@ impl Word for Len {
     }
 }
 
-enum SequenceElementType {
+pub enum SequenceElementType {
     /// A byte, from a string-ascii or buffer.
     Byte,
     /// A 32-bit unicode scalar value, from a string-utf8.


### PR DESCRIPTION
Add support for String::ASCII and Buff on `index-of` function.

Edit: and also support for String::UTF-8.