### PR TITLE
Handle thrown errors from top-level statements

### DIFF
--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -278,7 +278,8 @@
         ;; 4: expected a non-negative number
         ;; 5: buffer to integer expects a buffer length <= 16
         ;; 6: panic
-    (func $runtime-error (param $error-code i32)
+        ;; 7: short return
+    (func $stdlib.runtime-error (param $error-code i32)
         ;; TODO: Implement runtime error
         unreachable
     )
@@ -311,7 +312,7 @@
         (if (i64.eq (i64.shr_s (local.get $a_hi) (i64.const 63)) (i64.shr_s (local.get $b_hi) (i64.const 63))) ;; if a and b have the same sign
             (then
                 (if (i64.ne (i64.shr_s (local.get $a_hi) (i64.const 63)) (i64.shr_s (local.get $sum_hi) (i64.const 63))) ;; and the result has a different sign
-                    (then (call $runtime-error (i32.const 0)))
+                    (then (call $stdlib.runtime-error (i32.const 0)))
                 )
             )
         )
@@ -327,7 +328,7 @@
 
         ;; overflow condition: sum (a) < operand (b)
         (if (call $stdlib.lt-uint (local.get $a_lo) (local.get $a_hi) (local.get $b_lo) (local.get $b_hi))
-            (then (call $runtime-error (i32.const 0)))
+            (then (call $stdlib.runtime-error (i32.const 0)))
         )
 
         (local.get $a_lo) (local.get $a_hi)
@@ -369,7 +370,7 @@
         (if (i64.ne (i64.shr_s (local.get $a_hi) (i64.const 63)) (i64.shr_s (local.get $b_hi) (i64.const 63))) ;; if a and b have different signs
             (then
                 (if (i64.ne (i64.shr_s (local.get $a_hi) (i64.const 63)) (i64.shr_s (local.get $diff_hi) (i64.const 63))) ;; and the result has a different sign from a
-                    (then (call $runtime-error (i32.const 1)))
+                    (then (call $stdlib.runtime-error (i32.const 1)))
                 )
             )
         )
@@ -393,7 +394,7 @@
 
         ;; Check for underflow
         (if (i64.gt_u (local.get $diff_hi) (local.get $a_hi))
-            (then (call $runtime-error (i32.const 1)))
+            (then (call $stdlib.runtime-error (i32.const 1)))
         )
 
         ;; Return the result
@@ -464,7 +465,7 @@
         (if (i32.le_u (local.get $tmp) (i32.const 126))
             (then
                 ;; product will overflow if the sum of leading zeros is <= 126
-                (call $runtime-error (i32.const 0))
+                (call $stdlib.runtime-error (i32.const 0))
             )
         )
 
@@ -490,7 +491,7 @@
 
         ;; if result/2 > 2**127 overflow
         (if (i64.lt_s (local.get $b_hi) (i64.const 0))
-            (then (call $runtime-error (i32.const 0)))
+            (then (call $stdlib.runtime-error (i32.const 0)))
         )
 
         ;; res *= 2, meaning res <<= 1
@@ -566,7 +567,7 @@
 
         ;; Sign bit should be 0, otherwise there is an overflow
         (if (i64.lt_s (local.get $a_hi) (i64.const 0))
-            (then (call $runtime-error (i32.const 0)))
+            (then (call $stdlib.runtime-error (i32.const 0)))
         )
 
         ;; Return the result and adapt with sign bit
@@ -591,7 +592,7 @@
 
         ;; Check for division by 0
         (if (i64.eqz (i64.or (local.get $divisor_hi) (local.get $divisor_lo)))
-            (then (call $runtime-error (i32.const 2)))
+            (then (call $stdlib.runtime-error (i32.const 2)))
         )
 
         ;; Long division algorithm
@@ -1016,7 +1017,7 @@
 
     (func $stdlib.log2-uint (param $lo i64) (param $hi i64) (result i64 i64)
         (if (i64.eqz (i64.or (local.get $hi) (local.get $lo)))
-            (then (call $runtime-error (i32.const 3)))
+            (then (call $stdlib.runtime-error (i32.const 3)))
         )
         (call $log2 (local.get $lo) (local.get $hi))
         (i64.const 0)
@@ -1024,7 +1025,7 @@
 
     (func $stdlib.log2-int (param $lo i64) (param $hi i64) (result i64 i64)
         (if (call $stdlib.le-int (local.get $lo) (local.get $hi) (i64.const 0) (i64.const 0))
-            (then (call $runtime-error (i32.const 3)))
+            (then (call $stdlib.runtime-error (i32.const 3)))
         )
         (call $log2 (local.get $lo) (local.get $hi))
         (i64.const 0)
@@ -1125,7 +1126,7 @@
 
     (func $stdlib.sqrti-int (param $lo i64) (param $hi i64) (result i64 i64)
         (if (i64.lt_s (local.get $hi) (i64.const 0))
-            (then (call $runtime-error (i32.const 4)))
+            (then (call $stdlib.runtime-error (i32.const 4)))
         )
         (call $stdlib.sqrti-uint (local.get $lo) (local.get $hi))
     )
@@ -1270,7 +1271,7 @@
                 (i64.gt_u (local.get $b_lo) (i64.const 127))
                 (i64.ne (local.get $b_hi) (i64.const 0))
             )
-            (then (call $runtime-error (i32.const 0)))
+            (then (call $stdlib.runtime-error (i32.const 0)))
         )
 
         ;; shortcut if a == 2
@@ -1313,7 +1314,7 @@
 
         ;; otherwise, if b < 0 => runtime error
         (if (i64.lt_s (local.get $b_hi) (i64.const 0))
-            (then (call $runtime-error (i32.const 4)))
+            (then (call $stdlib.runtime-error (i32.const 4)))
         )
 
         ;; if b > (a >= 0 ? 126 : 127) -> runtime error: overflow (since the biggest b that doesn't
@@ -1322,7 +1323,7 @@
                 (local.get $b_lo)
                 (i64.add (i64.const 126) (i64.extend_i32_u (i64.lt_s (local.get $a_hi) (i64.const 0))))
             )
-            (then (call $runtime-error (i32.const 0)))
+            (then (call $stdlib.runtime-error (i32.const 0)))
         )
 
         ;; shortcut if a == 2
@@ -1393,7 +1394,7 @@
 
         ;; overflow if result is negative
         (if (i64.lt_s (local.get $a_hi) (i64.const 0))
-            (then (call $runtime-error (i32.const 0)))
+            (then (call $stdlib.runtime-error (i32.const 0)))
         )
 
         (if (result i64 i64) (local.get $negative)
@@ -1916,7 +1917,7 @@
     (func $stdlib.buff-to-uint-be (param $offset i32) (param $length i32) (result i64 i64)
         (local $mask_lo i64) (local $mask_hi i64) (local $double v128)
         (if (i32.gt_u (local.get $length) (i32.const 16))
-            (then (call $runtime-error (i32.const 5)))
+            (then (call $stdlib.runtime-error (i32.const 5)))
         )
 
         (if (i32.eqz (local.get $length))
@@ -1954,7 +1955,7 @@
     (func $stdlib.buff-to-uint-le (param $offset i32) (param $length i32) (result i64 i64)
         (local $mask_lo i64) (local $mask_hi i64)
         (if (i32.gt_u (local.get $length) (i32.const 16))
-            (then (call $runtime-error (i32.const 5)))
+            (then (call $stdlib.runtime-error (i32.const 5)))
         )
 
         (if (i32.eqz (local.get $length))
@@ -2501,7 +2502,7 @@
     ;;
     (func $stdlib.to-uint (param $lo i64) (param $hi i64) (result i64 i64)
         (if (i64.lt_s (local.get $hi) (i64.const 0))
-            (then (call $runtime-error (i32.const 4)))
+            (then (call $stdlib.runtime-error (i32.const 4)))
         )
         (local.get $lo)
         (local.get $hi)
@@ -2520,7 +2521,7 @@
         ;; Thus, if $hi >= 2^63 the argument is >= 2^127,
         ;; no matter what is present in $lo.
         (if (i64.ge_u (local.get $hi) (i64.const 9223372036854775808))
-            (then (call $runtime-error (i32.const 4)))
+            (then (call $stdlib.runtime-error (i32.const 4)))
         )
         (local.get $lo)
         (local.get $hi)

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -364,6 +364,9 @@ impl WasmGenerator {
         // Restore the top-level locals map.
         self.bindings = top_level_locals;
 
+        // Reset the return type to None
+        self.return_type = None;
+
         Ok(func_builder.finish(param_locals, &mut self.module.funcs))
     }
 

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -368,15 +368,18 @@ impl WasmGenerator {
     }
 
     pub fn return_early(&self, builder: &mut InstrSeqBuilder) -> Result<(), GeneratorError> {
-        let early_return = self
-            .early_return_block_id
-            .ok_or(GeneratorError::InternalError(
-                "No return block avaliable".into(),
-            ))?;
-
-        builder.instr(walrus::ir::Br {
-            block: early_return,
-        });
+        if let Some(block_id) = self.early_return_block_id {
+            builder.instr(walrus::ir::Br { block: block_id });
+        } else {
+            // This must be from a top-leve statement, so it should cause a runtime error
+            builder.i32_const(7).call(
+                self.module
+                    .funcs
+                    .by_name("stdlib.runtime-error")
+                    .expect("stdlib.runtime-error not found"),
+            );
+            builder.unreachable();
+        }
 
         Ok(())
     }

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -364,8 +364,9 @@ impl WasmGenerator {
         // Restore the top-level locals map.
         self.bindings = top_level_locals;
 
-        // Reset the return type to None
+        // Reset the return type and early block to None
         self.return_type = None;
+        self.early_return_block_id = None;
 
         Ok(func_builder.finish(param_locals, &mut self.module.funcs))
     }

--- a/clar2wasm/src/words/arithmetic.rs
+++ b/clar2wasm/src/words/arithmetic.rs
@@ -188,3 +188,25 @@ impl Word for Sqrti {
         traverse_typed_multi_value(generator, builder, expr, args, "sqrti")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::tools::TestEnvironment;
+
+    #[test]
+    fn test_overflow() {
+        let mut env = TestEnvironment::default();
+        env.init_contract_with_snippet(
+            "snippet",
+            "(+ u340282366920938463463374607431768211455 u1)",
+        )
+        .expect_err("should panic");
+    }
+
+    #[test]
+    fn test_underflow() {
+        let mut env = TestEnvironment::default();
+        env.init_contract_with_snippet("snippet", "(- u0 u1)")
+            .expect_err("should panic");
+    }
+}

--- a/clar2wasm/src/words/conditionals.rs
+++ b/clar2wasm/src/words/conditionals.rs
@@ -967,4 +967,16 @@ mod tests {
             Some(Value::Int(11))
         );
     }
+
+    #[test]
+    fn asserts_top_level_true() {
+        assert_eq!(eval("(asserts! true (err u1))"), Some(Value::Bool(true)));
+    }
+
+    #[test]
+    fn asserts_top_level_false() {
+        let mut env = TestEnvironment::default();
+        env.init_contract_with_snippet("snippet", "(asserts! false (err u1))")
+            .expect_err("should panic");
+    }
 }

--- a/clar2wasm/src/words/conditionals.rs
+++ b/clar2wasm/src/words/conditionals.rs
@@ -405,15 +405,12 @@ impl Word for Unwrap {
         ));
 
         // The type-checker does not fill in the complete type for the throw
-        // expression, so we need to manually update it here.
-        generator.set_expr_type(
-            throw,
-            generator
-                .return_type
-                .as_ref()
-                .ok_or_else(|| GeneratorError::InternalError("Return type not set".to_string()))?
-                .clone(),
-        );
+        // expression, so we need to manually update it here. If the return
+        // type is not set, then we are not in a function, and the type can't
+        // be determined.
+        if let Some(return_ty) = &generator.return_type {
+            generator.set_expr_type(throw, return_ty.clone());
+        }
         generator.traverse_expr(&mut throw_branch, throw)?;
         generator.return_early(&mut throw_branch)?;
 
@@ -487,15 +484,12 @@ impl Word for UnwrapErr {
         ));
 
         // The type-checker does not fill in the complete type for the throw
-        // expression, so we need to manually update it here.
-        generator.set_expr_type(
-            throw,
-            generator
-                .return_type
-                .as_ref()
-                .ok_or_else(|| GeneratorError::InternalError("Return type not set".to_string()))?
-                .clone(),
-        );
+        // expression, so we need to manually update it here. If the return
+        // type is not set, then we are not in a function, and the type can't
+        // be determined.
+        if let Some(return_ty) = &generator.return_type {
+            generator.set_expr_type(throw, return_ty.clone());
+        }
         generator.traverse_expr(&mut throw_branch, throw)?;
         generator.return_early(&mut throw_branch)?;
 
@@ -570,15 +564,12 @@ impl Word for Asserts {
         ));
 
         // The type-checker does not fill in the complete type for the throw
-        // expression, so we need to manually update it here.
-        generator.set_expr_type(
-            throw,
-            generator
-                .return_type
-                .as_ref()
-                .ok_or_else(|| GeneratorError::InternalError("Return type not set".to_string()))?
-                .clone(),
-        );
+        // expression, so we need to manually update it here. If the return
+        // type is not set, then we are not in a function, and the type can't
+        // be determined.
+        if let Some(return_ty) = &generator.return_type {
+            generator.set_expr_type(throw, return_ty.clone());
+        }
         generator.traverse_expr(&mut throw_branch, throw)?;
         generator.return_early(&mut throw_branch)?;
 

--- a/clar2wasm/src/words/control_flow.rs
+++ b/clar2wasm/src/words/control_flow.rs
@@ -95,8 +95,8 @@ impl Word for UnwrapPanic {
                             generator
                                 .module
                                 .funcs
-                                .by_name("runtime-error")
-                                .expect("runtime_error not found"),
+                                .by_name("stdlib.runtime-error")
+                                .expect("stdlib.runtime-error not found"),
                         );
                     },
                     |_| {},
@@ -137,8 +137,8 @@ impl Word for UnwrapPanic {
                             generator
                                 .module
                                 .funcs
-                                .by_name("runtime-error")
-                                .expect("runtime_error not found"),
+                                .by_name("stdlib.runtime-error")
+                                .expect("stdlib.runtime-error not found"),
                         );
                     },
                     |_| {},
@@ -213,8 +213,8 @@ impl Word for UnwrapErrPanic {
                             generator
                                 .module
                                 .funcs
-                                .by_name("runtime-error")
-                                .expect("runtime_error not found"),
+                                .by_name("stdlib.runtime-error")
+                                .expect("stdlib.runtime-error not found"),
                         );
                     },
                 );

--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -943,10 +943,11 @@ fn wasm_equal_list(
 
 #[cfg(test)]
 mod tests {
-    use clarity::vm::Value;
-    use clarity::vm::Value::Bool;
-
     use crate::tools::{evaluate as eval, TestEnvironment};
+    use clarity::vm::{
+        types::{ListData, ListTypeData, SequenceData},
+        Value::{self, Int},
+    };
 
     #[test]
     fn index_of_list_not_present() {
@@ -1011,13 +1012,11 @@ mod tests {
         assert_eq!(val.unwrap(), Some(Value::none()));
     }
 
-    // TODO [chris]
-    #[ignore = "need asserts! function to be implemented"]
     #[test]
     fn index_of_list_check_stack() {
         let mut env = TestEnvironment::default();
         let val = env.init_contract_with_snippet(
-            "index_of",
+            "snippet",
             r#"
 (define-private (find-it? (needle int) (haystack (list 10 int)))
   (is-eq (index-of? haystack needle) none))
@@ -1026,7 +1025,17 @@ mod tests {
 "#,
         );
 
-        assert_eq!(val.unwrap(), Some(Bool(true)));
+        assert_eq!(
+            val.unwrap(),
+            Some(Value::Sequence(SequenceData::List(ListData {
+                data: vec![Int(4), Int(5), Int(6)],
+                type_signature: ListTypeData::new_list(
+                    clarity::vm::types::TypeSignature::IntType,
+                    3
+                )
+                .unwrap()
+            })))
+        );
     }
 
     #[test]

--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -943,11 +943,10 @@ fn wasm_equal_list(
 
 #[cfg(test)]
 mod tests {
+    use clarity::vm::types::{ListData, ListTypeData, SequenceData};
+    use clarity::vm::Value::{self, Int};
+
     use crate::tools::{evaluate as eval, TestEnvironment};
-    use clarity::vm::{
-        types::{ListData, ListTypeData, SequenceData},
-        Value::{self, Int},
-    };
 
     #[test]
     fn index_of_list_not_present() {


### PR DESCRIPTION
When an error is thrown from a top-level function, it should trigger a runtime error, known as a `ShortReturn`.