### PR TITLE
Add support for utf8 for `string-to-(u)int?`

### DIFF
--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -2341,6 +2341,89 @@
         )
     )
 
+    (func $stdlib.utf8-to-uint (param $offset i32) (param $len i32) (result i32 i64 i64)
+        (local $lo i64) (local $hi i64) (local $loaded i64)
+        ;; a string is automatically invalid if its size is 0 or
+        ;; bigger than 39 (*4 bytes), the max number of digits of a u128
+        (if (i32.lt_u (i32.sub (local.get $len) (i32.const 157)) (i32.const -156))
+            (then (return (i32.const 0) (i64.const 0) (i64.const 0)))
+        )
+        
+        ;; loop with simple multiplication, for speed
+        (loop $loop_small
+            ;; valid digit: 24 first bits are 0 and rest is valid ascii char
+            (i32.and
+                (i64.eqz (i64.and (local.tee $loaded (i64.load32_u (local.get $offset))) (i64.const 0xffffff)))
+                (i64.lt_u (local.tee $loaded (i64.sub (i64.shr_u (local.get $loaded) (i64.const 24)) (i64.const 48))) (i64.const 10))
+            )
+            ;; if next digit is valid, $lo * 10 + digit, otherwise we return none
+            (if
+                (then (local.set $lo (i64.add (i64.mul (local.get $lo) (i64.const 10)) (local.get $loaded))))
+                (else (return (i32.const 0) (i64.const 0) (i64.const 0)))
+            )
+            (local.set $offset (i32.add (local.get $offset) (i32.const 4)))
+            ;; we branch while we still have digits to add and $lo < (u64::MAX / 10)
+            (br_if $loop_small 
+                (i32.and 
+                    (i32.ne (local.tee $len (i32.sub (local.get $len) (i32.const 4))) (i32.const 0))
+                    (i64.lt_u (local.get $lo) (i64.const 1844674407370955161))
+                )
+            )
+        )
+
+        ;; we return if no more digits
+        (if (i32.eqz (local.get $len))
+            (then (return (i32.const 1) (local.get $lo) (i64.const 0)))
+        )
+
+        ;; here we keep looping but with our defined mul and add instead of i64.mul and i64.add
+        (loop $loop_big
+            (i32.and
+                (i64.eqz (i64.and (local.tee $loaded (i64.load32_u (local.get $offset))) (i64.const 0xffffff)))
+                (i64.lt_u (local.tee $loaded (i64.sub (i64.shr_u (local.get $loaded) (i64.const 24)) (i64.const 48))) (i64.const 10))
+            )
+            (if
+                (then 
+                    (call $stdlib.add-int128 
+                      (call $stdlib.mul-int128 (local.get $lo) (local.get $hi) (i64.const 10) (i64.const 0))
+                      (local.get $loaded) (i64.const 0)
+                    )
+                    (local.set $hi)
+                    (local.set $lo)
+                )
+                (else (return (i32.const 0) (i64.const 0) (i64.const 0)))
+            )
+            (local.set $offset (i32.add (local.get $offset) (i32.const 4)))
+            ;; we branch while we still have digits and $result < (u128::MAX / 10)
+            (br_if $loop_big
+                (i32.and 
+                    (i32.ne (local.tee $len (i32.sub (local.get $len) (i32.const 4))) (i32.const 0))
+                    (select
+                        (i64.lt_u (local.get $lo) (i64.const -7378697629483820647))
+                        (i64.lt_u (local.get $hi) (i64.const 1844674407370955161))
+                        (i64.eq (local.get $hi) (i64.const 1844674407370955161))
+                    )
+                )
+            )
+        )
+        ;; we have to return if we have no more digits, otherwise it means that we have 
+        ;; a result between (u128::MAX - 5)..u128::MAX or an overflow
+        (if (result i32 i64 i64)
+            (i32.eqz (local.get $len))
+            (then (i32.const 1) (local.get $lo) (local.get $hi))
+            (else
+                (i32.and
+                    (i64.eqz (i64.and (local.tee $loaded (i64.load32_u (local.get $offset))) (i64.const 0xffffff)))
+                    (i64.le_u (local.tee $loaded (i64.sub (i64.shr_u (local.get $loaded) (i64.const 24)) (i64.const 48))) (i64.const 5))
+                )
+                (if (result i32 i64 i64)
+                    (then (i32.const 1) (i64.add (i64.const -6) (local.get $loaded)) (i64.const -1))
+                    (else (i32.const 0) (i64.const 0) (i64.const 0))
+                )
+            )
+        )
+    )
+
     (func $stdlib.string-to-int (param $offset i32) (param $len i32) (result i32 i64 i64)
         (local $neg i32) (local $lo i64) (local $hi i64)
 
@@ -3146,8 +3229,9 @@
     (export "stdlib.is-valid-char" (func $stdlib.is-valid-char))
     (export "stdlib.is-transient" (func $stdlib.is-transient))
     (export "stdlib.is-version-valid" (func $stdlib.is-version-valid))
-    (export "stdlib.string-to-uint" (func $stdlib.string-to-uint))
     (export "stdlib.string-to-int" (func $stdlib.string-to-int))
+    (export "stdlib.string-to-uint" (func $stdlib.string-to-uint))
+    (export "stdlib.utf8-to-uint" (func $stdlib.utf8-to-uint))
     (export "stdlib.uint-to-string" (func $stdlib.uint-to-string))
     (export "stdlib.uint-to-utf8" (func $stdlib.uint-to-utf8))
     (export "stdlib.int-to-string" (func $stdlib.int-to-string))
@@ -3155,5 +3239,5 @@
     (export "stdlib.to-uint" (func $stdlib.to-uint))
     (export "stdlib.to-int" (func $stdlib.to-int))
     (export "stdlib.sha512-buf" (func $stdlib.sha512-buf))
-    (export "stdlib.sha512-int" (func $stdlib.sha512-int))  
+    (export "stdlib.sha512-int" (func $stdlib.sha512-int))
 )

--- a/clar2wasm/src/words/conversion.rs
+++ b/clar2wasm/src/words/conversion.rs
@@ -212,6 +212,46 @@ mod tests {
     }
 
     #[test]
+    fn valid_utf8_to_int() {
+        assert_eq!(
+            evaluate(r#"(string-to-int? u"1234567")"#),
+            Some(Value::some(Value::Int(1234567)).unwrap())
+        )
+    }
+
+    #[test]
+    fn valid_negative_utf8_to_int() {
+        assert_eq!(
+            evaluate(r#"(string-to-int? u"-1234567")"#),
+            Some(Value::some(Value::Int(-1234567)).unwrap())
+        )
+    }
+
+    #[test]
+    fn invalid_utf8_to_int() {
+        assert_eq!(
+            evaluate(r#"(string-to-int? u"0xabcd")"#),
+            Some(Value::none())
+        )
+    }
+
+    #[test]
+    fn valid_utf8_to_uint() {
+        assert_eq!(
+            evaluate(r#"(string-to-uint? u"98765")"#),
+            Some(Value::some(Value::UInt(98765)).unwrap())
+        )
+    }
+
+    #[test]
+    fn invalid_utf8_to_uint() {
+        assert_eq!(
+            evaluate(r#"(string-to-uint? u"0xabcd")"#),
+            Some(Value::none())
+        )
+    }
+
+    #[test]
     fn uint_to_string() {
         assert_eq!(
             evaluate(r#"(int-to-ascii u42)"#),

--- a/clar2wasm/src/words/conversion.rs
+++ b/clar2wasm/src/words/conversion.rs
@@ -1,4 +1,4 @@
-use clarity::vm::types::TypeSignature;
+use clarity::vm::types::{SequenceSubtype, StringSubtype, TypeSignature};
 
 use super::Word;
 use crate::wasm_generator::{ArgumentsExt, GeneratorError};
@@ -20,7 +20,24 @@ impl Word for StringToInt {
     ) -> Result<(), crate::wasm_generator::GeneratorError> {
         generator.traverse_args(builder, args)?;
 
-        let func = generator.func_by_name("stdlib.string-to-int");
+        let func_prefix = match generator
+            .get_expr_type(args.get_expr(0)?)
+            .expect("string-to-int? argument should have a type")
+        {
+            TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::ASCII(_))) => {
+                "string"
+            }
+            TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::UTF8(_))) => {
+                "utf8"
+            }
+            _ => {
+                return Err(GeneratorError::TypeError(
+                    "impossible type for string-to-int?".to_owned(),
+                ))
+            }
+        };
+
+        let func = generator.func_by_name(&format!("stdlib.{func_prefix}-to-int"));
         builder.call(func);
 
         Ok(())
@@ -44,7 +61,25 @@ impl Word for StringToUint {
     ) -> Result<(), crate::wasm_generator::GeneratorError> {
         generator.traverse_args(builder, args)?;
 
-        let func = generator.func_by_name("stdlib.string-to-uint");
+        let func_prefix = match generator
+            .get_expr_type(args.get_expr(0)?)
+            .expect("string-to-int? argument should have a type")
+        {
+            TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::ASCII(_))) => {
+                "string"
+            }
+            TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::UTF8(_))) => {
+                "utf8"
+            }
+            _ => {
+                return Err(GeneratorError::TypeError(
+                    "impossible type for string-to-int?".to_owned(),
+                ))
+            }
+        };
+
+        let func = generator.func_by_name(&format!("stdlib.{func_prefix}-to-uint"));
+
         builder.call(func);
 
         Ok(())

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -3059,7 +3059,7 @@ fn utf8_to_uint() {
     test_str("42", 1, 42, 0);
     test_str("1024", 1, 1024, 0);
 
-    // // Basic tests with big numbers
+    // Basic tests with big numbers
     test_str("184467440737095516156789", 1, -3211, 9999);
     test_str(
         "374467440737095681245698132",

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -3019,6 +3019,99 @@ fn string_to_int() {
 }
 
 #[test]
+fn utf8_to_uint() {
+    let (instance, mut store) = load_stdlib().unwrap();
+
+    let memory = instance
+        .get_memory(&mut store, "memory")
+        .expect("Could not find memory");
+
+    let conv = instance
+        .get_func(&mut store, "stdlib.utf8-to-uint")
+        .unwrap();
+    let mut result = [Val::I32(0), Val::I64(0), Val::I64(0)];
+
+    let mut test_str = |string: &str, expected_opt: i32, expected_lo: i64, expected_hi: i64| {
+        let string: Vec<_> = string
+            .bytes()
+            .flat_map(|b| (b as u32).to_be_bytes())
+            .collect();
+        memory
+            .write(&mut store, 1500, &string)
+            .expect("Could not write to memory");
+        conv.call(
+            &mut store,
+            &[Val::I32(1500), Val::I32(string.len() as i32)],
+            &mut result,
+        )
+        .expect("call to string-to-uint failed");
+        assert_eq!(result[0].unwrap_i32(), expected_opt);
+        assert_eq!(result[1].unwrap_i64(), expected_lo);
+        assert_eq!(result[2].unwrap_i64(), expected_hi);
+    };
+
+    // Fails with empty string
+    test_str("", 0, 0, 0);
+
+    // Basic tests only using low bytes
+    test_str("0", 1, 0, 0);
+    test_str("1", 1, 1, 0);
+    test_str("42", 1, 42, 0);
+    test_str("1024", 1, 1024, 0);
+
+    // // Basic tests with big numbers
+    test_str("184467440737095516156789", 1, -3211, 9999);
+    test_str(
+        "374467440737095681245698132",
+        1,
+        -6666426393504524204,
+        20299920,
+    );
+
+    // Tests with number between 64 and 65 bits
+    let n = u64::MAX as u128;
+    for i in -5..=5 {
+        test_str(
+            &n.checked_add_signed(i).unwrap().to_string(),
+            1,
+            (i - 1) as i64,
+            (i > 0) as i64,
+        );
+    }
+
+    // Tests with number close to u128::MAX
+    let n = u128::MAX - 10;
+    for i in 0..=10 {
+        test_str(&(n + i).to_string(), 1, -11 + i as i64, -1);
+    }
+
+    // None with too big numbers
+    test_str("340282366920938463463374607431768211456", 0, 0, 0);
+    test_str("1000000000000000000000000000000000000000", 0, 0, 0);
+
+    // None with invalid inputs
+    test_str("a", 0, 0, 0);
+    test_str("123a", 0, 0, 0);
+    test_str("12v345", 0, 0, 0);
+    test_str("340282366920938463463374607431768211455!", 0, 0, 0);
+
+    // valid number with a utf8 char -> 123 and something that starts with a valid number, but is actually a utf8 thingy
+    let string = vec![49, 0, 0, 0, 50, 0, 0, 0, 51, 0, 0, 0, 52, 1, 0, 0];
+    memory
+        .write(&mut store, 1500, &string)
+        .expect("Could not write to memory");
+    conv.call(
+        &mut store,
+        &[Val::I32(1500), Val::I32(string.len() as i32)],
+        &mut result,
+    )
+    .expect("call to string-to-uint failed");
+    assert_eq!(result[0].unwrap_i32(), 0);
+    assert_eq!(result[1].unwrap_i64(), 0);
+    assert_eq!(result[2].unwrap_i64(), 0);
+}
+
+#[test]
 fn is_transient() {
     let (instance, mut store) = load_stdlib().unwrap();
 


### PR DESCRIPTION
This PR adds support for UTF8 in `string-to-int?` and `string-to-uint?`.