### PR TITLE
Add property tests for `is-eq`

### DIFF
--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -886,10 +886,10 @@ fn wasm_equal_list(
                         .local_set(*offset_b);
 
                     // loop while we still have elements
-                    then.local_get(*len_a)
-                        .i32_const(offset_delta_a)
+                    then.local_get(*len_b)
+                        .i32_const(offset_delta_b)
                         .binop(BinaryOp::I32Sub)
-                        .local_tee(*len_a)
+                        .local_tee(*len_b)
                         .br_if(loop_id);
                 },
                 |_| {},
@@ -899,11 +899,11 @@ fn wasm_equal_list(
         };
 
         // Now that we have our comparison loop, we add it to the instructions.
-        // After it, we just have to check if the counter `len_a` is at 0, indicating
+        // After it, we just have to check if the counter `len_b` is at 0, indicating
         // we looped through all elements and everything is equal
         instr
             .instr(Loop { seq: loop_id })
-            .local_get(*len_a)
+            .local_get(*len_b)
             .unop(UnaryOp::I32Eqz);
         instr.id()
     };
@@ -912,7 +912,7 @@ fn wasm_equal_list(
     let equal_size_id = {
         let mut instr = builder.dangling_instr_seq(ValType::I32);
         // consequent when size is 0; alternative when size > 0
-        instr.local_get(*len_a).unop(UnaryOp::I32Eqz).instr(IfElse {
+        instr.local_get(*len_b).unop(UnaryOp::I32Eqz).instr(IfElse {
             consequent: empty_lists,
             alternative: comparison_loop,
         });

--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -901,8 +901,13 @@ fn wasm_equal_list(
         // Now that we have our comparison loop, we add it to the instructions.
         // After it, we just have to check if the counter `len_b` is at 0, indicating
         // we looped through all elements and everything is equal
+        // In case we have 3 or more operands for `is-eq`, we also should make sure that
+        // *offset_a* is reset at the end of the loop. We accomplish that by putting its original
+        // value on the stack before the loop and setting it back after the loop.
         instr
+            .local_get(*offset_a)
             .instr(Loop { seq: loop_id })
+            .local_set(*offset_a)
             .local_get(*len_b)
             .unop(UnaryOp::I32Eqz);
         instr.id()

--- a/clar2wasm/tests/wasm-generation/equal.rs
+++ b/clar2wasm/tests/wasm-generation/equal.rs
@@ -1,0 +1,40 @@
+use clar2wasm::tools::evaluate;
+use proptest::proptest;
+
+use crate::PropValue;
+
+use proptest::prelude::ProptestConfig;
+
+proptest! {
+    #[test]
+    fn is_eq_one_argument_always_true(val in PropValue::any()) {
+        assert_eq!(
+            evaluate(&format!(r#"(is-eq {val})"#)),
+            Some(clarity::vm::Value::Bool(true))
+        )
+    }
+}
+proptest! {
+    #[test]
+    fn is_eq_value_with_itself_always_true(val in PropValue::any()) {
+        assert_eq!(
+            evaluate(&format!(r#"(is-eq {val} {val})"#)),
+            Some(clarity::vm::Value::Bool(true))
+        )
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 1,
+        .. ProptestConfig::default()
+    })]
+    #[test]
+    fn is_eq_value_with_itself_always_true_3(val in PropValue::any()) {
+        dbg!(&val);
+        assert_eq!(
+            evaluate(&format!(r#"(is-eq {val} {val} {val})"#)),
+            Some(clarity::vm::Value::Bool(true))
+        )
+    }
+}

--- a/clar2wasm/tests/wasm-generation/equal.rs
+++ b/clar2wasm/tests/wasm-generation/equal.rs
@@ -3,8 +3,6 @@ use proptest::proptest;
 
 use crate::PropValue;
 
-use proptest::prelude::ProptestConfig;
-
 proptest! {
     #[test]
     fn is_eq_one_argument_always_true(val in PropValue::any()) {
@@ -25,10 +23,6 @@ proptest! {
 }
 
 proptest! {
-    #![proptest_config(ProptestConfig {
-        cases: 1,
-        .. ProptestConfig::default()
-    })]
     #[test]
     fn is_eq_value_with_itself_always_true_3(val in PropValue::any()) {
         dbg!(&val);

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -1,5 +1,6 @@
 pub mod regression;
 pub mod values;
+pub mod equal;
 
 use clarity::vm::types::{
     ASCIIData, BuffData, CharType, ListData, ListTypeData, OptionalData, ResponseData,


### PR DESCRIPTION
This PR adds property tests for the `is-eq` function:

- `is-eq` with one argument is always true
- `is-eq` with twice the same argument is always true
- `is-eq` with thrice the same argument is always true.

Those very simple tests showed a bug in the implementation of `wasm_equal` for lists, where side effect modifications would prevent the correct behavior if we use it more than two times in a row. This PR adds fixes for those bugs.
Fixes #226.