### PR TITLE
fix(clar2wasm): int division should overflow if i128::MIN / -1

### DIFF
--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -680,6 +680,15 @@
         (local $sign_divisor i64)
         (local $expected_sign i64)
 
+        ;; overflow if i128::MIN / -1
+        (if 
+            (i32.and
+                (i32.and (i64.eqz (local.get $dividend_lo)) (i64.eq (local.get $dividend_hi) (i64.const 0x8000000000000000)))
+                (i64.eq (i64.and (local.get $divisor_lo) (local.get $divisor_hi)) (i64.const -1))
+            )
+            (then (call $stdlib.runtime-error (i32.const 0)))
+        )
+
         ;; Compute the expected sign of the result
         (local.set $sign_dividend (i64.shr_s (local.get $dividend_hi) (i64.const 63)))
         (local.set $sign_divisor (i64.shr_s (local.get $divisor_hi) (i64.const 63)))

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -680,6 +680,19 @@ fn test_div_int() {
     let div = instance.get_func(&mut store, "stdlib.div-int").unwrap();
     let mut result = [Val::I64(0), Val::I64(0)];
 
+    // i128::MIN / -1 overflows
+    div.call(
+        &mut store,
+        &[
+            Val::I64(0),
+            Val::I64(-9223372036854775808),
+            Val::I64(-1),
+            Val::I64(-1),
+        ],
+        &mut result,
+    )
+    .expect_err("expected overflow");
+
     // 4 / 2 = 2
     div.call(
         &mut store,


### PR DESCRIPTION
Fixes #142 

I added an `if` statement in the Wasm standard for the only case of overflow in integer division and a unit test to make sure it's triggered.