### PR TITLE
Replace panics with proper error handling in clar2wasm

### DIFF
--- a/clar2wasm/src/lib.rs
+++ b/clar2wasm/src/lib.rs
@@ -93,7 +93,18 @@ pub fn compile(
         }
     };
 
-    let generator = WasmGenerator::new(contract_analysis.clone());
+    let generator = match WasmGenerator::new(contract_analysis.clone()) {
+        Ok(g) => g,
+        Err(e) => {
+            diagnostics.push(Diagnostic::err(&e));
+            return Err(CompileError::Generic {
+                ast,
+                diagnostics,
+                cost_tracker: Box::new(contract_analysis.cost_track.take().unwrap()),
+            });
+        }
+    };
+
     match generator.generate() {
         Ok(module) => Ok(CompileResult {
             ast,
@@ -113,6 +124,6 @@ pub fn compile(
 }
 
 pub fn compile_contract(contract_analysis: ContractAnalysis) -> Result<Module, GeneratorError> {
-    let generator = WasmGenerator::new(contract_analysis);
+    let generator = WasmGenerator::new(contract_analysis.clone())?;
     generator.generate()
 }

--- a/clar2wasm/src/lib.rs
+++ b/clar2wasm/src/lib.rs
@@ -93,19 +93,7 @@ pub fn compile(
         }
     };
 
-    let generator = match WasmGenerator::new(contract_analysis.clone()) {
-        Ok(g) => g,
-        Err(e) => {
-            diagnostics.push(Diagnostic::err(&e));
-            return Err(CompileError::Generic {
-                ast,
-                diagnostics,
-                cost_tracker: Box::new(contract_analysis.cost_track.take().unwrap()),
-            });
-        }
-    };
-
-    match generator.generate() {
+    match WasmGenerator::new(contract_analysis.clone()).and_then(WasmGenerator::generate) {
         Ok(module) => Ok(CompileResult {
             ast,
             diagnostics,
@@ -124,6 +112,6 @@ pub fn compile(
 }
 
 pub fn compile_contract(contract_analysis: ContractAnalysis) -> Result<Module, GeneratorError> {
-    let generator = WasmGenerator::new(contract_analysis.clone())?;
+    let generator = WasmGenerator::new(contract_analysis)?;
     generator.generate()
 }

--- a/clar2wasm/src/serialize.rs
+++ b/clar2wasm/src/serialize.rs
@@ -863,9 +863,9 @@ impl WasmGenerator {
             let wasm_types = clar2wasm_ty(value_ty);
             for _ in 0..wasm_types.len() {
                 builder.local_get(
-                    locals
-                        .pop()
-                        .ok_or(GeneratorError::InternalError("invalid tuple value".into()))?,
+                    locals.pop().ok_or_else(|| {
+                        GeneratorError::InternalError("invalid tuple value".into())
+                    })?,
                 );
             }
 

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -291,7 +291,7 @@ impl WasmGenerator {
         let function_type = if let Some(FunctionType::Fixed(fixed)) = opt_function_type {
             fixed.clone()
         } else {
-            return Err(GeneratorError::InternalError(match opt_function_type {
+            return Err(GeneratorError::TypeError(match opt_function_type {
                 Some(_) => "expected fixed function type".to_string(),
                 None => format!("unable to find function type for {}", name.as_str()),
             }));

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -86,25 +86,27 @@ pub trait ArgumentsExt {
 
 impl ArgumentsExt for &[SymbolicExpression] {
     fn get_expr(&self, n: usize) -> Result<&SymbolicExpression, GeneratorError> {
-        self.get(n).ok_or(GeneratorError::InternalError(format!(
-            "{self:?} does not have an argument of index {n}"
-        )))
+        self.get(n).ok_or_else(|| {
+            GeneratorError::InternalError(format!(
+                "{self:?} does not have an argument of index {n}"
+            ))
+        })
     }
 
     fn get_name(&self, n: usize) -> Result<&ClarityName, GeneratorError> {
-        self.get_expr(n)?
-            .match_atom()
-            .ok_or(GeneratorError::InternalError(format!(
+        self.get_expr(n)?.match_atom().ok_or_else(|| {
+            GeneratorError::InternalError(format!(
                 "{self:?} does not have a name at argument index {n}"
-            )))
+            ))
+        })
     }
 
     fn get_list(&self, n: usize) -> Result<&[SymbolicExpression], GeneratorError> {
-        self.get_expr(n)?
-            .match_list()
-            .ok_or(GeneratorError::InternalError(format!(
+        self.get_expr(n)?.match_list().ok_or_else(|| {
+            GeneratorError::InternalError(format!(
                 "{self:?} does not have a list at argument index {n}"
-            )))
+            ))
+        })
     }
 }
 
@@ -147,9 +149,11 @@ impl WasmGenerator {
                     .map_or(false, |name| name == stack_pointer_name)
             })
             .map(|global| global.id())
-            .ok_or(GeneratorError::InternalError(
-                "Expected to find a global named $stack-pointer".to_owned(),
-            ))?;
+            .ok_or_else(|| {
+                GeneratorError::InternalError(
+                    "Expected to find a global named $stack-pointer".to_owned(),
+                )
+            })?;
 
         Ok(WasmGenerator {
             contract_analysis,
@@ -246,18 +250,16 @@ impl WasmGenerator {
                     let arg_types: Result<Vec<TypeSignature>, GeneratorError> = args
                         .iter()
                         .map(|e| {
-                            self.get_expr_type(e)
-                                .cloned()
-                                .ok_or(GeneratorError::TypeError(
-                                    "expected valid argument type".to_owned(),
-                                ))
+                            self.get_expr_type(e).cloned().ok_or_else(|| {
+                                GeneratorError::TypeError("expected valid argument type".to_owned())
+                            })
                         })
                         .collect();
                     let return_type = self
                         .get_expr_type(expr)
-                        .ok_or(GeneratorError::TypeError(
-                            "Simple words must be typed".to_owned(),
-                        ))?
+                        .ok_or_else(|| {
+                            GeneratorError::TypeError("Simple words must be typed".to_owned())
+                        })?
                         .clone();
                     simpleword.visit(self, builder, &arg_types?, &return_type)?;
                 } else {
@@ -311,9 +313,14 @@ impl WasmGenerator {
             .i32_const(id_length as i32);
 
         // Call the host interface function, `define_function`
-        builder.call(self.module.funcs.by_name("stdlib.define_function").ok_or(
-            GeneratorError::InternalError("define_function not found".to_owned()),
-        )?);
+        builder.call(
+            self.module
+                .funcs
+                .by_name("stdlib.define_function")
+                .ok_or_else(|| {
+                    GeneratorError::InternalError("define_function not found".to_owned())
+                })?,
+        );
 
         let mut bindings = HashMap::new();
 
@@ -553,9 +560,9 @@ impl WasmGenerator {
         builder: &mut InstrSeqBuilder,
         expr: &SymbolicExpression,
     ) -> Result<InstrSeqId, GeneratorError> {
-        let return_type = clar2wasm_ty(self.get_expr_type(expr).ok_or(
-            GeneratorError::TypeError("Expression results must be typed".to_owned()),
-        )?);
+        let return_type = clar2wasm_ty(self.get_expr_type(expr).ok_or_else(|| {
+            GeneratorError::TypeError("Expression results must be typed".to_owned())
+        })?);
 
         let mut block = builder.dangling_instr_seq(InstrSeqType::new(
             &mut self.module.types,
@@ -1261,13 +1268,9 @@ impl WasmGenerator {
         }
 
         // Handle parameters and local bindings
-        let values = self
-            .bindings
-            .get(atom.as_str())
-            .ok_or(GeneratorError::InternalError(format!(
-                "unable to find local for {}",
-                atom.as_str()
-            )))?;
+        let values = self.bindings.get(atom.as_str()).ok_or_else(|| {
+            GeneratorError::InternalError(format!("unable to find local for {}", atom.as_str()))
+        })?;
 
         for value in values {
             builder.local_get(*value);
@@ -1366,9 +1369,7 @@ impl WasmGenerator {
             self.module
                 .funcs
                 .by_name(name.as_str())
-                .ok_or(GeneratorError::TypeError(format!(
-                    "function not found: {name}"
-                )))?,
+                .ok_or_else(|| GeneratorError::TypeError(format!("function not found: {name}")))?,
         );
 
         Ok(())

--- a/clar2wasm/src/words/arithmetic.rs
+++ b/clar2wasm/src/words/arithmetic.rs
@@ -15,7 +15,7 @@ fn simple_typed_multi_value(
         TypeSignature::IntType => "int",
         TypeSignature::UIntType => "uint",
         _ => {
-            return Err(GeneratorError::InternalError(
+            return Err(GeneratorError::TypeError(
                 "invalid type for arithmetic".to_string(),
             ));
         }

--- a/clar2wasm/src/words/bindings.rs
+++ b/clar2wasm/src/words/bindings.rs
@@ -35,7 +35,9 @@ impl ComplexWord for Let {
             // Store store the value in locals, and save to the var map
             let ty = generator
                 .get_expr_type(value)
-                .expect("let value expression must be typed")
+                .ok_or(GeneratorError::TypeError(
+                    "let value expression must be typed".to_owned(),
+                ))?
                 .clone();
             let locals = generator.save_to_locals(builder, &ty, true);
 

--- a/clar2wasm/src/words/bindings.rs
+++ b/clar2wasm/src/words/bindings.rs
@@ -35,9 +35,9 @@ impl ComplexWord for Let {
             // Store store the value in locals, and save to the var map
             let ty = generator
                 .get_expr_type(value)
-                .ok_or(GeneratorError::TypeError(
-                    "let value expression must be typed".to_owned(),
-                ))?
+                .ok_or_else(|| {
+                    GeneratorError::TypeError("let value expression must be typed".to_owned())
+                })?
                 .clone();
             let locals = generator.save_to_locals(builder, &ty, true);
 

--- a/clar2wasm/src/words/bitwise.rs
+++ b/clar2wasm/src/words/bitwise.rs
@@ -139,7 +139,7 @@ impl SimpleWord for BitwiseRShift {
             TypeSignature::IntType => "int",
             TypeSignature::UIntType => "uint",
             _ => {
-                return Err(GeneratorError::InternalError(
+                return Err(GeneratorError::TypeError(
                     "invalid type for shift".to_string(),
                 ));
             }

--- a/clar2wasm/src/words/blockinfo.rs
+++ b/clar2wasm/src/words/blockinfo.rs
@@ -33,9 +33,9 @@ impl ComplexWord for GetBlockInfo {
         // Reserve space on the stack for the return value
         let return_ty = generator
             .get_expr_type(expr)
-            .ok_or(GeneratorError::TypeError(
-                "get-block-info? expression must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| {
+                GeneratorError::TypeError("get-block-info? expression must be typed".to_owned())
+            })?
             .clone();
 
         let (return_offset, return_size) =
@@ -85,9 +85,11 @@ impl ComplexWord for GetBurnBlockInfo {
         // Reserve space on the stack for the return value
         let return_ty = generator
             .get_expr_type(expr)
-            .ok_or(GeneratorError::TypeError(
-                "get-burn-block-info? expression must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| {
+                GeneratorError::TypeError(
+                    "get-burn-block-info? expression must be typed".to_owned(),
+                )
+            })?
             .clone();
 
         let (return_offset, return_size) =

--- a/clar2wasm/src/words/blockinfo.rs
+++ b/clar2wasm/src/words/blockinfo.rs
@@ -33,7 +33,9 @@ impl ComplexWord for GetBlockInfo {
         // Reserve space on the stack for the return value
         let return_ty = generator
             .get_expr_type(expr)
-            .expect("get-block-info? expression must be typed")
+            .ok_or(GeneratorError::TypeError(
+                "get-block-info? expression must be typed".to_owned(),
+            ))?
             .clone();
 
         let (return_offset, return_size) =
@@ -83,7 +85,9 @@ impl ComplexWord for GetBurnBlockInfo {
         // Reserve space on the stack for the return value
         let return_ty = generator
             .get_expr_type(expr)
-            .expect("get-burn-block-info? expression must be typed")
+            .ok_or(GeneratorError::TypeError(
+                "get-burn-block-info? expression must be typed".to_owned(),
+            ))?
             .clone();
 
         let (return_offset, return_size) =

--- a/clar2wasm/src/words/buff_to_integer.rs
+++ b/clar2wasm/src/words/buff_to_integer.rs
@@ -1,17 +1,20 @@
 use clarity::vm::types::TypeSignature;
 
+use crate::wasm_generator::{GeneratorError, WasmGenerator};
 use crate::words::SimpleWord;
 
 fn traverse_buffer_to_integer(
     name: &str,
-    generator: &mut crate::wasm_generator::WasmGenerator,
+    generator: &mut WasmGenerator,
     builder: &mut walrus::InstrSeqBuilder,
-) -> Result<(), crate::wasm_generator::GeneratorError> {
+) -> Result<(), GeneratorError> {
     let func = generator
         .module
         .funcs
         .by_name(name)
-        .unwrap_or_else(|| panic!("function not found: {name}"));
+        .ok_or(GeneratorError::InternalError(format!(
+            "function not found: {name}"
+        )))?;
     builder.call(func);
     Ok(())
 }

--- a/clar2wasm/src/words/buff_to_integer.rs
+++ b/clar2wasm/src/words/buff_to_integer.rs
@@ -12,9 +12,7 @@ fn traverse_buffer_to_integer(
         .module
         .funcs
         .by_name(name)
-        .ok_or(GeneratorError::InternalError(format!(
-            "function not found: {name}"
-        )))?;
+        .ok_or_else(|| GeneratorError::InternalError(format!("function not found: {name}")))?;
     builder.call(func);
     Ok(())
 }

--- a/clar2wasm/src/words/comparison.rs
+++ b/clar2wasm/src/words/comparison.rs
@@ -36,7 +36,9 @@ fn traverse_comparison(
         .module
         .funcs
         .by_name(&format!("stdlib.{name}-{type_suffix}"))
-        .unwrap_or_else(|| panic!("function not found: {name}-{type_suffix}"));
+        .ok_or(GeneratorError::InternalError(format!(
+            "function not found: {name}-{type_suffix}"
+        )))?;
 
     builder.call(func);
 

--- a/clar2wasm/src/words/comparison.rs
+++ b/clar2wasm/src/words/comparison.rs
@@ -36,9 +36,9 @@ fn traverse_comparison(
         .module
         .funcs
         .by_name(&format!("stdlib.{name}-{type_suffix}"))
-        .ok_or(GeneratorError::InternalError(format!(
-            "function not found: {name}-{type_suffix}"
-        )))?;
+        .ok_or_else(|| {
+            GeneratorError::InternalError(format!("function not found: {name}-{type_suffix}"))
+        })?;
 
     builder.call(func);
 

--- a/clar2wasm/src/words/comparison.rs
+++ b/clar2wasm/src/words/comparison.rs
@@ -26,7 +26,7 @@ fn traverse_comparison(
             "buff"
         }
         _ => {
-            return Err(GeneratorError::InternalError(
+            return Err(GeneratorError::TypeError(
                 "invalid type for comparison".to_string(),
             ))
         }

--- a/clar2wasm/src/words/conditionals.rs
+++ b/clar2wasm/src/words/conditionals.rs
@@ -151,7 +151,9 @@ impl ComplexWord for Filter {
         // Get the type of the sequence
         let ty = generator
             .get_expr_type(sequence)
-            .expect("sequence expression must be typed")
+            .ok_or(GeneratorError::TypeError(
+                "sequence expression must be typed".to_owned(),
+            ))?
             .clone();
 
         // Get the type of the sequence
@@ -397,7 +399,11 @@ impl ComplexWord for Unwrap {
 
         generator.traverse_expr(builder, input)?;
 
-        let throw_type = clar2wasm_ty(generator.get_expr_type(throw).expect("Throw must be typed"));
+        let throw_type = clar2wasm_ty(
+            generator
+                .get_expr_type(throw)
+                .ok_or(GeneratorError::TypeError("Throw must be typed".to_owned()))?,
+        );
 
         let inner_type = match generator.get_expr_type(input) {
             Some(TypeSignature::OptionalType(inner_type)) => (**inner_type).clone(),
@@ -474,7 +480,11 @@ impl ComplexWord for UnwrapErr {
 
         generator.traverse_expr(builder, input)?;
 
-        let throw_type = clar2wasm_ty(generator.get_expr_type(throw).expect("Throw must be typed"));
+        let throw_type = clar2wasm_ty(
+            generator
+                .get_expr_type(throw)
+                .ok_or(GeneratorError::TypeError("Throw must be typed".to_owned()))?,
+        );
 
         let (ok_type, err_type) = if let Some(TypeSignature::ResponseType(inner_types)) =
             generator.get_expr_type(input)
@@ -559,8 +569,16 @@ impl ComplexWord for Asserts {
 
         generator.traverse_expr(builder, input)?;
 
-        let input_type = clar2wasm_ty(generator.get_expr_type(input).expect("Input must be typed"));
-        let throw_type = clar2wasm_ty(generator.get_expr_type(throw).expect("Throw must be typed"));
+        let input_type = clar2wasm_ty(
+            generator
+                .get_expr_type(input)
+                .ok_or(GeneratorError::TypeError("Input must be typed".to_owned()))?,
+        );
+        let throw_type = clar2wasm_ty(
+            generator
+                .get_expr_type(throw)
+                .ok_or(GeneratorError::TypeError("Throw must be typed".to_owned()))?,
+        );
 
         let mut success_branch = builder.dangling_instr_seq(InstrSeqType::new(
             &mut generator.module.types,

--- a/clar2wasm/src/words/conditionals.rs
+++ b/clar2wasm/src/words/conditionals.rs
@@ -160,8 +160,8 @@ impl ComplexWord for Filter {
         let seq_ty = match &ty {
             TypeSignature::SequenceType(seq_ty) => seq_ty.clone(),
             _ => {
-                return Err(GeneratorError::InternalError(
-                    "expected sequence type".to_string(),
+                return Err(GeneratorError::TypeError(
+                    "expected sequence type".to_owned(),
                 ));
             }
         };
@@ -491,7 +491,7 @@ impl ComplexWord for UnwrapErr {
         {
             (**inner_types).clone()
         } else {
-            return Err(GeneratorError::InternalError(
+            return Err(GeneratorError::TypeError(
                 "unwrap-error! only accepts response types".to_string(),
             ));
         };

--- a/clar2wasm/src/words/conditionals.rs
+++ b/clar2wasm/src/words/conditionals.rs
@@ -151,9 +151,9 @@ impl ComplexWord for Filter {
         // Get the type of the sequence
         let ty = generator
             .get_expr_type(sequence)
-            .ok_or(GeneratorError::TypeError(
-                "sequence expression must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| {
+                GeneratorError::TypeError("sequence expression must be typed".to_owned())
+            })?
             .clone();
 
         // Get the type of the sequence
@@ -446,7 +446,7 @@ impl ComplexWord for Unwrap {
         let throw_type = clar2wasm_ty(
             generator
                 .get_expr_type(throw)
-                .ok_or(GeneratorError::TypeError("Throw must be typed".to_owned()))?,
+                .ok_or_else(|| GeneratorError::TypeError("Throw must be typed".to_owned()))?,
         );
 
         let inner_type = match generator.get_expr_type(input) {
@@ -527,7 +527,7 @@ impl ComplexWord for UnwrapErr {
         let throw_type = clar2wasm_ty(
             generator
                 .get_expr_type(throw)
-                .ok_or(GeneratorError::TypeError("Throw must be typed".to_owned()))?,
+                .ok_or_else(|| GeneratorError::TypeError("Throw must be typed".to_owned()))?,
         );
 
         let (ok_type, err_type) = if let Some(TypeSignature::ResponseType(inner_types)) =
@@ -616,12 +616,12 @@ impl ComplexWord for Asserts {
         let input_type = clar2wasm_ty(
             generator
                 .get_expr_type(input)
-                .ok_or(GeneratorError::TypeError("Input must be typed".to_owned()))?,
+                .ok_or_else(|| GeneratorError::TypeError("Input must be typed".to_owned()))?,
         );
         let throw_type = clar2wasm_ty(
             generator
                 .get_expr_type(throw)
-                .ok_or(GeneratorError::TypeError("Throw must be typed".to_owned()))?,
+                .ok_or_else(|| GeneratorError::TypeError("Throw must be typed".to_owned()))?,
         );
 
         let mut success_branch = builder.dangling_instr_seq(InstrSeqType::new(

--- a/clar2wasm/src/words/consensus_buff.rs
+++ b/clar2wasm/src/words/consensus_buff.rs
@@ -26,7 +26,9 @@ impl ComplexWord for ToConsensusBuff {
 
         let ty = generator
             .get_expr_type(args.get_expr(0)?)
-            .expect("to-consensus-buff? value expression must be typed")
+            .ok_or(GeneratorError::TypeError(
+                "to-consensus-buff? value expression must be typed".to_owned(),
+            ))?
             .clone();
 
         // Save the offset (current stack pointer) into a local.
@@ -93,7 +95,9 @@ impl ComplexWord for FromConsensusBuff {
         // of this expression.
         let ty = generator
             .get_expr_type(_expr)
-            .expect("from-consensus-buff? value expression must be typed")
+            .ok_or(GeneratorError::TypeError(
+                "from-consensus-buff? value expression must be typed".to_owned(),
+            ))?
             .clone();
         let wasm_result_ty = clar2wasm_ty(&ty);
         let value_ty = if let TypeSignature::OptionalType(ref inner) = ty {

--- a/clar2wasm/src/words/consensus_buff.rs
+++ b/clar2wasm/src/words/consensus_buff.rs
@@ -26,9 +26,11 @@ impl ComplexWord for ToConsensusBuff {
 
         let ty = generator
             .get_expr_type(args.get_expr(0)?)
-            .ok_or(GeneratorError::TypeError(
-                "to-consensus-buff? value expression must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| {
+                GeneratorError::TypeError(
+                    "to-consensus-buff? value expression must be typed".to_owned(),
+                )
+            })?
             .clone();
 
         // Save the offset (current stack pointer) into a local.
@@ -95,9 +97,11 @@ impl ComplexWord for FromConsensusBuff {
         // of this expression.
         let ty = generator
             .get_expr_type(_expr)
-            .ok_or(GeneratorError::TypeError(
-                "from-consensus-buff? value expression must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| {
+                GeneratorError::TypeError(
+                    "from-consensus-buff? value expression must be typed".to_owned(),
+                )
+            })?
             .clone();
         let wasm_result_ty = clar2wasm_ty(&ty);
         let value_ty = if let TypeSignature::OptionalType(ref inner) = ty {

--- a/clar2wasm/src/words/constants.rs
+++ b/clar2wasm/src/words/constants.rs
@@ -38,9 +38,9 @@ impl ComplexWord for DefineConstant {
 
             let ty = generator
                 .get_expr_type(value)
-                .ok_or(GeneratorError::TypeError(
-                    "constant value must be typed".to_owned(),
-                ))?
+                .ok_or_else(|| {
+                    GeneratorError::TypeError("constant value must be typed".to_owned())
+                })?
                 .clone();
 
             let len = get_type_in_memory_size(&ty, true) as u32;

--- a/clar2wasm/src/words/constants.rs
+++ b/clar2wasm/src/words/constants.rs
@@ -38,7 +38,9 @@ impl ComplexWord for DefineConstant {
 
             let ty = generator
                 .get_expr_type(value)
-                .expect("constant value must be typed")
+                .ok_or(GeneratorError::TypeError(
+                    "constant value must be typed".to_owned(),
+                ))?
                 .clone();
 
             let len = get_type_in_memory_size(&ty, true) as u32;

--- a/clar2wasm/src/words/contract.rs
+++ b/clar2wasm/src/words/contract.rs
@@ -91,9 +91,9 @@ impl ComplexWord for ContractCall {
 
             let arg_ty = generator
                 .get_expr_type(arg)
-                .ok_or(GeneratorError::TypeError(
-                    "contract-call? argument must be typed".to_owned(),
-                ))?
+                .ok_or_else(|| {
+                    GeneratorError::TypeError("contract-call? argument must be typed".to_owned())
+                })?
                 .clone();
 
             arg_length += generator.write_to_memory(builder, arg_offset, arg_length, &arg_ty);
@@ -105,9 +105,9 @@ impl ComplexWord for ContractCall {
         // Reserve space for the return value
         let return_ty = generator
             .get_expr_type(expr)
-            .ok_or(GeneratorError::TypeError(
-                "contract-call? expression must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| {
+                GeneratorError::TypeError("contract-call? expression must be typed".to_owned())
+            })?
             .clone();
         let (return_offset, return_size) =
             generator.create_call_stack_local(builder, &return_ty, true, true);

--- a/clar2wasm/src/words/contract.rs
+++ b/clar2wasm/src/words/contract.rs
@@ -91,7 +91,9 @@ impl ComplexWord for ContractCall {
 
             let arg_ty = generator
                 .get_expr_type(arg)
-                .expect("contract-call? argument must be typed")
+                .ok_or(GeneratorError::TypeError(
+                    "contract-call? argument must be typed".to_owned(),
+                ))?
                 .clone();
 
             arg_length += generator.write_to_memory(builder, arg_offset, arg_length, &arg_ty);
@@ -103,7 +105,9 @@ impl ComplexWord for ContractCall {
         // Reserve space for the return value
         let return_ty = generator
             .get_expr_type(expr)
-            .expect("contract-call? expression must be typed")
+            .ok_or(GeneratorError::TypeError(
+                "contract-call? expression must be typed".to_owned(),
+            ))?
             .clone();
         let (return_offset, return_size) =
             generator.create_call_stack_local(builder, &return_ty, true, true);

--- a/clar2wasm/src/words/control_flow.rs
+++ b/clar2wasm/src/words/control_flow.rs
@@ -39,7 +39,7 @@ impl ComplexWord for Begin {
             })?,
             generator
                 .get_expr_type(expr)
-                .expect("begin must be typed")
+                .ok_or(GeneratorError::TypeError("begin must be typed".to_owned()))?
                 .clone(),
         );
         generator.traverse_statement_list(builder, args)
@@ -70,7 +70,9 @@ impl ComplexWord for UnwrapPanic {
         // Get the type of the input expression
         let input_ty = generator
             .get_expr_type(input)
-            .expect("'unwrap-err' input expression must be typed")
+            .ok_or(GeneratorError::TypeError(
+                "'unwrap-err' input expression must be typed".to_owned(),
+            ))?
             .clone();
 
         match &input_ty {
@@ -179,7 +181,9 @@ impl ComplexWord for UnwrapErrPanic {
         // Get the type of the input expression
         let input_ty = generator
             .get_expr_type(input)
-            .expect("'unwrap-err-panic' input expression must be typed")
+            .ok_or(GeneratorError::TypeError(
+                "'unwrap-err-panic' input expression must be typed".to_owned(),
+            ))?
             .clone();
 
         match &input_ty {

--- a/clar2wasm/src/words/control_flow.rs
+++ b/clar2wasm/src/words/control_flow.rs
@@ -1,6 +1,6 @@
 use clarity::vm::types::TypeSignature;
 use clarity::vm::{ClarityName, SymbolicExpression};
-use walrus::ir::UnaryOp;
+use walrus::ir::{IfElse, UnaryOp};
 
 use super::ComplexWord;
 use crate::wasm_generator::{drop_value, ArgumentsExt, GeneratorError, WasmGenerator};
@@ -90,19 +90,29 @@ impl ComplexWord for UnwrapPanic {
                 let val_locals = generator.save_to_locals(builder, val_ty, true);
 
                 // If the indicator is 0, throw a runtime error
-                builder.unop(UnaryOp::I32Eqz).if_else(
-                    None,
-                    |then| {
-                        then.i32_const(Trap::Panic as i32).call(
-                            generator
-                                .module
-                                .funcs
-                                .by_name("stdlib.runtime-error")
-                                .expect("stdlib.runtime-error not found"),
-                        );
-                    },
-                    |_| {},
-                );
+                let if_id = {
+                    let mut if_case = builder.dangling_instr_seq(None);
+                    if_case.i32_const(Trap::Panic as i32).call(
+                        generator
+                            .module
+                            .funcs
+                            .by_name("stdlib.runtime-error")
+                            .ok_or(GeneratorError::InternalError(
+                                "stdlib.runtime-error not found".to_owned(),
+                            ))?,
+                    );
+                    if_case.id()
+                };
+
+                let else_id = {
+                    let else_case = builder.dangling_instr_seq(None);
+                    else_case.id()
+                };
+
+                builder.unop(UnaryOp::I32Eqz).instr(IfElse {
+                    consequent: if_id,
+                    alternative: else_id,
+                });
 
                 // Otherwise, push the value back onto the stack
                 for val_local in val_locals {
@@ -132,19 +142,29 @@ impl ComplexWord for UnwrapPanic {
                 let ok_val_locals = generator.save_to_locals(builder, ok_ty, true);
 
                 // If the indicator is 0, throw a runtime error
-                builder.unop(UnaryOp::I32Eqz).if_else(
-                    None,
-                    |then| {
-                        then.i32_const(Trap::Panic as i32).call(
-                            generator
-                                .module
-                                .funcs
-                                .by_name("stdlib.runtime-error")
-                                .expect("stdlib.runtime-error not found"),
-                        );
-                    },
-                    |_| {},
-                );
+                let if_id = {
+                    let mut if_case = builder.dangling_instr_seq(None);
+                    if_case.i32_const(Trap::Panic as i32).call(
+                        generator
+                            .module
+                            .funcs
+                            .by_name("stdlib.runtime-error")
+                            .ok_or(GeneratorError::InternalError(
+                                "stdlib.runtime-error not found".to_owned(),
+                            ))?,
+                    );
+                    if_case.id()
+                };
+
+                let else_id = {
+                    let else_case = builder.dangling_instr_seq(None);
+                    else_case.id()
+                };
+
+                builder.unop(UnaryOp::I32Eqz).instr(IfElse {
+                    consequent: if_id,
+                    alternative: else_id,
+                });
 
                 // Otherwise, push the value back onto the stack
                 for val_local in ok_val_locals {
@@ -209,19 +229,29 @@ impl ComplexWord for UnwrapErrPanic {
                 drop_value(builder, ok_ty);
 
                 // If the indicator is 0, throw a runtime error
-                builder.unop(UnaryOp::I32Eqz).if_else(
-                    None,
-                    |_| {},
-                    |else_| {
-                        else_.i32_const(Trap::Panic as i32).call(
-                            generator
-                                .module
-                                .funcs
-                                .by_name("stdlib.runtime-error")
-                                .expect("stdlib.runtime-error not found"),
-                        );
-                    },
-                );
+                let if_id = {
+                    let if_case = builder.dangling_instr_seq(None);
+                    if_case.id()
+                };
+
+                let else_id = {
+                    let mut else_case = builder.dangling_instr_seq(None);
+                    else_case.i32_const(Trap::Panic as i32).call(
+                        generator
+                            .module
+                            .funcs
+                            .by_name("stdlib.runtime-error")
+                            .ok_or(GeneratorError::InternalError(
+                                "stdlib.runtime-error not found".to_owned(),
+                            ))?,
+                    );
+                    else_case.id()
+                };
+
+                builder.unop(UnaryOp::I32Eqz).instr(IfElse {
+                    consequent: if_id,
+                    alternative: else_id,
+                });
 
                 // Otherwise, push the value back onto the stack
                 for val_local in err_val_locals {

--- a/clar2wasm/src/words/control_flow.rs
+++ b/clar2wasm/src/words/control_flow.rs
@@ -39,7 +39,7 @@ impl ComplexWord for Begin {
             })?,
             generator
                 .get_expr_type(expr)
-                .ok_or(GeneratorError::TypeError("begin must be typed".to_owned()))?
+                .ok_or_else(|| GeneratorError::TypeError("begin must be typed".to_owned()))?
                 .clone(),
         );
         generator.traverse_statement_list(builder, args)
@@ -70,9 +70,9 @@ impl ComplexWord for UnwrapPanic {
         // Get the type of the input expression
         let input_ty = generator
             .get_expr_type(input)
-            .ok_or(GeneratorError::TypeError(
-                "'unwrap-err' input expression must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| {
+                GeneratorError::TypeError("'unwrap-err' input expression must be typed".to_owned())
+            })?
             .clone();
 
         match &input_ty {
@@ -97,9 +97,11 @@ impl ComplexWord for UnwrapPanic {
                             .module
                             .funcs
                             .by_name("stdlib.runtime-error")
-                            .ok_or(GeneratorError::InternalError(
-                                "stdlib.runtime-error not found".to_owned(),
-                            ))?,
+                            .ok_or_else(|| {
+                                GeneratorError::InternalError(
+                                    "stdlib.runtime-error not found".to_owned(),
+                                )
+                            })?,
                     );
                     if_case.id()
                 };
@@ -149,9 +151,11 @@ impl ComplexWord for UnwrapPanic {
                             .module
                             .funcs
                             .by_name("stdlib.runtime-error")
-                            .ok_or(GeneratorError::InternalError(
-                                "stdlib.runtime-error not found".to_owned(),
-                            ))?,
+                            .ok_or_else(|| {
+                                GeneratorError::InternalError(
+                                    "stdlib.runtime-error not found".to_owned(),
+                                )
+                            })?,
                     );
                     if_case.id()
                 };
@@ -201,9 +205,11 @@ impl ComplexWord for UnwrapErrPanic {
         // Get the type of the input expression
         let input_ty = generator
             .get_expr_type(input)
-            .ok_or(GeneratorError::TypeError(
-                "'unwrap-err-panic' input expression must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| {
+                GeneratorError::TypeError(
+                    "'unwrap-err-panic' input expression must be typed".to_owned(),
+                )
+            })?
             .clone();
 
         match &input_ty {
@@ -241,9 +247,11 @@ impl ComplexWord for UnwrapErrPanic {
                             .module
                             .funcs
                             .by_name("stdlib.runtime-error")
-                            .ok_or(GeneratorError::InternalError(
-                                "stdlib.runtime-error not found".to_owned(),
-                            ))?,
+                            .ok_or_else(|| {
+                                GeneratorError::InternalError(
+                                    "stdlib.runtime-error not found".to_owned(),
+                                )
+                            })?,
                     );
                     else_case.id()
                 };

--- a/clar2wasm/src/words/conversion.rs
+++ b/clar2wasm/src/words/conversion.rs
@@ -95,7 +95,7 @@ impl SimpleWord for IntToAscii {
             TypeSignature::IntType => "int",
             TypeSignature::UIntType => "uint",
             _ => {
-                return Err(GeneratorError::InternalError(
+                return Err(GeneratorError::TypeError(
                     "invalid type for int-to-ascii".to_owned(),
                 ));
             }
@@ -128,7 +128,7 @@ impl SimpleWord for IntToUtf8 {
             TypeSignature::IntType => "int",
             TypeSignature::UIntType => "uint",
             _ => {
-                return Err(GeneratorError::InternalError(
+                return Err(GeneratorError::TypeError(
                     "invalid type for int-to-utf8".to_owned(),
                 ));
             }

--- a/clar2wasm/src/words/data_vars.rs
+++ b/clar2wasm/src/words/data_vars.rs
@@ -30,9 +30,9 @@ impl ComplexWord for DefineDataVar {
         // the top-level, we have not set up the call stack yet.
         let ty = generator
             .get_expr_type(initial)
-            .ok_or(GeneratorError::TypeError(
-                "initial value expression must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| {
+                GeneratorError::TypeError("initial value expression must be typed".to_owned())
+            })?
             .clone();
         let offset = generator.module.locals.add(ValType::I32);
         builder
@@ -69,9 +69,9 @@ impl ComplexWord for DefineDataVar {
                 .module
                 .funcs
                 .by_name("stdlib.define_variable")
-                .ok_or(GeneratorError::InternalError(
-                    "stdlib.define_variable not found".to_owned(),
-                ))?,
+                .ok_or_else(|| {
+                    GeneratorError::InternalError("stdlib.define_variable not found".to_owned())
+                })?,
         );
         Ok(())
     }
@@ -100,17 +100,15 @@ impl ComplexWord for SetDataVar {
         let id_offset = *generator
             .literal_memory_offset
             .get(&LiteralMemoryEntry::Ascii(name.as_str().into()))
-            .ok_or(GeneratorError::InternalError(format!(
-                "variable not found: {name}"
-            )))?;
+            .ok_or_else(|| GeneratorError::InternalError(format!("variable not found: {name}")))?;
         let id_length = name.len();
 
         // Create space on the call stack to write the value
         let ty = generator
             .get_expr_type(value)
-            .ok_or(GeneratorError::TypeError(
-                "var-set value expression must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| {
+                GeneratorError::TypeError("var-set value expression must be typed".to_owned())
+            })?
             .clone();
         let (offset, size) = generator.create_call_stack_local(builder, &ty, true, false);
 
@@ -131,9 +129,9 @@ impl ComplexWord for SetDataVar {
                 .module
                 .funcs
                 .by_name("stdlib.set_variable")
-                .ok_or(GeneratorError::InternalError(
-                    "stdlib.set_variable not found".to_owned(),
-                ))?,
+                .ok_or_else(|| {
+                    GeneratorError::InternalError("stdlib.set_variable not found".to_owned())
+                })?,
         );
 
         // `var-set` always returns `true`
@@ -164,17 +162,15 @@ impl ComplexWord for GetDataVar {
         let id_offset = *generator
             .literal_memory_offset
             .get(&LiteralMemoryEntry::Ascii(name.as_str().into()))
-            .ok_or(GeneratorError::TypeError(format!(
-                "variable not found: {name}"
-            )))?;
+            .ok_or_else(|| GeneratorError::TypeError(format!("variable not found: {name}")))?;
         let id_length = name.len();
 
         // Create a new local to hold the result on the call stack
         let ty = generator
             .get_expr_type(expr)
-            .ok_or(GeneratorError::TypeError(
-                "var-get expression must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| {
+                GeneratorError::TypeError("var-get expression must be typed".to_owned())
+            })?
             .clone();
         let (offset, size) = generator.create_call_stack_local(builder, &ty, true, true);
 
@@ -192,9 +188,9 @@ impl ComplexWord for GetDataVar {
                 .module
                 .funcs
                 .by_name("stdlib.get_variable")
-                .ok_or(GeneratorError::InternalError(
-                    "stdlib.get_variable not found".to_owned(),
-                ))?,
+                .ok_or_else(|| {
+                    GeneratorError::InternalError("stdlib.get_variable not found".to_owned())
+                })?,
         );
 
         // Host interface fills the result into the specified memory. Read it

--- a/clar2wasm/src/words/default_to.rs
+++ b/clar2wasm/src/words/default_to.rs
@@ -35,13 +35,17 @@ impl ComplexWord for DefaultTo {
         // Default value type
         let default_ty = generator
             .get_expr_type(default)
-            .expect("default expression must be typed")
+            .ok_or(GeneratorError::TypeError(
+                "default expression must be typed".to_owned(),
+            ))?
             .clone();
 
         // Optional value type
         let opt_ty = generator
             .get_expr_type(optional)
-            .expect("optional expression must be typed")
+            .ok_or(GeneratorError::TypeError(
+                "optional expression must be typed".to_owned(),
+            ))?
             .clone();
         // Optional value
         let opt_val_ty = if let TypeSignature::OptionalType(opt_type) = &opt_ty {

--- a/clar2wasm/src/words/default_to.rs
+++ b/clar2wasm/src/words/default_to.rs
@@ -47,17 +47,17 @@ impl ComplexWord for DefaultTo {
         // Default value type
         let default_ty = generator
             .get_expr_type(default)
-            .ok_or(GeneratorError::TypeError(
-                "default expression must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| {
+                GeneratorError::TypeError("default expression must be typed".to_owned())
+            })?
             .clone();
 
         // Optional value type
         let opt_ty = generator
             .get_expr_type(optional)
-            .ok_or(GeneratorError::TypeError(
-                "optional expression must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| {
+                GeneratorError::TypeError("optional expression must be typed".to_owned())
+            })?
             .clone();
         // Optional value
         let opt_val_ty = if let TypeSignature::OptionalType(opt_type) = &opt_ty {

--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -140,7 +140,7 @@ impl ComplexWord for IndexOf {
                 }
             },
             _ => {
-                return Err(GeneratorError::InternalError(
+                return Err(GeneratorError::TypeError(
                     "expected sequence type".to_string(),
                 ));
             }

--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -30,7 +30,9 @@ impl ComplexWord for IsEq {
         generator.traverse_expr(builder, first_op)?;
         let ty = generator
             .get_expr_type(first_op)
-            .expect("is-eq value expression must be typed")
+            .ok_or(GeneratorError::TypeError(
+                "is-eq value expression must be typed".to_owned(),
+            ))?
             .clone();
 
         // No need to go further if there is only one argument
@@ -67,7 +69,9 @@ impl ComplexWord for IsEq {
             // insert the new operand into locals
             let operand_ty = generator
                 .get_expr_type(operand)
-                .expect("is-eq value expression must be typed")
+                .ok_or(GeneratorError::TypeError(
+                    "is-eq value expression must be typed".to_owned(),
+                ))?
                 .clone();
             assign_to_locals(builder, &ty, &operand_ty, &nth_locals)?;
 
@@ -118,8 +122,9 @@ impl ComplexWord for IndexOf {
         // Get type of the Sequence element.
         let elem_ty = match generator
             .get_expr_type(seq)
-            .expect("Sequence expression must be typed")
-        {
+            .ok_or(GeneratorError::TypeError(
+                "Sequence expression must be typed".to_owned(),
+            ))? {
             TypeSignature::SequenceType(ty) => match &ty {
                 SequenceSubtype::ListType(list_type) => Ok(SequenceElementType::Other(
                     list_type.get_list_item_type().clone(),

--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -179,7 +179,7 @@ impl ComplexWord for IndexOf {
         let else_id = {
             let else_case = &mut builder.dangling_instr_seq(ty);
             let item = args.get_expr(1).unwrap();
-            let _ = generator.traverse_expr(else_case, item);
+            generator.traverse_expr(else_case, item)?;
             // STACK: [item]
 
             // Get the type of the item expression

--- a/clar2wasm/src/words/hashing.rs
+++ b/clar2wasm/src/words/hashing.rs
@@ -128,9 +128,15 @@ impl SimpleWord for Keccak256 {
         builder.local_get(result_local).i32_const(result_size);
 
         // Call the host interface function, `keccak256`
-        builder.call(generator.module.funcs.by_name("stdlib.keccak256").ok_or(
-            GeneratorError::InternalError("stdlib.keccak256 not found".to_owned()),
-        )?);
+        builder.call(
+            generator
+                .module
+                .funcs
+                .by_name("stdlib.keccak256")
+                .ok_or_else(|| {
+                    GeneratorError::InternalError("stdlib.keccak256 not found".to_owned())
+                })?,
+        );
 
         Ok(())
     }
@@ -202,9 +208,15 @@ impl SimpleWord for Sha512_256 {
         builder.local_get(result_local).i32_const(result_size);
 
         // Call the host interface function, `sha512`
-        builder.call(generator.module.funcs.by_name("stdlib.sha512_256").ok_or(
-            GeneratorError::InternalError("stdlib.sha512_256 not found".to_owned()),
-        )?);
+        builder.call(
+            generator
+                .module
+                .funcs
+                .by_name("stdlib.sha512_256")
+                .ok_or_else(|| {
+                    GeneratorError::InternalError("stdlib.sha512_256 not found".to_owned())
+                })?,
+        );
 
         Ok(())
     }

--- a/clar2wasm/src/words/hashing.rs
+++ b/clar2wasm/src/words/hashing.rs
@@ -26,7 +26,9 @@ pub fn traverse_hash(
         .module
         .funcs
         .by_name(&format!("stdlib.{name}-{hash_type}"))
-        .unwrap_or_else(|| panic!("function not found: {name}-{hash_type}"));
+        .ok_or_else(|| {
+            GeneratorError::InternalError(format!("function not found: {name}-{hash_type}"))
+        })?;
 
     builder
         .i32_const(offset_res as i32) // result offset
@@ -126,13 +128,9 @@ impl SimpleWord for Keccak256 {
         builder.local_get(result_local).i32_const(result_size);
 
         // Call the host interface function, `keccak256`
-        builder.call(
-            generator
-                .module
-                .funcs
-                .by_name("stdlib.keccak256")
-                .expect("function not found"),
-        );
+        builder.call(generator.module.funcs.by_name("stdlib.keccak256").ok_or(
+            GeneratorError::InternalError("stdlib.keccak256 not found".to_owned()),
+        )?);
 
         Ok(())
     }
@@ -204,13 +202,9 @@ impl SimpleWord for Sha512_256 {
         builder.local_get(result_local).i32_const(result_size);
 
         // Call the host interface function, `sha512`
-        builder.call(
-            generator
-                .module
-                .funcs
-                .by_name("stdlib.sha512_256")
-                .expect("function not found"),
-        );
+        builder.call(generator.module.funcs.by_name("stdlib.sha512_256").ok_or(
+            GeneratorError::InternalError("stdlib.sha512_256 not found".to_owned()),
+        )?);
 
         Ok(())
     }

--- a/clar2wasm/src/words/maps.rs
+++ b/clar2wasm/src/words/maps.rs
@@ -30,13 +30,9 @@ impl ComplexWord for MapDefinition {
             .i32_const(name_offset as i32)
             .i32_const(name_length as i32);
 
-        builder.call(
-            generator
-                .module
-                .funcs
-                .by_name("stdlib.define_map")
-                .expect("function not found"),
-        );
+        builder.call(generator.module.funcs.by_name("stdlib.define_map").ok_or(
+            GeneratorError::InternalError("stdlib.define_map not found".to_owned()),
+        )?);
         Ok(())
     }
 }
@@ -63,7 +59,9 @@ impl ComplexWord for MapGet {
         let id_offset = *generator
             .literal_memory_offset
             .get(&LiteralMemoryEntry::Ascii(name.as_str().into()))
-            .expect("map not found: {name}");
+            .ok_or(GeneratorError::InternalError(format!(
+                "map not found: {name}"
+            )))?;
         let id_length = name.len();
 
         // Push the identifier offset and length onto the data stack
@@ -74,7 +72,9 @@ impl ComplexWord for MapGet {
         // Create space on the call stack to write the key
         let ty = generator
             .get_expr_type(key)
-            .expect("map-set value expression must be typed")
+            .ok_or(GeneratorError::TypeError(
+                "map-set value expression must be typed".to_owned(),
+            ))?
             .clone();
         let (key_offset, key_size) = generator.create_call_stack_local(builder, &ty, true, false);
 
@@ -90,7 +90,9 @@ impl ComplexWord for MapGet {
         // Create a new local to hold the result on the call stack
         let ty = generator
             .get_expr_type(expr)
-            .expect("map-get? expression must be typed")
+            .ok_or(GeneratorError::TypeError(
+                "map-get? expression must be typed".to_owned(),
+            ))?
             .clone();
         let (return_offset, return_size) =
             generator.create_call_stack_local(builder, &ty, true, true);
@@ -132,7 +134,9 @@ impl ComplexWord for MapSet {
         let id_offset = *generator
             .literal_memory_offset
             .get(&LiteralMemoryEntry::Ascii(name.as_str().into()))
-            .expect("map not found: {name}");
+            .ok_or(GeneratorError::InternalError(format!(
+                "map not found: {name}"
+            )))?;
         let id_length = name.len();
 
         // Push the identifier offset and length onto the data stack
@@ -143,7 +147,9 @@ impl ComplexWord for MapSet {
         // Create space on the call stack to write the key
         let ty = generator
             .get_expr_type(key)
-            .expect("map-set value expression must be typed")
+            .ok_or(GeneratorError::TypeError(
+                "map-set value expression must be typed".to_owned(),
+            ))?
             .clone();
         let (key_offset, key_size) = generator.create_call_stack_local(builder, &ty, true, false);
 
@@ -159,7 +165,9 @@ impl ComplexWord for MapSet {
         // Create space on the call stack to write the value
         let ty = generator
             .get_expr_type(value)
-            .expect("map-set value expression must be typed")
+            .ok_or(GeneratorError::TypeError(
+                "map-set value expression must be typed".to_owned(),
+            ))?
             .clone();
         let (val_offset, val_size) = generator.create_call_stack_local(builder, &ty, true, false);
 
@@ -202,7 +210,9 @@ impl ComplexWord for MapInsert {
         let id_offset = *generator
             .literal_memory_offset
             .get(&LiteralMemoryEntry::Ascii(name.as_str().into()))
-            .expect("map not found: {name}");
+            .ok_or(GeneratorError::InternalError(format!(
+                "map not found: {name}"
+            )))?;
         let id_length = name.len();
 
         // Push the identifier offset and length onto the data stack
@@ -213,7 +223,9 @@ impl ComplexWord for MapInsert {
         // Create space on the call stack to write the key
         let ty = generator
             .get_expr_type(key)
-            .expect("map-set value expression must be typed")
+            .ok_or(GeneratorError::TypeError(
+                "map-set value expression must be typed".to_owned(),
+            ))?
             .clone();
         let (key_offset, key_size) = generator.create_call_stack_local(builder, &ty, true, false);
 
@@ -229,7 +241,9 @@ impl ComplexWord for MapInsert {
         // Create space on the call stack to write the value
         let ty = generator
             .get_expr_type(value)
-            .expect("map-set value expression must be typed")
+            .ok_or(GeneratorError::TypeError(
+                "map-set value expression must be typed".to_owned(),
+            ))?
             .clone();
         let (val_offset, val_size) = generator.create_call_stack_local(builder, &ty, true, false);
 
@@ -271,7 +285,10 @@ impl ComplexWord for MapDelete {
         let id_offset = *generator
             .literal_memory_offset
             .get(&LiteralMemoryEntry::Ascii(name.as_str().into()))
-            .expect("map not found: {name}");
+            .ok_or(GeneratorError::InternalError(format!(
+                "map not found: {name}"
+            )))?;
+
         let id_length = name.len();
 
         // Push the identifier offset and length onto the data stack
@@ -282,7 +299,9 @@ impl ComplexWord for MapDelete {
         // Create space on the call stack to write the key
         let ty = generator
             .get_expr_type(key)
-            .expect("map-set value expression must be typed")
+            .ok_or(GeneratorError::TypeError(
+                "map-set value expression must be typed".to_owned(),
+            ))?
             .clone();
         let (key_offset, key_size) = generator.create_call_stack_local(builder, &ty, true, false);
 
@@ -296,13 +315,9 @@ impl ComplexWord for MapDelete {
         builder.local_get(key_offset).i32_const(key_size);
 
         // Call the host interface function, `map_delete`
-        builder.call(
-            generator
-                .module
-                .funcs
-                .by_name("stdlib.map_delete")
-                .expect("map_delete not found"),
-        );
+        builder.call(generator.module.funcs.by_name("stdlib.map_delete").ok_or(
+            GeneratorError::TypeError("stdlib.map_delete not found".to_owned()),
+        )?);
 
         Ok(())
     }

--- a/clar2wasm/src/words/maps.rs
+++ b/clar2wasm/src/words/maps.rs
@@ -30,9 +30,15 @@ impl ComplexWord for MapDefinition {
             .i32_const(name_offset as i32)
             .i32_const(name_length as i32);
 
-        builder.call(generator.module.funcs.by_name("stdlib.define_map").ok_or(
-            GeneratorError::InternalError("stdlib.define_map not found".to_owned()),
-        )?);
+        builder.call(
+            generator
+                .module
+                .funcs
+                .by_name("stdlib.define_map")
+                .ok_or_else(|| {
+                    GeneratorError::InternalError("stdlib.define_map not found".to_owned())
+                })?,
+        );
         Ok(())
     }
 }
@@ -59,9 +65,7 @@ impl ComplexWord for MapGet {
         let id_offset = *generator
             .literal_memory_offset
             .get(&LiteralMemoryEntry::Ascii(name.as_str().into()))
-            .ok_or(GeneratorError::InternalError(format!(
-                "map not found: {name}"
-            )))?;
+            .ok_or_else(|| GeneratorError::InternalError(format!("map not found: {name}")))?;
         let id_length = name.len();
 
         // Push the identifier offset and length onto the data stack
@@ -72,9 +76,9 @@ impl ComplexWord for MapGet {
         // Create space on the call stack to write the key
         let ty = generator
             .get_expr_type(key)
-            .ok_or(GeneratorError::TypeError(
-                "map-set value expression must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| {
+                GeneratorError::TypeError("map-set value expression must be typed".to_owned())
+            })?
             .clone();
         let (key_offset, key_size) = generator.create_call_stack_local(builder, &ty, true, false);
 
@@ -90,9 +94,9 @@ impl ComplexWord for MapGet {
         // Create a new local to hold the result on the call stack
         let ty = generator
             .get_expr_type(expr)
-            .ok_or(GeneratorError::TypeError(
-                "map-get? expression must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| {
+                GeneratorError::TypeError("map-get? expression must be typed".to_owned())
+            })?
             .clone();
         let (return_offset, return_size) =
             generator.create_call_stack_local(builder, &ty, true, true);
@@ -134,9 +138,7 @@ impl ComplexWord for MapSet {
         let id_offset = *generator
             .literal_memory_offset
             .get(&LiteralMemoryEntry::Ascii(name.as_str().into()))
-            .ok_or(GeneratorError::InternalError(format!(
-                "map not found: {name}"
-            )))?;
+            .ok_or_else(|| GeneratorError::InternalError(format!("map not found: {name}")))?;
         let id_length = name.len();
 
         // Push the identifier offset and length onto the data stack
@@ -147,9 +149,9 @@ impl ComplexWord for MapSet {
         // Create space on the call stack to write the key
         let ty = generator
             .get_expr_type(key)
-            .ok_or(GeneratorError::TypeError(
-                "map-set value expression must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| {
+                GeneratorError::TypeError("map-set value expression must be typed".to_owned())
+            })?
             .clone();
         let (key_offset, key_size) = generator.create_call_stack_local(builder, &ty, true, false);
 
@@ -165,9 +167,9 @@ impl ComplexWord for MapSet {
         // Create space on the call stack to write the value
         let ty = generator
             .get_expr_type(value)
-            .ok_or(GeneratorError::TypeError(
-                "map-set value expression must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| {
+                GeneratorError::TypeError("map-set value expression must be typed".to_owned())
+            })?
             .clone();
         let (val_offset, val_size) = generator.create_call_stack_local(builder, &ty, true, false);
 
@@ -210,9 +212,7 @@ impl ComplexWord for MapInsert {
         let id_offset = *generator
             .literal_memory_offset
             .get(&LiteralMemoryEntry::Ascii(name.as_str().into()))
-            .ok_or(GeneratorError::InternalError(format!(
-                "map not found: {name}"
-            )))?;
+            .ok_or_else(|| GeneratorError::InternalError(format!("map not found: {name}")))?;
         let id_length = name.len();
 
         // Push the identifier offset and length onto the data stack
@@ -223,9 +223,9 @@ impl ComplexWord for MapInsert {
         // Create space on the call stack to write the key
         let ty = generator
             .get_expr_type(key)
-            .ok_or(GeneratorError::TypeError(
-                "map-set value expression must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| {
+                GeneratorError::TypeError("map-set value expression must be typed".to_owned())
+            })?
             .clone();
         let (key_offset, key_size) = generator.create_call_stack_local(builder, &ty, true, false);
 
@@ -241,9 +241,9 @@ impl ComplexWord for MapInsert {
         // Create space on the call stack to write the value
         let ty = generator
             .get_expr_type(value)
-            .ok_or(GeneratorError::TypeError(
-                "map-set value expression must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| {
+                GeneratorError::TypeError("map-set value expression must be typed".to_owned())
+            })?
             .clone();
         let (val_offset, val_size) = generator.create_call_stack_local(builder, &ty, true, false);
 
@@ -285,9 +285,7 @@ impl ComplexWord for MapDelete {
         let id_offset = *generator
             .literal_memory_offset
             .get(&LiteralMemoryEntry::Ascii(name.as_str().into()))
-            .ok_or(GeneratorError::InternalError(format!(
-                "map not found: {name}"
-            )))?;
+            .ok_or_else(|| GeneratorError::InternalError(format!("map not found: {name}")))?;
 
         let id_length = name.len();
 
@@ -299,9 +297,9 @@ impl ComplexWord for MapDelete {
         // Create space on the call stack to write the key
         let ty = generator
             .get_expr_type(key)
-            .ok_or(GeneratorError::TypeError(
-                "map-set value expression must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| {
+                GeneratorError::TypeError("map-set value expression must be typed".to_owned())
+            })?
             .clone();
         let (key_offset, key_size) = generator.create_call_stack_local(builder, &ty, true, false);
 
@@ -315,9 +313,15 @@ impl ComplexWord for MapDelete {
         builder.local_get(key_offset).i32_const(key_size);
 
         // Call the host interface function, `map_delete`
-        builder.call(generator.module.funcs.by_name("stdlib.map_delete").ok_or(
-            GeneratorError::TypeError("stdlib.map_delete not found".to_owned()),
-        )?);
+        builder.call(
+            generator
+                .module
+                .funcs
+                .by_name("stdlib.map_delete")
+                .ok_or_else(|| {
+                    GeneratorError::TypeError("stdlib.map_delete not found".to_owned())
+                })?,
+        );
 
         Ok(())
     }

--- a/clar2wasm/src/words/options.rs
+++ b/clar2wasm/src/words/options.rs
@@ -17,9 +17,7 @@ pub fn traverse_optional(
     // Get the type of the optional expression
     let ty = generator
         .get_expr_type(opt)
-        .ok_or(GeneratorError::TypeError(
-            "input expression must be typed".to_owned(),
-        ))?
+        .ok_or_else(|| GeneratorError::TypeError("input expression must be typed".to_owned()))?
         .clone();
 
     let some_ty = if let TypeSignature::OptionalType(some_type) = &ty {

--- a/clar2wasm/src/words/options.rs
+++ b/clar2wasm/src/words/options.rs
@@ -17,7 +17,9 @@ pub fn traverse_optional(
     // Get the type of the optional expression
     let ty = generator
         .get_expr_type(opt)
-        .expect("input expression must be typed")
+        .ok_or(GeneratorError::TypeError(
+            "input expression must be typed".to_owned(),
+        ))?
         .clone();
 
     let some_ty = if let TypeSignature::OptionalType(some_type) = &ty {

--- a/clar2wasm/src/words/print.rs
+++ b/clar2wasm/src/words/print.rs
@@ -27,7 +27,9 @@ impl ComplexWord for Print {
         // Save the value to locals
         let ty = generator
             .get_expr_type(value)
-            .expect("print value expression must be typed")
+            .ok_or(GeneratorError::TypeError(
+                "print value expression must be typed".to_owned(),
+            ))?
             .clone();
         let val_locals = generator.save_to_locals(builder, &ty, true);
 
@@ -41,7 +43,9 @@ impl ComplexWord for Print {
 
         let ty = generator
             .get_expr_type(value)
-            .expect("print value expression must be typed")
+            .ok_or(GeneratorError::TypeError(
+                "print value expression must be typed".to_owned(),
+            ))?
             .clone();
 
         // Push the value back onto the data stack

--- a/clar2wasm/src/words/print.rs
+++ b/clar2wasm/src/words/print.rs
@@ -27,9 +27,9 @@ impl ComplexWord for Print {
         // Save the value to locals
         let ty = generator
             .get_expr_type(value)
-            .ok_or(GeneratorError::TypeError(
-                "print value expression must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| {
+                GeneratorError::TypeError("print value expression must be typed".to_owned())
+            })?
             .clone();
         let val_locals = generator.save_to_locals(builder, &ty, true);
 
@@ -43,9 +43,9 @@ impl ComplexWord for Print {
 
         let ty = generator
             .get_expr_type(value)
-            .ok_or(GeneratorError::TypeError(
-                "print value expression must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| {
+                GeneratorError::TypeError("print value expression must be typed".to_owned())
+            })?
             .clone();
 
         // Push the value back onto the data stack

--- a/clar2wasm/src/words/responses.rs
+++ b/clar2wasm/src/words/responses.rs
@@ -17,9 +17,7 @@ pub fn traverse_response(
     // Get the type of the response expression
     let ty = generator
         .get_expr_type(res)
-        .ok_or(GeneratorError::TypeError(
-            "input expression must be typed".to_owned(),
-        ))?
+        .ok_or_else(|| GeneratorError::TypeError("input expression must be typed".to_owned()))?
         .clone();
 
     let (ok_ty, err_ty) = if let TypeSignature::ResponseType(types) = &ty {

--- a/clar2wasm/src/words/responses.rs
+++ b/clar2wasm/src/words/responses.rs
@@ -17,7 +17,9 @@ pub fn traverse_response(
     // Get the type of the response expression
     let ty = generator
         .get_expr_type(res)
-        .expect("input expression must be typed")
+        .ok_or(GeneratorError::TypeError(
+            "input expression must be typed".to_owned(),
+        ))?
         .clone();
 
     let (ok_ty, err_ty) = if let TypeSignature::ResponseType(types) = &ty {

--- a/clar2wasm/src/words/secp256k1.rs
+++ b/clar2wasm/src/words/secp256k1.rs
@@ -24,7 +24,9 @@ impl ComplexWord for Recover {
         // Reserve stack space for the host-function to write the result
         let ret_ty = generator
             .get_expr_type(expr)
-            .expect("result of secp256k1-recover? should be typed")
+            .ok_or(GeneratorError::TypeError(
+                "result of secp256k1-recover? should be typed".to_owned(),
+            ))?
             .clone();
 
         let (result_local, result_size) =
@@ -37,7 +39,9 @@ impl ComplexWord for Recover {
                 .module
                 .funcs
                 .by_name("stdlib.secp256k1_recover")
-                .expect("function not found"),
+                .ok_or(GeneratorError::InternalError(
+                    "stdlib.secp256k1_recover not found".to_owned(),
+                ))?,
         );
 
         generator.read_from_memory(builder, result_local, 0, &ret_ty);
@@ -71,7 +75,9 @@ impl ComplexWord for Verify {
                 .module
                 .funcs
                 .by_name("stdlib.secp256k1_verify")
-                .expect("function not found"),
+                .ok_or(GeneratorError::InternalError(
+                    "stdlib.secp256k1_verify not found".to_owned(),
+                ))?,
         );
 
         Ok(())

--- a/clar2wasm/src/words/secp256k1.rs
+++ b/clar2wasm/src/words/secp256k1.rs
@@ -24,9 +24,9 @@ impl ComplexWord for Recover {
         // Reserve stack space for the host-function to write the result
         let ret_ty = generator
             .get_expr_type(expr)
-            .ok_or(GeneratorError::TypeError(
-                "result of secp256k1-recover? should be typed".to_owned(),
-            ))?
+            .ok_or_else(|| {
+                GeneratorError::TypeError("result of secp256k1-recover? should be typed".to_owned())
+            })?
             .clone();
 
         let (result_local, result_size) =
@@ -39,9 +39,9 @@ impl ComplexWord for Recover {
                 .module
                 .funcs
                 .by_name("stdlib.secp256k1_recover")
-                .ok_or(GeneratorError::InternalError(
-                    "stdlib.secp256k1_recover not found".to_owned(),
-                ))?,
+                .ok_or_else(|| {
+                    GeneratorError::InternalError("stdlib.secp256k1_recover not found".to_owned())
+                })?,
         );
 
         generator.read_from_memory(builder, result_local, 0, &ret_ty);
@@ -75,9 +75,9 @@ impl ComplexWord for Verify {
                 .module
                 .funcs
                 .by_name("stdlib.secp256k1_verify")
-                .ok_or(GeneratorError::InternalError(
-                    "stdlib.secp256k1_verify not found".to_owned(),
-                ))?,
+                .ok_or_else(|| {
+                    GeneratorError::InternalError("stdlib.secp256k1_verify not found".to_owned())
+                })?,
         );
 
         Ok(())

--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -128,7 +128,7 @@ impl ComplexWord for Fold {
                 }
             },
             _ => {
-                return Err(GeneratorError::InternalError(
+                return Err(GeneratorError::TypeError(
                     "expected sequence type".to_string(),
                 ));
             }
@@ -279,7 +279,7 @@ impl ComplexWord for Append {
     ) -> Result<(), GeneratorError> {
         let ty = generator
             .get_expr_type(expr)
-            .ok_or(GeneratorError::InternalError(
+            .ok_or(GeneratorError::TypeError(
                 "append result must be typed".to_string(),
             ))?
             .clone();
@@ -320,7 +320,7 @@ impl ComplexWord for Append {
         // Get the type of the element that we're appending.
         let elem_ty = generator
             .get_expr_type(elem)
-            .ok_or(GeneratorError::InternalError(
+            .ok_or(GeneratorError::TypeError(
                 "append element must be typed".to_string(),
             ))?
             .clone();
@@ -371,7 +371,7 @@ impl ComplexWord for AsMaxLen {
         // Get the length.
         generator
             .get_expr_type(seq)
-            .ok_or_else(|| GeneratorError::InternalError("append result must be typed".to_string()))
+            .ok_or_else(|| GeneratorError::TypeError("append result must be typed".to_string()))
             .and_then(|ty| match ty {
                 TypeSignature::SequenceType(SequenceSubtype::ListType(list)) => {
                     // The length of the list in bytes is on the top of the stack. If we
@@ -403,7 +403,7 @@ impl ComplexWord for AsMaxLen {
                 | TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::ASCII(
                     _,
                 ))) => Ok(()),
-                _ => Err(GeneratorError::InternalError(
+                _ => Err(GeneratorError::TypeError(
                     "expected sequence type".to_string(),
                 )),
             })?;
@@ -565,7 +565,7 @@ impl ComplexWord for Map {
                     _,
                 ))) => (SequenceElementType::UnicodeScalar, 4),
                 _ => {
-                    return Err(GeneratorError::InternalError(
+                    return Err(GeneratorError::TypeError(
                         "expected sequence type".to_string(),
                     ));
                 }
@@ -758,7 +758,7 @@ impl ComplexWord for Len {
         // Get the length
         generator
             .get_expr_type(seq)
-            .ok_or_else(|| GeneratorError::InternalError("append result must be typed".to_string()))
+            .ok_or_else(|| GeneratorError::TypeError("append result must be typed".to_string()))
             .and_then(|ty| match ty {
                 TypeSignature::SequenceType(SequenceSubtype::ListType(list)) => {
                     // The length of the list in bytes is on the top of the stack. If we
@@ -788,7 +788,7 @@ impl ComplexWord for Len {
                 | TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::ASCII(
                     _,
                 ))) => Ok(()),
-                _ => Err(GeneratorError::InternalError(
+                _ => Err(GeneratorError::TypeError(
                     "expected sequence type".to_string(),
                 )),
             })?;
@@ -871,7 +871,7 @@ impl ComplexWord for ElementAt {
         // Record the element type, for use later.
         let element_ty: SequenceElementType = generator
             .get_expr_type(seq)
-            .ok_or_else(|| GeneratorError::InternalError("append result must be typed".to_string()))
+            .ok_or_else(|| GeneratorError::TypeError("append result must be typed".to_string()))
             .and_then(|ty| match ty {
                 TypeSignature::SequenceType(SequenceSubtype::ListType(list)) => {
                     // The length of the list in bytes is on the top of the stack. If we
@@ -904,7 +904,7 @@ impl ComplexWord for ElementAt {
 
                     Ok(SequenceElementType::UnicodeScalar)
                 }
-                _ => Err(GeneratorError::InternalError(
+                _ => Err(GeneratorError::TypeError(
                     "expected sequence type".to_string(),
                 )),
             })?;
@@ -924,7 +924,7 @@ impl ComplexWord for ElementAt {
         // If the index is out of range, then return `none`, else load the
         // value at the specified index and return `(some value)`.
         let result_ty = generator.get_expr_type(expr).ok_or_else(|| {
-            GeneratorError::InternalError("append result must be typed".to_string())
+            GeneratorError::TypeError("append result must be typed".to_string())
         })?;
         let result_wasm_types = clar2wasm_ty(result_ty);
         builder.if_else(
@@ -1010,7 +1010,7 @@ impl ComplexWord for ReplaceAt {
         let seq = args.get_expr(0)?;
         let seq_ty = generator
             .get_expr_type(seq)
-            .ok_or(GeneratorError::InternalError(
+            .ok_or(GeneratorError::TypeError(
                 "replace-at? result must be typed".to_string(),
             ))?
             .clone();
@@ -1090,7 +1090,7 @@ impl ComplexWord for ReplaceAt {
 
                 Ok(SequenceElementType::UnicodeScalar)
             }
-            _ => Err(GeneratorError::InternalError(
+            _ => Err(GeneratorError::TypeError(
                 "expected sequence type".to_string(),
             )),
         }?;
@@ -1113,7 +1113,7 @@ impl ComplexWord for ReplaceAt {
         generator.traverse_expr(builder, replacement)?;
 
         let input_ty = generator.get_expr_type(replacement).ok_or_else(|| {
-            GeneratorError::InternalError("replace-at? value must be typed".to_string())
+            GeneratorError::TypeError("replace-at? value must be typed".to_string())
         })?;
         let input_wasm_types = clar2wasm_ty(input_ty);
 
@@ -1123,7 +1123,7 @@ impl ComplexWord for ReplaceAt {
         // If the index is out of range, then return `none`, else write the
         // value at the specified index and return `(some value)`.
         let result_ty = generator.get_expr_type(expr).ok_or_else(|| {
-            GeneratorError::InternalError("append result must be typed".to_string())
+            GeneratorError::TypeError("append result must be typed".to_string())
         })?;
         let result_wasm_types = clar2wasm_ty(result_ty);
         builder.if_else(
@@ -1271,7 +1271,7 @@ impl ComplexWord for Slice {
 
         let seq_ty = generator
             .get_expr_type(seq)
-            .ok_or(GeneratorError::InternalError(
+            .ok_or(GeneratorError::TypeError(
                 "slice? sequence must be typed".to_string(),
             ))?
             .clone();
@@ -1305,7 +1305,7 @@ impl ComplexWord for Slice {
 
                 Ok(())
             }
-            _ => Err(GeneratorError::InternalError(
+            _ => Err(GeneratorError::TypeError(
                 "expected sequence type".to_string(),
             )),
         }?;
@@ -1375,7 +1375,7 @@ impl ComplexWord for Slice {
 
         let seq_ty = generator
             .get_expr_type(seq)
-            .ok_or(GeneratorError::InternalError(
+            .ok_or(GeneratorError::TypeError(
                 "slice? sequence must be typed".to_string(),
             ))?
             .clone();
@@ -1409,7 +1409,7 @@ impl ComplexWord for Slice {
 
                 Ok(())
             }
-            _ => Err(GeneratorError::InternalError(
+            _ => Err(GeneratorError::TypeError(
                 "expected sequence type".to_string(),
             )),
         }?;

--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -41,9 +41,7 @@ impl ComplexWord for ListCons {
     ) -> Result<(), GeneratorError> {
         let ty = generator
             .get_expr_type(expr)
-            .ok_or(GeneratorError::TypeError(
-                "list expression must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| GeneratorError::TypeError("list expression must be typed".to_owned()))?
             .clone();
         let (elem_ty, _num_elem) =
             if let TypeSignature::SequenceType(SequenceSubtype::ListType(list_type)) = &ty {
@@ -115,18 +113,18 @@ impl ComplexWord for Fold {
         // The result type must match the type of the initial value
         let result_clar_ty = generator
             .get_expr_type(initial)
-            .ok_or(GeneratorError::TypeError(
-                "fold's initial value expression must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| {
+                GeneratorError::TypeError(
+                    "fold's initial value expression must be typed".to_owned(),
+                )
+            })?
             .clone();
         let result_wasm_types = clar2wasm_ty(&result_clar_ty);
 
         // Get the type of the sequence
-        let elem_ty = match generator
-            .get_expr_type(sequence)
-            .ok_or(GeneratorError::TypeError(
-                "sequence expression must be typed".to_owned(),
-            ))? {
+        let elem_ty = match generator.get_expr_type(sequence).ok_or_else(|| {
+            GeneratorError::TypeError("sequence expression must be typed".to_owned())
+        })? {
             TypeSignature::SequenceType(seq_ty) => match &seq_ty {
                 SequenceSubtype::ListType(list_type) => Ok(SequenceElementType::Other(
                     list_type.get_list_item_type().clone(),
@@ -290,9 +288,7 @@ impl ComplexWord for Append {
     ) -> Result<(), GeneratorError> {
         let ty = generator
             .get_expr_type(expr)
-            .ok_or(GeneratorError::TypeError(
-                "append result must be typed".to_string(),
-            ))?
+            .ok_or_else(|| GeneratorError::TypeError("append result must be typed".to_string()))?
             .clone();
 
         let memory = generator.get_memory();
@@ -331,9 +327,7 @@ impl ComplexWord for Append {
         // Get the type of the element that we're appending.
         let elem_ty = generator
             .get_expr_type(elem)
-            .ok_or(GeneratorError::TypeError(
-                "append element must be typed".to_string(),
-            ))?
+            .ok_or_else(|| GeneratorError::TypeError("append element must be typed".to_string()))?
             .clone();
 
         // Store the element at the write pointer.
@@ -463,9 +457,7 @@ impl ComplexWord for Concat {
         // Create a new sequence to hold the result in the stack frame
         let ty = generator
             .get_expr_type(expr)
-            .ok_or(GeneratorError::TypeError(
-                "concat expression must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| GeneratorError::TypeError("concat expression must be typed".to_owned()))?
             .clone();
         let (offset, _) = generator.create_call_stack_local(builder, &ty, false, true);
         builder.local_get(offset);
@@ -528,9 +520,7 @@ impl ComplexWord for Map {
 
         let ty = generator
             .get_expr_type(expr)
-            .ok_or(GeneratorError::TypeError(
-                "list expression must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| GeneratorError::TypeError("list expression must be typed".to_owned()))?
             .clone();
 
         let return_element_type =
@@ -559,9 +549,9 @@ impl ComplexWord for Map {
 
             let (element_ty, element_size) = match generator
                 .get_expr_type(arg)
-                .ok_or(GeneratorError::TypeError(
-                    "sequence expression must be typed".to_owned(),
-                ))?
+                .ok_or_else(|| {
+                    GeneratorError::TypeError("sequence expression must be typed".to_owned())
+                })?
                 .clone()
             {
                 TypeSignature::SequenceType(SequenceSubtype::ListType(lt)) => {
@@ -1019,9 +1009,9 @@ impl ComplexWord for ReplaceAt {
         let seq = args.get_expr(0)?;
         let seq_ty = generator
             .get_expr_type(seq)
-            .ok_or(GeneratorError::TypeError(
-                "replace-at? result must be typed".to_string(),
-            ))?
+            .ok_or_else(|| {
+                GeneratorError::TypeError("replace-at? result must be typed".to_string())
+            })?
             .clone();
 
         // Create a new stack local for a copy of the input list
@@ -1280,9 +1270,7 @@ impl ComplexWord for Slice {
 
         let seq_ty = generator
             .get_expr_type(seq)
-            .ok_or(GeneratorError::TypeError(
-                "slice? sequence must be typed".to_string(),
-            ))?
+            .ok_or_else(|| GeneratorError::TypeError("slice? sequence must be typed".to_string()))?
             .clone();
 
         // Get the offset of the specified index.
@@ -1384,9 +1372,7 @@ impl ComplexWord for Slice {
 
         let seq_ty = generator
             .get_expr_type(seq)
-            .ok_or(GeneratorError::TypeError(
-                "slice? sequence must be typed".to_string(),
-            ))?
+            .ok_or_else(|| GeneratorError::TypeError("slice? sequence must be typed".to_string()))?
             .clone();
 
         // Get the offset of the specified index.

--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -923,9 +923,9 @@ impl ComplexWord for ElementAt {
 
         // If the index is out of range, then return `none`, else load the
         // value at the specified index and return `(some value)`.
-        let result_ty = generator.get_expr_type(expr).ok_or_else(|| {
-            GeneratorError::TypeError("append result must be typed".to_string())
-        })?;
+        let result_ty = generator
+            .get_expr_type(expr)
+            .ok_or_else(|| GeneratorError::TypeError("append result must be typed".to_string()))?;
         let result_wasm_types = clar2wasm_ty(result_ty);
         builder.if_else(
             InstrSeqType::new(
@@ -1122,9 +1122,9 @@ impl ComplexWord for ReplaceAt {
 
         // If the index is out of range, then return `none`, else write the
         // value at the specified index and return `(some value)`.
-        let result_ty = generator.get_expr_type(expr).ok_or_else(|| {
-            GeneratorError::TypeError("append result must be typed".to_string())
-        })?;
+        let result_ty = generator
+            .get_expr_type(expr)
+            .ok_or_else(|| GeneratorError::TypeError("append result must be typed".to_string()))?;
         let result_wasm_types = clar2wasm_ty(result_ty);
         builder.if_else(
             InstrSeqType::new(

--- a/clar2wasm/src/words/tokens.rs
+++ b/clar2wasm/src/words/tokens.rs
@@ -243,9 +243,15 @@ impl ComplexWord for DefineNonFungibleToken {
             .i32_const(name_offset as i32)
             .i32_const(name_length as i32);
 
-        builder.call(generator.module.funcs.by_name("stdlib.define_nft").ok_or(
-            GeneratorError::InternalError("stdlib.define_nft not found".to_owned()),
-        )?);
+        builder.call(
+            generator
+                .module
+                .funcs
+                .by_name("stdlib.define_nft")
+                .ok_or_else(|| {
+                    GeneratorError::InternalError("stdlib.define_nft not found".to_owned())
+                })?,
+        );
         Ok(())
     }
 }
@@ -280,9 +286,7 @@ impl ComplexWord for BurnNonFungibleToken {
 
         let identifier_ty = generator
             .get_expr_type(identifier)
-            .ok_or(GeneratorError::TypeError(
-                "NFT identifier must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| GeneratorError::TypeError("NFT identifier must be typed".to_owned()))?
             .clone();
 
         // Allocate space on the stack for the identifier
@@ -336,9 +340,7 @@ impl ComplexWord for TransferNonFungibleToken {
 
         let identifier_ty = generator
             .get_expr_type(identifier)
-            .ok_or(GeneratorError::TypeError(
-                "NFT identifier must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| GeneratorError::TypeError("NFT identifier must be typed".to_owned()))?
             .clone();
 
         // Allocate space on the stack for the identifier
@@ -394,9 +396,7 @@ impl ComplexWord for MintNonFungibleToken {
 
         let identifier_ty = generator
             .get_expr_type(identifier)
-            .ok_or(GeneratorError::TypeError(
-                "NFT identifier must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| GeneratorError::TypeError("NFT identifier must be typed".to_owned()))?
             .clone();
 
         // Allocate space on the stack for the identifier
@@ -448,9 +448,7 @@ impl ComplexWord for GetOwnerOfNonFungibleToken {
 
         let identifier_ty = generator
             .get_expr_type(identifier)
-            .ok_or(GeneratorError::TypeError(
-                "NFT identifier must be typed".to_owned(),
-            ))?
+            .ok_or_else(|| GeneratorError::TypeError("NFT identifier must be typed".to_owned()))?
             .clone();
 
         // Allocate space on the stack for the identifier

--- a/clar2wasm/src/words/tokens.rs
+++ b/clar2wasm/src/words/tokens.rs
@@ -243,13 +243,9 @@ impl ComplexWord for DefineNonFungibleToken {
             .i32_const(name_offset as i32)
             .i32_const(name_length as i32);
 
-        builder.call(
-            generator
-                .module
-                .funcs
-                .by_name("stdlib.define_nft")
-                .expect("function not found"),
-        );
+        builder.call(generator.module.funcs.by_name("stdlib.define_nft").ok_or(
+            GeneratorError::InternalError("stdlib.define_nft not found".to_owned()),
+        )?);
         Ok(())
     }
 }
@@ -284,7 +280,9 @@ impl ComplexWord for BurnNonFungibleToken {
 
         let identifier_ty = generator
             .get_expr_type(identifier)
-            .expect("NFT identifier must be typed")
+            .ok_or(GeneratorError::TypeError(
+                "NFT identifier must be typed".to_owned(),
+            ))?
             .clone();
 
         // Allocate space on the stack for the identifier
@@ -338,7 +336,9 @@ impl ComplexWord for TransferNonFungibleToken {
 
         let identifier_ty = generator
             .get_expr_type(identifier)
-            .expect("NFT identifier must be typed")
+            .ok_or(GeneratorError::TypeError(
+                "NFT identifier must be typed".to_owned(),
+            ))?
             .clone();
 
         // Allocate space on the stack for the identifier
@@ -394,7 +394,9 @@ impl ComplexWord for MintNonFungibleToken {
 
         let identifier_ty = generator
             .get_expr_type(identifier)
-            .expect("NFT identifier must be typed")
+            .ok_or(GeneratorError::TypeError(
+                "NFT identifier must be typed".to_owned(),
+            ))?
             .clone();
 
         // Allocate space on the stack for the identifier
@@ -446,7 +448,9 @@ impl ComplexWord for GetOwnerOfNonFungibleToken {
 
         let identifier_ty = generator
             .get_expr_type(identifier)
-            .expect("NFT identifier must be typed")
+            .ok_or(GeneratorError::TypeError(
+                "NFT identifier must be typed".to_owned(),
+            ))?
             .clone();
 
         // Allocate space on the stack for the identifier

--- a/clar2wasm/src/words/traits.rs
+++ b/clar2wasm/src/words/traits.rs
@@ -33,7 +33,9 @@ impl ComplexWord for DefineTrait {
                 .module
                 .funcs
                 .by_name("stdlib.define_trait")
-                .expect("function not found"),
+                .ok_or(GeneratorError::InternalError(
+                    "stdlib.define_trait not found".to_owned(),
+                ))?,
         );
         Ok(())
     }
@@ -92,13 +94,9 @@ impl ComplexWord for ImplTrait {
             .i32_const(trait_offset as i32)
             .i32_const(trait_length as i32);
 
-        builder.call(
-            generator
-                .module
-                .funcs
-                .by_name("stdlib.impl_trait")
-                .expect("function not found"),
-        );
+        builder.call(generator.module.funcs.by_name("stdlib.impl_trait").ok_or(
+            GeneratorError::InternalError("stdlib.impl_trait not found".to_owned()),
+        )?);
         Ok(())
     }
 }

--- a/clar2wasm/src/words/traits.rs
+++ b/clar2wasm/src/words/traits.rs
@@ -33,9 +33,9 @@ impl ComplexWord for DefineTrait {
                 .module
                 .funcs
                 .by_name("stdlib.define_trait")
-                .ok_or(GeneratorError::InternalError(
-                    "stdlib.define_trait not found".to_owned(),
-                ))?,
+                .ok_or_else(|| {
+                    GeneratorError::InternalError("stdlib.define_trait not found".to_owned())
+                })?,
         );
         Ok(())
     }
@@ -94,9 +94,15 @@ impl ComplexWord for ImplTrait {
             .i32_const(trait_offset as i32)
             .i32_const(trait_length as i32);
 
-        builder.call(generator.module.funcs.by_name("stdlib.impl_trait").ok_or(
-            GeneratorError::InternalError("stdlib.impl_trait not found".to_owned()),
-        )?);
+        builder.call(
+            generator
+                .module
+                .funcs
+                .by_name("stdlib.impl_trait")
+                .ok_or_else(|| {
+                    GeneratorError::InternalError("stdlib.impl_trait not found".to_owned())
+                })?,
+        );
         Ok(())
     }
 }

--- a/clar2wasm/src/words/tuples.rs
+++ b/clar2wasm/src/words/tuples.rs
@@ -23,7 +23,7 @@ impl ComplexWord for TupleCons {
     ) -> Result<(), GeneratorError> {
         let ty = generator
             .get_expr_type(expr)
-            .ok_or(GeneratorError::InternalError(
+            .ok_or(GeneratorError::TypeError(
                 "tuple expression must be typed".to_string(),
             ))?
             .clone();
@@ -31,7 +31,7 @@ impl ComplexWord for TupleCons {
         let tuple_ty = match ty {
             TypeSignature::TupleType(tuple) => tuple,
             _ => {
-                return Err(GeneratorError::InternalError(
+                return Err(GeneratorError::TypeError(
                     "expected tuple type".to_string(),
                 ))
             }
@@ -108,11 +108,11 @@ impl ComplexWord for TupleGet {
         let tuple_ty = generator
             .get_expr_type(&args[1])
             .ok_or_else(|| {
-                GeneratorError::InternalError("tuple expression must be typed".to_string())
+                GeneratorError::TypeError("tuple expression must be typed".to_string())
             })
             .and_then(|lhs_ty| match lhs_ty {
                 TypeSignature::TupleType(tuple) => Ok(tuple),
-                _ => Err(GeneratorError::InternalError(
+                _ => Err(GeneratorError::TypeError(
                     "expected tuple type".to_string(),
                 )),
             })?
@@ -182,11 +182,11 @@ impl ComplexWord for TupleMerge {
         let lhs_tuple_ty = generator
             .get_expr_type(&args[0])
             .ok_or_else(|| {
-                GeneratorError::InternalError("tuple expression must be typed".to_string())
+                GeneratorError::TypeError("tuple expression must be typed".to_string())
             })
             .and_then(|lhs_ty| match lhs_ty {
                 TypeSignature::TupleType(tuple) => Ok(tuple),
-                _ => Err(GeneratorError::InternalError(
+                _ => Err(GeneratorError::TypeError(
                     "expected tuple type".to_string(),
                 )),
             })?
@@ -195,11 +195,11 @@ impl ComplexWord for TupleMerge {
         let rhs_tuple_ty = generator
             .get_expr_type(&args[1])
             .ok_or_else(|| {
-                GeneratorError::InternalError("tuple expression must be typed".to_string())
+                GeneratorError::TypeError("tuple expression must be typed".to_string())
             })
             .and_then(|lhs_ty| match lhs_ty {
                 TypeSignature::TupleType(tuple) => Ok(tuple),
-                _ => Err(GeneratorError::InternalError(
+                _ => Err(GeneratorError::TypeError(
                     "expected tuple type".to_string(),
                 )),
             })?

--- a/clar2wasm/src/words/tuples.rs
+++ b/clar2wasm/src/words/tuples.rs
@@ -30,11 +30,7 @@ impl ComplexWord for TupleCons {
 
         let tuple_ty = match ty {
             TypeSignature::TupleType(tuple) => tuple,
-            _ => {
-                return Err(GeneratorError::TypeError(
-                    "expected tuple type".to_string(),
-                ))
-            }
+            _ => return Err(GeneratorError::TypeError("expected tuple type".to_string())),
         };
 
         // The args for `tuple` should be pairs of values, with the first value
@@ -107,14 +103,10 @@ impl ComplexWord for TupleGet {
 
         let tuple_ty = generator
             .get_expr_type(&args[1])
-            .ok_or_else(|| {
-                GeneratorError::TypeError("tuple expression must be typed".to_string())
-            })
+            .ok_or_else(|| GeneratorError::TypeError("tuple expression must be typed".to_string()))
             .and_then(|lhs_ty| match lhs_ty {
                 TypeSignature::TupleType(tuple) => Ok(tuple),
-                _ => Err(GeneratorError::TypeError(
-                    "expected tuple type".to_string(),
-                )),
+                _ => Err(GeneratorError::TypeError("expected tuple type".to_string())),
             })?
             .clone();
 
@@ -181,27 +173,19 @@ impl ComplexWord for TupleMerge {
 
         let lhs_tuple_ty = generator
             .get_expr_type(&args[0])
-            .ok_or_else(|| {
-                GeneratorError::TypeError("tuple expression must be typed".to_string())
-            })
+            .ok_or_else(|| GeneratorError::TypeError("tuple expression must be typed".to_string()))
             .and_then(|lhs_ty| match lhs_ty {
                 TypeSignature::TupleType(tuple) => Ok(tuple),
-                _ => Err(GeneratorError::TypeError(
-                    "expected tuple type".to_string(),
-                )),
+                _ => Err(GeneratorError::TypeError("expected tuple type".to_string())),
             })?
             .clone();
 
         let rhs_tuple_ty = generator
             .get_expr_type(&args[1])
-            .ok_or_else(|| {
-                GeneratorError::TypeError("tuple expression must be typed".to_string())
-            })
+            .ok_or_else(|| GeneratorError::TypeError("tuple expression must be typed".to_string()))
             .and_then(|lhs_ty| match lhs_ty {
                 TypeSignature::TupleType(tuple) => Ok(tuple),
-                _ => Err(GeneratorError::TypeError(
-                    "expected tuple type".to_string(),
-                )),
+                _ => Err(GeneratorError::TypeError("expected tuple type".to_string())),
             })?
             .clone();
 


### PR DESCRIPTION
This PR replaces panics with proper error handling and propagation. Some of the `datastore.rs` methods are left because they're only being used in `TestEnvironment`