### PR TITLE
Implement `map`

### DIFF
--- a/clar2wasm/Cargo.toml
+++ b/clar2wasm/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 build = "build.rs"
 
 [dependencies]
-# clarity = { path = "../stacks-core/clarity" }
 clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-next" }
 clap = { version = "4.3.17", features = ["derive"] }
 regex = "1.9.1"
@@ -21,7 +20,7 @@ rusqlite = { version = "0.28.0", optional = true }
 wat = "1.0.74"
 
 [features]
-developer-mode = ["sha2", "chrono", "rusqlite"]
+developer-mode = ["sha2", "chrono", "rusqlite", "clarity/testing"]
 flamegraph = []
 pb = []
 

--- a/clar2wasm/Cargo.toml
+++ b/clar2wasm/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 build = "build.rs"
 
 [dependencies]
+# clarity = { path = "../stacks-core/clarity" }
 clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-next" }
 clap = { version = "4.3.17", features = ["derive"] }
 regex = "1.9.1"

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -769,27 +769,6 @@ impl WasmGenerator {
         }
     }
 
-    pub fn type_size(&self, ty: &TypeSignature) -> i32 {
-        match ty {
-            TypeSignature::IntType | TypeSignature::UIntType => 16,
-            TypeSignature::OptionalType(inner) => 4 + self.type_size(inner),
-            TypeSignature::ResponseType(inner) => {
-                let (ok_type, err_type) = &**inner;
-                4 + self.type_size(ok_type) + self.type_size(err_type)
-            }
-            // Principals and sequence types are stored in-memory and
-            // represented by an offset and length.
-            TypeSignature::PrincipalType | TypeSignature::SequenceType(_) => 8,
-            TypeSignature::TupleType(tuple) => {
-                todo!()
-            }
-            // Unknown types just get a placeholder i32 value.
-            TypeSignature::NoType => 4,
-            TypeSignature::BoolType => 4,
-            _ => unimplemented!("Type not yet supported for reading from memory: {ty}"),
-        }
-    }
-
     /// Read a value from memory at offset stored in local variable `offset`,
     /// with type `ty`, and push it onto the top of the data stack.
     pub(crate) fn read_from_memory(

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -640,10 +640,7 @@ impl WasmGenerator {
                 );
                 16
             }
-            TypeSignature::PrincipalType
-            | TypeSignature::SequenceType(SequenceSubtype::BufferType(_))
-            | TypeSignature::SequenceType(SequenceSubtype::ListType(_))
-            | TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::ASCII(_))) => {
+            TypeSignature::PrincipalType | TypeSignature::SequenceType(_) => {
                 // Data stack: TOP | Length | Offset | ...
                 // Save the offset/length to locals.
                 let seq_offset = self.module.locals.add(ValType::I32);

--- a/clar2wasm/src/words/conditionals.rs
+++ b/clar2wasm/src/words/conditionals.rs
@@ -186,8 +186,8 @@ impl Word for Filter {
             // [ input_end ]
             .local_set(input_end);
         // [ ]
-        // now we have an empty stack, and three initialized locals
 
+        // now we have an empty stack, and three initialized locals
         // reserve space for the length of the output list
 
         let (output_offset, _) = generator.create_call_stack_local(builder, &ty, false, true);

--- a/clar2wasm/src/words/conditionals.rs
+++ b/clar2wasm/src/words/conditionals.rs
@@ -186,10 +186,9 @@ impl Word for Filter {
             // [ input_end ]
             .local_set(input_end);
         // [ ]
-
         // now we have an empty stack, and three initialized locals
-        // reserve space for the length of the output list
 
+        // reserve space for the length of the output list
         let (output_offset, _) = generator.create_call_stack_local(builder, &ty, false, true);
 
         let memory = generator.get_memory();

--- a/clar2wasm/src/words/consensus_buff.rs
+++ b/clar2wasm/src/words/consensus_buff.rs
@@ -66,6 +66,7 @@ impl Word for ToConsensusBuf {
                     else_.i32_const(0).i32_const(0).i32_const(0);
                 },
             );
+
         Ok(())
     }
 }

--- a/clar2wasm/src/words/consensus_buff.rs
+++ b/clar2wasm/src/words/consensus_buff.rs
@@ -66,7 +66,6 @@ impl Word for ToConsensusBuf {
                     else_.i32_const(0).i32_const(0).i32_const(0);
                 },
             );
-
         Ok(())
     }
 }

--- a/clar2wasm/src/words/mod.rs
+++ b/clar2wasm/src/words/mod.rs
@@ -130,6 +130,7 @@ pub(crate) static WORDS: &[&'static dyn Word] = &[
     &sequences::Fold,
     &sequences::Len,
     &sequences::ListCons,
+    &sequences::Map,
     &sequences::ReplaceAt,
     &sequences::Slice,
     &stx::StxBurn,

--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -1694,8 +1694,8 @@ mod tests {
   (+ a b 1))
 ";
 
-        // let a = &format!("{MAP_FNS} (map addify-1 (list 1 2 3))");
-        // assert_eq!(clarity::vm::execute(a).unwrap(), eval(a));
+        let a = &format!("{MAP_FNS} (map addify-1 (list 1 2 3))");
+        assert_eq!(clarity::vm::execute(a).unwrap(), eval(a));
 
         let a = &format!("{MAP_FNS} (map addify-2 (list 1 2 3) (list 7 8))");
         assert_eq!(clarity::vm::execute(a).unwrap(), eval(a));

--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -1646,7 +1646,6 @@ mod tests {
         );
     }
 
-    // TODO: The string-utf8 can be uncommented when #216 is merged.
     #[test]
     fn test_map_mixed() {
         assert_eq!(
@@ -1656,14 +1655,14 @@ mod tests {
     (a int)
     (b uint)
     (c (string-ascii 1))
-    ;;(d (string-utf8 1))
+    (d (string-utf8 1))
     (e (buff 1))
     )
     (+
         a
         (to-int b)
         (unwrap-panic (string-to-int? c))
-        ;;(unwrap-panic (string-to-int? d))
+        (unwrap-panic (string-to-int? d))
         (buff-to-int-be e)
     )
 )
@@ -1671,14 +1670,13 @@ mod tests {
     (list 1 2 3)
     (list u1 u2 u3)
     "123"
-    ;;u"123"
+    u"123"
     0x010203
 )
         "#
             ),
             Some(
-                Value::cons_list_unsanitized(vec![Value::Int(4), Value::Int(8), Value::Int(12),])
-                    // Value::cons_list_unsanitized(vec![Value::Int(5), Value::Int(10), Value::Int(15),])
+                Value::cons_list_unsanitized(vec![Value::Int(5), Value::Int(10), Value::Int(15),])
                     .unwrap()
             )
         );

--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -1678,7 +1678,7 @@ mod tests {
             ),
             Some(
                 Value::cons_list_unsanitized(vec![Value::Int(4), Value::Int(8), Value::Int(12),])
-                // Value::cons_list_unsanitized(vec![Value::Int(5), Value::Int(10), Value::Int(15),])
+                    // Value::cons_list_unsanitized(vec![Value::Int(5), Value::Int(10), Value::Int(15),])
                     .unwrap()
             )
         );


### PR DESCRIPTION
This completes the implementation of `map`. Once #216 is merged, we can rebase on top of that and uncomment the utf8 part of the test `test_map_mixed`.