### PR TITLE
sha512-buf implementation in standard.wat and unit tests are added

### DIFF
--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -2536,7 +2536,7 @@
 
         ;; For binary representation, you can take a look at https://sha256algorithm.com/
         ;; Keep in mind that SHA-256 handles 4-byte words, but SHA-512 handles 8-byte words
-        ;; SHA-256 block is 512-bits(64 bytes) but SHA-512 block is 1028 bits (128 bytes)
+        ;; SHA-256 block is of 512-bits(64 bytes) but SHA-512 block is of 1028-bits(128 bytes)
         ;; For initial values, constants and high level understanding of SHA-512, please take a look at this rust implementation
         ;; https://github.com/dandyvica/sha/blob/master/src/sha512.rs
         ;; If you're interested in the paper, please take a look at https://eprint.iacr.org/2010/548.pdf

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -177,6 +177,12 @@
                                                            (param $arguments_length i32)
                                                            (param $return_offset i32)
                                                            (param $return_length i32)))
+                                                           
+    (import "clarity" "begin_public_call" (func $stdlib.begin_public_call))
+    (import "clarity" "begin_read_only_call" (func $stdlib.begin_read_only_call))
+    (import "clarity" "commit_call" (func $stdlib.commit_call))
+    (import "clarity" "roll_back_call" (func $stdlib.roll_back_call))
+
     (import "clarity" "keccak256" (func $stdlib.keccak256 (param $buffer_offset i32)
                                                    (param $buffer_length i32)
                                                    (param $result_offset i32)

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -177,10 +177,6 @@
                                                            (param $arguments_length i32)
                                                            (param $return_offset i32)
                                                            (param $return_length i32)))
-    (import "clarity" "begin_public_call" (func $stdlib.begin_public_call))
-    (import "clarity" "begin_read_only_call" (func $stdlib.begin_read_only_call))
-    (import "clarity" "commit_call" (func $stdlib.commit_call))
-    (import "clarity" "roll_back_call" (func $stdlib.roll_back_call))
     (import "clarity" "keccak256" (func $stdlib.keccak256 (param $buffer_offset i32)
                                                    (param $buffer_length i32)
                                                    (param $result_offset i32)
@@ -262,6 +258,12 @@
     ;; (hash-160) K' constants
     (data (i32.const 628) "\e6\8b\a2\50\24\d1\4d\5c\f3\3e\70\6d\e9\76\6d\7a\00\00\00\00")
 
+    ;; sha512 initial values (64 bytes) 
+    (data (i32.const 648) "\08\c9\bc\f3\67\e6\09\6a\3b\a7\ca\84\85\ae\67\bb\2b\f8\94\fe\72\f3\6e\3c\f1\36\1d\5f\3a\f5\4f\a5\d1\82\e6\ad\7f\52\0e\51\1f\6c\3e\2b\8c\68\05\9b\6b\bd\41\fb\ab\d9\83\1f\79\21\7e\13\19\cd\e0\5b")
+
+    ;; sha512 K constants
+    (data (i32.const 712) "\22\ae\28\d7\98\2f\8a\42\cd\65\ef\23\91\44\37\71\2f\3b\4d\ec\cf\fb\c0\b5\bc\db\89\81\a5\db\b5\e9\38\b5\48\f3\5b\c2\56\39\19\d0\05\b6\f1\11\f1\59\9b\4f\19\af\a4\82\3f\92\18\81\6d\da\d5\5e\1c\ab\42\02\03\a3\98\aa\07\d8\be\6f\70\45\01\5b\83\12\8c\b2\e4\4e\be\85\31\24\e2\b4\ff\d5\c3\7d\0c\55\6f\89\7b\f2\74\5d\be\72\b1\96\16\3b\fe\b1\de\80\35\12\c7\25\a7\06\dc\9b\94\26\69\cf\74\f1\9b\c1\d2\4a\f1\9e\c1\69\9b\e4\e3\25\4f\38\86\47\be\ef\b5\d5\8c\8b\c6\9d\c1\0f\65\9c\ac\77\cc\a1\0c\24\75\02\2b\59\6f\2c\e9\2d\83\e4\a6\6e\aa\84\74\4a\d4\fb\41\bd\dc\a9\b0\5c\b5\53\11\83\da\88\f9\76\ab\df\66\ee\52\51\3e\98\10\32\b4\2d\6d\c6\31\a8\3f\21\fb\98\c8\27\03\b0\e4\0e\ef\be\c7\7f\59\bf\c2\8f\a8\3d\f3\0b\e0\c6\25\a7\0a\93\47\91\a7\d5\6f\82\03\e0\51\63\ca\06\70\6e\0e\0a\67\29\29\14\fc\2f\d2\46\85\0a\b7\27\26\c9\26\5c\38\21\1b\2e\ed\2a\c4\5a\fc\6d\2c\4d\df\b3\95\9d\13\0d\38\53\de\63\af\8b\54\73\0a\65\a8\b2\77\3c\bb\0a\6a\76\e6\ae\ed\47\2e\c9\c2\81\3b\35\82\14\85\2c\72\92\64\03\f1\4c\a1\e8\bf\a2\01\30\42\bc\4b\66\1a\a8\91\97\f8\d0\70\8b\4b\c2\30\be\54\06\a3\51\6c\c7\18\52\ef\d6\19\e8\92\d1\10\a9\65\55\24\06\99\d6\2a\20\71\57\85\35\0e\f4\b8\d1\bb\32\70\a0\6a\10\c8\d0\d2\b8\16\c1\a4\19\53\ab\41\51\08\6c\37\1e\99\eb\8e\df\4c\77\48\27\a8\48\9b\e1\b5\bc\b0\34\63\5a\c9\c5\b3\0c\1c\39\cb\8a\41\e3\4a\aa\d8\4e\73\e3\63\77\4f\ca\9c\5b\a3\b8\b2\d6\f3\6f\2e\68\fc\b2\ef\5d\ee\82\8f\74\60\2f\17\43\6f\63\a5\78\72\ab\f0\a1\14\78\c8\84\ec\39\64\1a\08\02\c7\8c\28\1e\63\23\fa\ff\be\90\e9\bd\82\de\eb\6c\50\a4\15\79\c6\b2\f7\a3\f9\be\2b\53\72\e3\f2\78\71\c6\9c\61\26\ea\ce\3e\27\ca\07\c2\c0\21\c7\b8\86\d1\1e\eb\e0\cd\d6\7d\da\ea\78\d1\6e\ee\7f\4f\7d\f5\ba\6f\17\72\aa\67\f0\06\a6\98\c8\a2\c5\7d\63\0a\ae\0d\f9\be\04\98\3f\11\1b\47\1c\13\35\0b\71\1b\84\7d\04\23\f5\77\db\28\93\24\c7\40\7b\ab\ca\32\bc\be\c9\15\0a\be\9e\3c\4c\0d\10\9c\c4\67\1d\43\b6\42\3e\cb\be\d4\c5\4c\2a\7e\65\fc\9c\29\7f\59\ec\fa\d6\3a\ab\6f\cb\5f\17\58\47\4a\8c\19\44\6c")
+    
     ;; table that contains the 5 hash160 functions used during compression
     (type $hash160-compress-function (func (param i32 i32 i32 i32) (result i32)))
     (table 5 funcref) ;; table for hash160 compress function
@@ -1413,6 +1415,7 @@
         (local.set $length)
 
         (local.set $i (i32.const 0))
+
         (loop
             (call $block64 (local.get $i))
             (call $working-vars)
@@ -1485,6 +1488,7 @@
         ;;   0..32 -> Initial hash vals (will be the result hash in the end)
         ;;   32..288 -> Space to store W (result of $block64)
         ;;   288..$length+288 -> shifted data
+
         (memory.copy (global.get $stack-pointer) (i32.const 0) (i32.const 32))
         (memory.copy (i32.add (global.get $stack-pointer) (i32.const 288)) (local.get $offset) (local.get $length))
 
@@ -1504,6 +1508,7 @@
             (i32.add (global.get $stack-pointer) (local.get $length))
             (i32.const 0x80)
         )
+        
         ;; Fill the remaining part before the size with 0s
         (memory.fill
             (i32.add (i32.add (global.get $stack-pointer) (local.get $length)) (i32.const 289))
@@ -1536,6 +1541,7 @@
                 )
             )
         )
+
         i64.store offset=288
 
         (local.get $res_len)
@@ -1554,10 +1560,12 @@
         ;; TODO? : unroll this loop, since it's one instruction 4 times?
         (loop
             (i32.add (local.get $origin) (local.get $i))
+            
             (i8x16.swizzle
                 (v128.load offset=288 (i32.add (local.get $data) (local.get $i)))
                 (v128.const i8x16 3 2 1 0 7 6 5 4 11 10 9 8 15 14 13 12)
             )
+
             v128.store offset=32
 
             (br_if 0
@@ -2522,6 +2530,292 @@
         (local.get $hi)
     )
 
+    (func $stdlib.sha512-buf (param $offset i32) (param $length i32) (param $offset-result i32)(result i32 i32)
+
+        ;; Length of the data after adding padding and length to it
+        (local $length_after_padding i32)
+
+        (local $message_length_64 i64)
+        
+        ;; Index to track all blocks
+        (local $outer-index i32) 
+        
+        ;; Temporary block data (a word of 8 bytes) in current block iteration
+        (local $block-iteration-temp i64)
+
+        ;; Local index to a block, to perform iterations on bytes
+        (local $inner-index i32)
+
+        ;; Temporary block data, in an iteration
+        (local $temp-block-data i32)
+
+        ;; Variables used in hash rounds
+        (local $a i64) (local $b i64) (local $c i64) (local $d i64)
+        (local $e i64) (local $f i64) (local $g i64) (local $h i64)
+        (local $temp1 i64) (local $temp2 i64)
+
+        
+
+        ;; Copying initial values (64 bytes) for SHA-512 from 648 index
+        (memory.copy (global.get $stack-pointer) (i32.const 648) (i32.const 64))
+
+        ;; Copying the data from the offset to isolated environment (i.e. target-index = $stack-pointer+(initial-values+(80 rounds * 8)))
+        (memory.copy (i32.add (global.get $stack-pointer) (i32.const 704)) (local.get $offset) (local.get $length))
+
+        (local.set $length_after_padding ;; total size of data with expansion divisible by 128
+            (i32.add
+                (i32.or
+                    ;; len + 16 bytes for the size
+                    (i32.add (local.get $length) (i32.const 16))
+                        (i32.const 0x7f)
+                    )
+                    (i32.const 1)
+                )
+        )
+
+        
+        ;; Add "1" at the end of the data
+        (i32.store offset=704
+            (i32.add (global.get $stack-pointer) (local.get $length))
+            (i32.const 0x80)
+        )
+
+        ;; Fill the remaining part before the size with 0s
+        (memory.fill
+                (i32.add (i32.add (global.get $stack-pointer) (local.get $length)) (i32.const 705))
+                (i32.const 0)
+
+                ;; Leave the last 8 bytes for the length
+                ;; Not handling 16 bytes length here
+                (i32.sub (i32.sub (local.get $length_after_padding) (local.get $length)) (i32.const 8))
+        )
+
+        ;; Add the length, as a 64bits big-endian integer
+        (local.set $message_length_64 (i64.extend_i32_u (i32.shl (local.get $length) (i32.const 3))))
+
+
+        ;; Although length is being handled as i64 (8 bytes)
+        ;; This is the location where reversed length is going to be stored
+        (i32.sub (i32.add (global.get $stack-pointer) (local.get $length_after_padding)) (i32.const 8))
+
+        ;; i64.store values in little-endian format, so to convert the length to big-endian, we need to reverse the 8 bits of length
+        (i64.or
+                (i64.or
+                    (i64.or
+                        (i64.shl (local.get $message_length_64) (i64.const 0x38))
+                        (i64.shl (i64.and (local.get $message_length_64) (i64.const 0xff00)) (i64.const 0x28))
+                    )
+                    (i64.or
+                        (i64.shl (i64.and (local.get $message_length_64) (i64.const 0xff0000)) (i64.const 0x18))
+                        (i64.shl (i64.and (local.get $message_length_64) (i64.const 0xff000000)) (i64.const 0x8))
+                    )
+                )
+                (i64.or
+                    (i64.or
+                        (i64.and (i64.shr_u (local.get $message_length_64) (i64.const 0x8)) (i64.const 0xff000000))
+                        (i64.and (i64.shr_u (local.get $message_length_64) (i64.const 0x18)) (i64.const 0xff0000))
+                    )
+                    (i64.or
+                        (i64.and (i64.shr_u (local.get $message_length_64) (i64.const 0x28)) (i64.const 0xff00))
+                        (i64.shr_u (local.get $message_length_64) (i64.const 0x38))
+                    )
+                )
+        )
+
+        i64.store offset=704
+
+        
+        (local.set $outer-index (i32.const 0))
+
+        ;; Iterations on blocks
+        (loop
+            
+            ;; Process a block
+            
+            (local.set $temp-block-data (i32.add (global.get $stack-pointer) (local.get $outer-index)))
+            
+            (local.set $inner-index (i32.const 0))
+
+            ;; Reverse each word in the block (8 bytes for sha-512) to convert it to little-endian format
+            (loop
+                (i32.add (global.get $stack-pointer) (local.get $inner-index))
+                
+                (i8x16.swizzle
+                    (v128.load offset=704 (i32.add (local.get $temp-block-data) (local.get $inner-index)))
+                    (v128.const i8x16 7 6 5 4 3 2 1 0 15 14 13 12 11 10 9 8)
+                )
+
+                v128.store offset=64
+
+                (br_if 0
+                    (i32.lt_u
+                        (local.tee $inner-index (i32.add (local.get $inner-index) (i32.const 16)))
+                        (i32.const 128)
+                    )
+                )
+            )
+            
+            (local.set $inner-index (i32.const 0))
+
+            (loop
+                (local.set $temp-block-data (i32.add (global.get $stack-pointer) (local.get $inner-index)))
+                
+                ;; Location to store the calculated word in current iteration (current-word + 16) 
+                (i32.add (local.get $temp-block-data) (i32.const 128))
+
+                ;; w(current)
+                (i64.load offset=64 (local.get $temp-block-data))
+
+                ;; sigma 0
+                (local.set $block-iteration-temp (i64.load offset=72 (local.get $temp-block-data))) ;; offset (w+1) = 64 + 8 
+                (i64.rotr (local.get $block-iteration-temp) (i64.const 1))
+                (i64.xor (i64.rotr (local.get $block-iteration-temp) (i64.const 8)))
+                (i64.xor (i64.shr_u (local.get $block-iteration-temp) (i64.const 7)))
+                i64.add
+
+                ;; w(current+9)
+                (i64.add (i64.load offset=136 (local.get $temp-block-data))) ;; offset = 64+72
+
+                ;; sigma 1
+                (local.set $block-iteration-temp (i64.load offset=176 (local.get $temp-block-data))) ;; offset = 64 + 112 w(current+14)
+                (i64.rotr (local.get $block-iteration-temp) (i64.const 19))
+                (i64.xor (i64.rotr (local.get $block-iteration-temp) (i64.const 61)))
+                (i64.xor (i64.shr_u (local.get $block-iteration-temp) (i64.const 6)))
+                i64.add
+
+
+                ;; save
+                i64.store offset=64
+
+                
+                (br_if 0
+                    (i32.lt_u
+                        (local.tee $inner-index (i32.add (local.get $inner-index) (i32.const 8)))
+                        (i32.const 512)
+                    )
+                )
+            )
+
+
+            ;; Calculating variables
+            (local.set $a (i64.load offset=0 (global.get $stack-pointer)))
+            (local.set $b (i64.load offset=8 (global.get $stack-pointer)))
+            (local.set $c (i64.load offset=16 (global.get $stack-pointer)))
+            (local.set $d (i64.load offset=24 (global.get $stack-pointer)))
+            (local.set $e (i64.load offset=32 (global.get $stack-pointer)))
+            (local.set $f (i64.load offset=40 (global.get $stack-pointer)))
+            (local.set $g (i64.load offset=48 (global.get $stack-pointer)))
+            (local.set $h (i64.load offset=56 (global.get $stack-pointer)))
+
+
+
+            (local.set $inner-index (i32.const 0))
+
+            (loop
+                ;; compute $temp1: h + sigma1 + choice + k0 + w0
+                (local.get $h) ;; h
+
+                (i64.rotr (local.get $e) (i64.const 14))
+                (i64.xor (i64.rotr (local.get $e) (i64.const 18)))
+                (i64.xor (i64.rotr (local.get $e) (i64.const 41)))
+                i64.add ;; + sigma1
+
+                (i64.and (local.get $e) (local.get $f))
+                (i64.xor (i64.and (i64.xor (local.get $e) (i64.const -1)) (local.get $g)))
+                i64.add ;; + choice
+
+                (i64.add (i64.load offset=712 (local.get $inner-index))) ;; + k(current)
+            
+                (i64.add (i64.load offset=64 (i32.add (global.get $stack-pointer) (local.get $inner-index)))) ;; + w(current)
+
+                (local.set $temp1)
+
+                ;; compute temp2: sigma0 + majority
+
+                (i64.rotr (local.get $a) (i64.const 28))
+                (i64.xor (i64.rotr (local.get $a) (i64.const 34)))
+                (i64.xor (i64.rotr (local.get $a) (i64.const 39))) ;; sigma0
+
+                (i64.and (local.get $a) (local.get $b))
+                (i64.xor (i64.and (local.get $a) (local.get $c)))
+                (i64.xor (i64.and (local.get $b) (local.get $c)))
+                i64.add ;; + majority
+
+                (local.set $temp2)
+
+                ;; assign new variables
+                (local.set $h (local.get $g))
+                (local.set $g (local.get $f))
+                (local.set $f (local.get $e))
+                (local.set $e (i64.add (local.get $d) (local.get $temp1)))
+                (local.set $d (local.get $c))
+                (local.set $c (local.get $b))
+                (local.set $b (local.get $a))
+                (local.set $a (i64.add (local.get $temp1) (local.get $temp2)))
+
+            
+                (br_if 0
+                    (i32.lt_u
+                        (local.tee $inner-index (i32.add (local.get $inner-index) (i32.const 8)))
+                        (i32.const 640)
+                    )
+                )
+            )
+
+            ;; update hash
+            (i64.store offset=0 (global.get $stack-pointer) (i64.add (i64.load offset=0 (global.get $stack-pointer)) (local.get $a)))
+            (i64.store offset=8 (global.get $stack-pointer) (i64.add (i64.load offset=8 (global.get $stack-pointer)) (local.get $b)))
+            (i64.store offset=16 (global.get $stack-pointer) (i64.add (i64.load offset=16 (global.get $stack-pointer)) (local.get $c)))
+            (i64.store offset=24 (global.get $stack-pointer) (i64.add (i64.load offset=24 (global.get $stack-pointer)) (local.get $d)))
+            (i64.store offset=32 (global.get $stack-pointer) (i64.add (i64.load offset=32 (global.get $stack-pointer)) (local.get $e)))
+            (i64.store offset=40 (global.get $stack-pointer) (i64.add (i64.load offset=40 (global.get $stack-pointer)) (local.get $f)))
+            (i64.store offset=48 (global.get $stack-pointer) (i64.add (i64.load offset=48 (global.get $stack-pointer)) (local.get $g)))
+            (i64.store offset=56 (global.get $stack-pointer) (i64.add (i64.load offset=56 (global.get $stack-pointer)) (local.get $h)))
+
+
+
+            (br_if 0
+                (i32.lt_u
+                    (local.tee $outer-index (i32.add (local.get $outer-index) (i32.const 128)))
+                    (local.get $length_after_padding)
+                )
+            )
+        )
+
+        ;; store at result position with correct endianness
+        (v128.store
+            (local.get $offset-result)
+            (i8x16.swizzle
+                (v128.load (global.get $stack-pointer))
+                (v128.const i8x16 7 6 5 4 3 2 1 0 15 14 13 12 11 10 9 8)
+            )
+        )
+        (v128.store offset=16
+            (local.get $offset-result)
+            (i8x16.swizzle
+                (v128.load offset=16 (global.get $stack-pointer))
+                (v128.const i8x16 7 6 5 4 3 2 1 0 15 14 13 12 11 10 9 8)
+            )
+        )
+
+        (v128.store offset=32
+            (local.get $offset-result)
+            (i8x16.swizzle
+                (v128.load offset=32 (global.get $stack-pointer))
+                (v128.const i8x16 7 6 5 4 3 2 1 0 15 14 13 12 11 10 9 8)
+            )
+        )
+        (v128.store offset=48
+            (local.get $offset-result)
+            (i8x16.swizzle
+                (v128.load offset=48 (global.get $stack-pointer))
+                (v128.const i8x16 7 6 5 4 3 2 1 0 15 14 13 12 11 10 9 8)
+            )
+        )
+
+        (local.get $offset-result) (i32.const 64)
+    )
+
     (export "stdlib.add-uint" (func $stdlib.add-uint))
     (export "stdlib.add-int" (func $stdlib.add-int))
     (export "stdlib.sub-uint" (func $stdlib.sub-uint))
@@ -2585,4 +2879,6 @@
     (export "stdlib.int-to-string" (func $stdlib.int-to-string))
     (export "stdlib.to-uint" (func $stdlib.to-uint))
     (export "stdlib.to-int" (func $stdlib.to-int))
+    (export "stdlib.sha512-buf" (func $stdlib.sha512-buf))
+   
 )

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -2536,7 +2536,7 @@
 
         ;; For binary representation, you can take a look at https://sha256algorithm.com/
         ;; Keep in mind that SHA-256 handles 4-byte words, but SHA-512 handles 8-byte words
-        ;; SHA-256 block is of 512-bits(64 bytes) but SHA-512 block is of 1028-bits(128 bytes)
+        ;; SHA-256 block is of 512-bits(64 bytes) but SHA-512 block is of 1024-bits(128 bytes)
         ;; For initial values, constants and high level understanding of SHA-512, please take a look at this rust implementation
         ;; https://github.com/dandyvica/sha/blob/master/src/sha512.rs
         ;; If you're interested in the paper, please take a look at https://eprint.iacr.org/2010/548.pdf

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -177,7 +177,7 @@
                                                            (param $arguments_length i32)
                                                            (param $return_offset i32)
                                                            (param $return_length i32)))
-                                                           
+
     (import "clarity" "begin_public_call" (func $stdlib.begin_public_call))
     (import "clarity" "begin_read_only_call" (func $stdlib.begin_read_only_call))
     (import "clarity" "commit_call" (func $stdlib.commit_call))
@@ -2821,6 +2821,8 @@
         )
 
         (local.get $offset-result) (i32.const 64)
+    )
+    
     ;; Converts a span of 4-byte unicode scalar values into UTF-8.
     ;; The input bytes are assumed to be composed of valid unicode scalar values.
     ;; Do not call this function with arbitrary bytes.

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -23,7 +23,7 @@ use walrus::{
 use crate::words;
 
 /// First free position after data directly defined in standard.wat
-pub const END_OF_STANDARD_DATA: u32 = 648;
+pub const END_OF_STANDARD_DATA: u32 = 1352;
 
 /// WasmGenerator is a Clarity AST visitor that generates a WebAssembly module
 /// as it traverses the AST.

--- a/clar2wasm/src/words/hashing.rs
+++ b/clar2wasm/src/words/hashing.rs
@@ -203,23 +203,18 @@ impl Word for Sha512 {
                 );
                 Ok(())
             }
-            TypeSignature::SequenceType(SequenceSubtype::BufferType(_)) => {
-                traverse_hash(
-                    "sha512",
-                    core::mem::size_of::<u32>() * 8,
-                    generator,
-                    builder,
-                    expr,
-                    args,
-                )
-            }
-            _ => {
-                Err(GeneratorError::TypeError(
-                    "invalid type for sha512".to_string(),
-                ))
-            }
+            TypeSignature::SequenceType(SequenceSubtype::BufferType(_)) => traverse_hash(
+                "sha512",
+                core::mem::size_of::<u32>() * 8,
+                generator,
+                builder,
+                expr,
+                args,
+            ),
+            _ => Err(GeneratorError::TypeError(
+                "invalid type for sha512".to_string(),
+            )),
         }
-
     }
 }
 

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -517,7 +517,7 @@ fn prop_store_i64_be() {
 fn prop_sha256_buff() {
     test_on_buffer_hash(
         "stdlib.sha256-buf",
-        1024,
+        1600,
         END_OF_STANDARD_DATA as usize + 32,
         300,
         END_OF_STANDARD_DATA as i32,

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::ops::DerefMut;
 
 use clar2wasm::wasm_generator::END_OF_STANDARD_DATA;
-use clarity::util::hash::{Hash160, Sha256Sum,Sha512Sum};
+use clarity::util::hash::{Hash160, Sha256Sum, Sha512Sum};
 use proptest::{prop_assert_eq, proptest};
 use wasmtime::Val;
 

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -517,7 +517,7 @@ fn prop_store_i64_be() {
 fn prop_sha256_buff() {
     test_on_buffer_hash(
         "stdlib.sha256-buf",
-        1600,
+        2048,
         END_OF_STANDARD_DATA as usize + 32,
         300,
         END_OF_STANDARD_DATA as i32,
@@ -530,7 +530,7 @@ fn prop_sha256_buff() {
 fn prop_sha256_int_on_signed() {
     test_on_int_hash(
         "stdlib.sha256-int",
-        1024,
+        2048,
         END_OF_STANDARD_DATA as i32,
         32,
         |n| Sha256Sum::from_data(&n.to_le_bytes()).as_bytes().to_vec(),
@@ -541,7 +541,7 @@ fn prop_sha256_int_on_signed() {
 fn prop_sha256_int_on_unsigned() {
     test_on_uint_hash(
         "stdlib.sha256-int",
-        1024,
+        2048,
         END_OF_STANDARD_DATA as i32,
         32,
         |n| Sha256Sum::from_data(&n.to_le_bytes()).as_bytes().to_vec(),
@@ -565,7 +565,7 @@ fn prop_hash160_buff() {
 fn prop_hash160_int_on_signed() {
     test_on_int_hash(
         "stdlib.hash160-int",
-        1024,
+        2048,
         END_OF_STANDARD_DATA as i32,
         20,
         |n| Hash160::from_data(&n.to_le_bytes()).as_bytes().to_vec(),
@@ -576,7 +576,7 @@ fn prop_hash160_int_on_signed() {
 fn prop_hash160_int_on_unsigned() {
     test_on_uint_hash(
         "stdlib.hash160-int",
-        1024,
+        2048,
         END_OF_STANDARD_DATA as i32,
         20,
         |n| Hash160::from_data(&n.to_le_bytes()).as_bytes().to_vec(),

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::ops::DerefMut;
 
 use clar2wasm::wasm_generator::END_OF_STANDARD_DATA;
-use clarity::util::hash::{Hash160, Sha256Sum};
+use clarity::util::hash::{Hash160, Sha256Sum,Sha512Sum};
 use proptest::{prop_assert_eq, proptest};
 use wasmtime::Val;
 
@@ -523,6 +523,19 @@ fn prop_sha256_buff() {
         END_OF_STANDARD_DATA as i32,
         32,
         |buf| Sha256Sum::from_data(buf).as_bytes().to_vec(),
+    )
+}
+
+#[test]
+fn prop_sha512_buff() {
+    test_on_buffer_hash(
+        "stdlib.sha512-buf",
+        2048,
+        END_OF_STANDARD_DATA as usize + 64,
+        300,
+        END_OF_STANDARD_DATA as i32,
+        64,
+        |buf| Sha512Sum::from_data(buf).as_bytes().to_vec(),
     )
 }
 


### PR DESCRIPTION
This PR adds SHA-512 support in `standard.wat`. 

- `END_OF_STANDARD_DATA` in `wasm_generator.rs` updated to 1352.
- This SHA-512 uses 8 bytes for length (which is sufficient for our use case)
- Written in only one function (for improved performance)
- Existing `sha256-buf` structure followed for consistency 
- Unit tests are passing


