### PR TITLE
Property tests for `default-to` + fix

### DIFF
--- a/clar2wasm/tests/wasm-generation/default_to.rs
+++ b/clar2wasm/tests/wasm-generation/default_to.rs
@@ -1,0 +1,33 @@
+use clar2wasm::tools::evaluate;
+use proptest::{prop_compose, proptest};
+
+use crate::{prop_signature, PropValue};
+
+proptest! {
+    #[test]
+    fn default_to_with_none_is_always_default(val in PropValue::any()) {
+        assert_eq!(
+            evaluate(&format!(r#"(default-to {val} none)"#)),
+            Some(val.into())
+        )
+    }
+}
+
+prop_compose! {
+    fn default_and_value_of_same_type()
+        (signature in prop_signature())
+        (default in PropValue::from_type(signature.clone()) , value in PropValue::from_type(signature))
+        -> (PropValue, PropValue) {
+            (default, value)
+        }
+}
+
+proptest! {
+    #[test]
+    fn default_to_with_some_is_always_value((default, value) in default_and_value_of_same_type()) {
+        assert_eq!(
+            evaluate(&format!(r#"(default-to {default} (some {value}))"#)),
+            Some(value.into())
+        )
+    }
+}

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -1,3 +1,4 @@
+pub mod default_to;
 pub mod equal;
 pub mod regression;
 pub mod values;

--- a/clar2wasm/tests/wasm-generation/regression.rs
+++ b/clar2wasm/tests/wasm-generation/regression.rs
@@ -2,6 +2,7 @@
 /// so that we can be sure they won't fail again after some random refactor
 /// in the future.
 use clar2wasm::tools::evaluate;
+use clarity::vm::types::ResponseData;
 use clarity::vm::Value;
 use hex::FromHex as _;
 
@@ -57,5 +58,24 @@ fn is_eq_list_opt_resp() {
     assert_eq!(
         evaluate(&format!(r#"(is-eq {l} {l})"#)),
         Some(Value::Bool(true))
+    )
+}
+
+#[test]
+fn default_to() {
+    assert_eq!(
+        evaluate("(default-to (list 100) (some (list 1 2 3)))"),
+        evaluate("(list 1 2 3)")
+    )
+}
+
+#[test]
+fn default_to_2() {
+    assert_eq!(
+        evaluate("(default-to (err -8865319038999812741356205373046857778) (some (ok 94740629357611018681632671610045749418)))"),
+        Some(Value::Response(ResponseData{
+            committed: true,
+            data: Box::new(Value::Int(94740629357611018681632671610045749418))
+        }))
     )
 }


### PR DESCRIPTION
This PR adds two property tests for the `default-to` function:

- `default-to <something> none === <something>`
- `default-to <anything> (some <something>) === <something>`

Adding those tests showed a bug in the current implementation: the typechecker failing to set the complete type for the default and the optional value, there was a small workaround to add a few zeros in the generated Wasm. It didn't work for all cases.
The new fix explicitly fixes the types of both arguments, fixing the issue.

Fixes #232  