### PR TITLE
Fix: `is-eq` for optional had a lazy bug

### DIFF
--- a/clar2wasm/tests/wasm-generation/equal.rs
+++ b/clar2wasm/tests/wasm-generation/equal.rs
@@ -25,7 +25,6 @@ proptest! {
 proptest! {
     #[test]
     fn is_eq_value_with_itself_always_true_3(val in PropValue::any()) {
-        dbg!(&val);
         assert_eq!(
             evaluate(&format!(r#"(is-eq {val} {val} {val})"#)),
             Some(clarity::vm::Value::Bool(true))

--- a/clar2wasm/tests/wasm-generation/regression.rs
+++ b/clar2wasm/tests/wasm-generation/regression.rs
@@ -50,3 +50,12 @@ fn to_consensus_buff_1() {
         )
     );
 }
+
+#[test]
+fn is_eq_list_opt_resp() {
+    let l = "(list none (some (ok 1)))";
+    assert_eq!(
+        evaluate(&format!(r#"(is-eq {l} {l})"#)),
+        Some(Value::Bool(true))
+    )
+}


### PR DESCRIPTION
Fixes #234 

This bug came from my poor usage of a `i32.or`, where I considered it as if it was a lazy operator.
Replacing it with a if-else statement did the trick.
