### PR TITLE
Property tests for generated values

### DIFF
--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -508,15 +508,21 @@ fn wasm_equal_optional(
         let mut then = builder.dangling_instr_seq(ValType::I32);
         // is none ?
         then.local_get(*first_variant).unop(UnaryOp::I32Eqz);
-        // is some inner equal ?
-        wasm_equal(
-            some_ty,
-            nth_some_ty,
-            generator,
-            &mut then,
-            first_inner,
-            nth_inner,
-        )?; // is some arguments equal ?
+        // is some inner equal ? (or automatic true if NoType)
+        if some_ty == &TypeSignature::NoType {
+            // if first operand is NoType, it means that it is a none and we
+            // put true directly to because it is enough to check for variant equality
+            then.i32_const(1);
+        } else {
+            wasm_equal(
+                some_ty,
+                nth_some_ty,
+                generator,
+                &mut then,
+                first_inner,
+                nth_inner,
+            )?; // is some arguments equal ?
+        }
         then.binop(BinaryOp::I32Or);
         then.id()
     };

--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -51,11 +51,7 @@ impl Word for ListCons {
             // This means that the placeholder will be represented with a different number of `ValType`, and will
             // cause errors (example: function called with wrong number of arguments).
             // While we wait for a real fix in the typechecker, here is a workaround to set all the elements types.
-            generator
-                .contract_analysis
-                .type_map
-                .as_mut()
-                .map(|tm| tm.set_type(expr, elem_ty.clone()));
+            generator.set_expr_type(expr, elem_ty.clone());
 
             generator.traverse_expr(builder, expr)?;
             // Write this element to memory

--- a/clar2wasm/src/words/tuples.rs
+++ b/clar2wasm/src/words/tuples.rs
@@ -71,11 +71,7 @@ impl Word for TupleCons {
             // does not have the same amount of values in the Wasm code than the correct type.
             // While we wait for a real fix in the typechecker, here is a workaround to make sure that the type
             // is correct.
-            generator
-                .contract_analysis
-                .type_map
-                .as_mut()
-                .map(|tm| tm.set_type(value, ty.clone()));
+            generator.set_expr_type(value, ty.clone());
 
             generator.traverse_expr(builder, value)?;
         }

--- a/clar2wasm/src/words/tuples.rs
+++ b/clar2wasm/src/words/tuples.rs
@@ -59,12 +59,24 @@ impl Word for TupleCons {
         }
 
         // Now we can iterate over the tuple type and build the tuple.
-        for key in tuple_ty.get_type_map().keys() {
+        for (key, ty) in tuple_ty.get_type_map() {
             let value = values
                 .remove(key)
                 .ok_or(GeneratorError::InternalError(format!(
                     "missing key '{key}' in tuple"
                 )))?;
+
+            // WORKAROUND: if you have a tuple like `(tuple (foo none))`, the `none` will have the type
+            // NoType, even if it has a defined type in the tuple. This creates issues because the placeholder
+            // does not have the same amount of values in the Wasm code than the correct type.
+            // While we wait for a real fix in the typechecker, here is a workaround to make sure that the type
+            // is correct.
+            generator
+                .contract_analysis
+                .type_map
+                .as_mut()
+                .map(|tm| tm.set_type(value, ty.clone()));
+
             generator.traverse_expr(builder, value)?;
         }
 

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -1,3 +1,4 @@
+pub mod regression;
 pub mod values;
 
 use clarity::vm::types::{

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -4,7 +4,6 @@ use clarity::vm::types::{
     ASCIIData, BuffData, ListData, ListTypeData, OptionalData, ResponseData, SequenceData,
     SequenceSubtype, StringSubtype, TupleData, TupleTypeSignature, TypeSignature, Value,
 };
-
 use proptest::prelude::*;
 
 pub fn prop_signature() -> impl Strategy<Value = TypeSignature> {

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -1,0 +1,254 @@
+pub mod values;
+
+use clarity::vm::types::{
+    ASCIIData, BuffData, ListData, ListTypeData, OptionalData, ResponseData, SequenceData,
+    SequenceSubtype, StringSubtype, TupleData, TupleTypeSignature, TypeSignature, Value,
+};
+
+use proptest::prelude::*;
+
+pub fn prop_signature() -> impl Strategy<Value = TypeSignature> {
+    let leaf = prop_oneof![
+        Just(TypeSignature::IntType),
+        Just(TypeSignature::UIntType),
+        Just(TypeSignature::BoolType),
+        (0u32..256).prop_map(|s| TypeSignature::SequenceType(SequenceSubtype::BufferType(
+            s.try_into().unwrap()
+        ))),
+        (0u32..256).prop_map(|s| TypeSignature::SequenceType(SequenceSubtype::StringType(
+            StringSubtype::ASCII(s.try_into().unwrap())
+        ))),
+        // TODO: principal,
+        // TODO: string-utf8
+        // TODO: CallableType
+    ];
+    leaf.prop_recursive(5, 64, 10, |inner| {
+        prop_oneof![
+            // optional type: 10% NoType + 90% any other type
+            prop_oneof![
+                1 => Just(TypeSignature::NoType),
+                9 => inner.clone(),
+            ]
+            .prop_map(|t| TypeSignature::new_option(t).unwrap()),
+            // response type: 20% (NoType, any) + 20% (any, NoType) + 60% (any, any)
+            prop_oneof![
+                1 => inner.clone().prop_map(|ok_ty| TypeSignature::new_response(ok_ty, TypeSignature::NoType).unwrap()),
+                1 => inner.clone().prop_map(|err_ty| TypeSignature::new_response(TypeSignature::NoType, err_ty).unwrap()),
+                3 => (inner.clone(), inner.clone()).prop_map(|(ok_ty, err_ty)| TypeSignature::new_response(ok_ty, err_ty).unwrap()),
+            ],
+            // tuple type
+            prop::collection::btree_map(
+                r#"[a-zA-Z]{1,16}"#.prop_map(|name| name.try_into().unwrap()),
+                inner.clone(),
+                1..16
+            )
+            .prop_map(|btree| TypeSignature::TupleType(btree.try_into().unwrap())),
+            // list type
+            (16u32..64, inner.clone()).prop_map(|(s, ty)| (ListTypeData::new_list(ty, s).unwrap()).into()),
+        ]
+    })
+}
+
+pub struct PropValue(Value);
+
+impl From<Value> for PropValue {
+    fn from(value: Value) -> Self {
+        PropValue(value)
+    }
+}
+
+impl From<PropValue> for Value {
+    fn from(value: PropValue) -> Self {
+        value.0
+    }
+}
+
+impl std::fmt::Debug for PropValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self, f)
+    }
+}
+
+impl std::fmt::Display for PropValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.0 {
+            Value::Sequence(SequenceData::String(clarity::vm::types::CharType::ASCII(
+                ASCIIData { data },
+            ))) => {
+                write!(f, "\"")?;
+                for b in data {
+                    if [b'\\', b'"'].contains(b) {
+                        write!(f, "\\")?;
+                    }
+                    write!(f, "{}", *b as char)?;
+                }
+                write!(f, "\"")
+            }
+            Value::Optional(OptionalData { data }) => match data {
+                Some(inner) => write!(f, "(some {})", PropValue(*inner.clone())),
+                None => write!(f, "none"),
+            },
+            Value::Response(ResponseData { committed, data }) => {
+                if *committed {
+                    write!(f, "(ok {})", PropValue(*data.clone()))
+                } else {
+                    write!(f, "(err {})", PropValue(*data.clone()))
+                }
+            }
+            Value::Sequence(SequenceData::List(ListData { data, .. })) => {
+                write!(f, "(list")?;
+                for d in data {
+                    write!(f, " ")?;
+                    write!(f, "{}", PropValue(d.clone()))?;
+                }
+                write!(f, ")")
+            }
+            Value::Tuple(data) => {
+                write!(f, "(tuple")?;
+                for (key, value) in &data.data_map {
+                    write!(f, " ")?;
+                    write!(f, "({} {})", &**key, PropValue(value.clone()))?;
+                }
+                write!(f, ")")
+            }
+            otherwise => write!(f, "{otherwise}"),
+        }
+    }
+}
+
+impl PropValue {
+    pub fn any() -> impl Strategy<Value = Self> {
+        prop_signature().prop_flat_map(prop_value).prop_map_into()
+    }
+
+    pub fn from_type(ty: TypeSignature) -> impl Strategy<Value = Self> {
+        prop_value(ty).prop_map_into()
+    }
+}
+
+fn prop_value(ty: TypeSignature) -> impl Strategy<Value = Value> {
+    match ty {
+        TypeSignature::NoType => unreachable!(),
+        TypeSignature::IntType => int().boxed(),
+        TypeSignature::UIntType => uint().boxed(),
+        TypeSignature::BoolType => bool().boxed(),
+        TypeSignature::OptionalType(ty) => optional(*ty).boxed(),
+        TypeSignature::ResponseType(ok_err) => response(ok_err.0, ok_err.1).boxed(),
+        TypeSignature::SequenceType(SequenceSubtype::BufferType(size)) => {
+            buffer(size.into()).boxed()
+        }
+        TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::ASCII(size))) => {
+            string_ascii(size.into()).boxed()
+        }
+        TypeSignature::SequenceType(SequenceSubtype::ListType(list_type_data)) => {
+            list(list_type_data).boxed()
+        }
+        TypeSignature::TupleType(tuple_ty) => tuple(tuple_ty).boxed(),
+
+        // TODO
+        TypeSignature::PrincipalType => todo!(),
+        TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::UTF8(_))) => todo!(),
+        TypeSignature::CallableType(_) => todo!(),
+        TypeSignature::ListUnionType(_) => todo!(),
+        TypeSignature::TraitReferenceType(_) => todo!(),
+    }
+}
+
+fn int() -> impl Strategy<Value = Value> {
+    any::<i128>().prop_map(Value::Int)
+}
+
+fn uint() -> impl Strategy<Value = Value> {
+    any::<u128>().prop_map(Value::UInt)
+}
+
+fn bool() -> impl Strategy<Value = Value> {
+    any::<bool>().prop_map(Value::Bool)
+}
+
+pub fn string_ascii(size: u32) -> impl Strategy<Value = Value> {
+    let size = size as usize;
+    prop::collection::vec(0x32u8..0x7e, size..=size).prop_map(|bytes| {
+        Value::Sequence(SequenceData::String(clarity::vm::types::CharType::ASCII(
+            clarity::vm::types::ASCIIData { data: bytes },
+        )))
+    })
+}
+
+fn buffer(size: u32) -> impl Strategy<Value = Value> {
+    let size = size as usize;
+    prop::collection::vec(any::<u8>(), size..=size)
+        .prop_map(|bytes| Value::Sequence(SequenceData::Buffer(BuffData { data: bytes })))
+}
+
+fn optional(inner_ty: TypeSignature) -> impl Strategy<Value = Value> {
+    match inner_ty {
+        TypeSignature::NoType => Just(Value::none()).boxed(),
+        _ => prop::option::of(prop_value(inner_ty))
+            .prop_map(|v| {
+                Value::Optional(OptionalData {
+                    data: v.map(Box::new),
+                })
+            })
+            .boxed(),
+    }
+}
+
+fn response(ok_ty: TypeSignature, err_ty: TypeSignature) -> impl Strategy<Value = Value> {
+    match (ok_ty, err_ty) {
+        (TypeSignature::NoType, err_ty) => prop_value(err_ty)
+            .prop_map(|err| {
+                Value::Response(ResponseData {
+                    committed: false,
+                    data: Box::new(err),
+                })
+            })
+            .boxed(),
+        (ok_ty, TypeSignature::NoType) => prop_value(ok_ty)
+            .prop_map(|ok| {
+                Value::Response(ResponseData {
+                    committed: true,
+                    data: Box::new(ok),
+                })
+            })
+            .boxed(),
+        (ok_ty, err_ty) => prop::result::maybe_err(prop_value(ok_ty), prop_value(err_ty))
+            .prop_map(|res| {
+                Value::Response(ResponseData {
+                    committed: res.is_ok(),
+                    data: res.map_or_else(Box::new, Box::new),
+                })
+            })
+            .boxed(),
+    }
+}
+
+fn list(list_type_data: ListTypeData) -> impl Strategy<Value = Value> {
+    prop::collection::vec(
+        prop_value(list_type_data.get_list_item_type().clone()),
+        0..list_type_data.get_max_len() as usize,
+    )
+    .prop_map(move |v| {
+        Value::Sequence(SequenceData::List(ListData {
+            data: v,
+            type_signature: list_type_data.clone(),
+        }))
+    })
+}
+
+fn tuple(tuple_ty: TupleTypeSignature) -> impl Strategy<Value = Value> {
+    let fields: Vec<_> = tuple_ty.get_type_map().keys().cloned().collect();
+    let strategies: Vec<_> = tuple_ty
+        .get_type_map()
+        .values()
+        .cloned()
+        .map(prop_value)
+        .collect();
+    strategies.prop_map(move |vec_values| {
+        TupleData {
+            type_signature: tuple_ty.clone(),
+            data_map: fields.clone().into_iter().zip(vec_values).collect(),
+        }
+        .into()
+    })
+}

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -19,7 +19,6 @@ pub fn prop_signature() -> impl Strategy<Value = TypeSignature> {
         ))),
         // TODO: principal,
         // TODO: string-utf8
-        // TODO: CallableType
     ];
     leaf.prop_recursive(5, 64, 10, |inner| {
         prop_oneof![

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -167,7 +167,7 @@ fn bool() -> impl Strategy<Value = Value> {
 
 pub fn string_ascii(size: u32) -> impl Strategy<Value = Value> {
     let size = size as usize;
-    prop::collection::vec(0x32u8..0x7e, size..=size).prop_map(|bytes| {
+    prop::collection::vec(0x20u8..0x7e, size..=size).prop_map(|bytes| {
         Value::Sequence(SequenceData::String(clarity::vm::types::CharType::ASCII(
             clarity::vm::types::ASCIIData { data: bytes },
         )))

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -12,10 +12,10 @@ pub fn prop_signature() -> impl Strategy<Value = TypeSignature> {
         Just(TypeSignature::IntType),
         Just(TypeSignature::UIntType),
         Just(TypeSignature::BoolType),
-        (0u32..256).prop_map(|s| TypeSignature::SequenceType(SequenceSubtype::BufferType(
+        (0u32..128).prop_map(|s| TypeSignature::SequenceType(SequenceSubtype::BufferType(
             s.try_into().unwrap()
         ))),
-        (0u32..256).prop_map(|s| TypeSignature::SequenceType(SequenceSubtype::StringType(
+        (0u32..128).prop_map(|s| TypeSignature::SequenceType(SequenceSubtype::StringType(
             StringSubtype::ASCII(s.try_into().unwrap())
         ))),
         // TODO: principal,
@@ -40,11 +40,11 @@ pub fn prop_signature() -> impl Strategy<Value = TypeSignature> {
             prop::collection::btree_map(
                 r#"[a-zA-Z]{1,16}"#.prop_map(|name| name.try_into().unwrap()),
                 inner.clone(),
-                1..16
+                1..8
             )
             .prop_map(|btree| TypeSignature::TupleType(btree.try_into().unwrap())),
             // list type
-            (16u32..64, inner.clone()).prop_map(|(s, ty)| (ListTypeData::new_list(ty, s).unwrap()).into()),
+            (8u32..32, inner.clone()).prop_map(|(s, ty)| (ListTypeData::new_list(ty, s).unwrap()).into()),
         ]
     })
 }

--- a/clar2wasm/tests/wasm-generation/regression.rs
+++ b/clar2wasm/tests/wasm-generation/regression.rs
@@ -1,0 +1,27 @@
+/// This files purpose is to add examples of generated values that failed,
+/// so that we can be sure they won't fail again after some random refactor
+/// in the future.
+use clar2wasm::tools::evaluate;
+
+use crate::PropValue;
+
+fn evaluate_expression(expr: &str) {
+    let v: PropValue = evaluate(expr)
+        .expect("Failed to evaluate expression")
+        .into();
+    assert_eq!(expr, v.to_string());
+}
+
+#[test]
+fn list_ok_response() {
+    evaluate_expression(
+        r#"(list (ok (ok -1475)) (ok (err u115911259112154807243168097824046874107)))"#,
+    )
+}
+
+#[test]
+fn list_err_response() {
+    evaluate_expression(
+        r#"(list (err (ok -1475)) (err (err u115911259112154807243168097824046874107)))"#,
+    )
+}

--- a/clar2wasm/tests/wasm-generation/regression.rs
+++ b/clar2wasm/tests/wasm-generation/regression.rs
@@ -25,3 +25,10 @@ fn list_err_response() {
         r#"(list (err (ok -1475)) (err (err u115911259112154807243168097824046874107)))"#,
     )
 }
+
+#[test]
+fn list_some_response() {
+    evaluate_expression(
+        r#"(list (some (ok -1475)) (some (err u115911259112154807243168097824046874107)))"#,
+    )
+}

--- a/clar2wasm/tests/wasm-generation/values.rs
+++ b/clar2wasm/tests/wasm-generation/values.rs
@@ -1,0 +1,20 @@
+use clar2wasm::tools::evaluate;
+use proptest::proptest;
+
+use proptest::prelude::ProptestConfig;
+
+use crate::PropValue;
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 500,
+        .. ProptestConfig::default()
+    })]
+    #[test]
+    fn evaluated_value_is_the_value_itself(val in PropValue::any()) {
+        assert_eq!(
+            evaluate(&val.to_string()),
+            Some(val.into())
+        )
+    }
+}

--- a/clar2wasm/tests/wasm-generation/values.rs
+++ b/clar2wasm/tests/wasm-generation/values.rs
@@ -1,7 +1,6 @@
 use clar2wasm::tools::evaluate;
-use proptest::proptest;
-
 use proptest::prelude::ProptestConfig;
+use proptest::proptest;
 
 use crate::PropValue;
 

--- a/tests/contracts/equal.clar
+++ b/tests/contracts/equal.clar
@@ -114,6 +114,10 @@
     (ok (is-eq (some 1) (some 1)))
 )
 
+(define-public (call-optional-none-equal)
+    (ok (is-eq none none))
+)
+
 (define-public (call-optional-unequal)
     (ok (is-eq (some 0x01) (some 0x02)))
 )

--- a/tests/src/lib_tests.rs
+++ b/tests/src/lib_tests.rs
@@ -3227,6 +3227,16 @@ test_contract_call_response!(
 );
 
 test_contract_call_response!(
+    test_call_optional_none_equal,
+    "equal",
+    "call-optional-none-equal",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Bool(true));
+    }
+);
+
+test_contract_call_response!(
     test_call_optional_unequal,
     "equal",
     "call-optional-unequal",


### PR DESCRIPTION
This PR adds a new way to add tests to the codebase. 

We have now in _clar2wasm/tests/wasm-generation_ `prop_signature` which allows the generation of random value signatures, and the struct `PropValue`, which allows the generation of values of any type, or for a determined type.

There is also the first property test that uses them. It checks that any generated value, when evaluated, is equal to itself.

This PR also adds implementations for most of the remaining types in `WasmGenerator::write_to_memory`, since this is needed for `list` values.

It also contains fixes in the `tuple` and `list` functions. The typechecker does not always give the correct type to the values there, which might generate incorrect Wasm code. See the comments in those functions `traverse` for examples.

There is also a fix for `wasm_equal_optional`. This is because this PR started as a way to test `is-eq`. But since we needed more implementations in `write_to_memory`, different fixes and also a [fix in stacks-core](https://github.com/stacks-network/stacks-core/commit/fa5071b8edbf52d9927a5750d3c52093d25aeab2), I decided to reduce the scope of this PR and just have the test for the evaluation of values.
However, since a fix already existed before I decided to modify the scope of the PR, I kept it here.