### PR TITLE
fix: zero length utf8 bytes in `from-consensus-buff`

### DIFF
--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -3286,7 +3286,15 @@
         (local $byte4 i32)
         (local $scalar i32)     ;; Scalar value
 
-        (call $log (i64.extend_i32_u (local.get $length)))
+        ;; If the length is 0, just return 0
+        (if (i32.eqz (local.get $length))
+            (then
+                (return 
+                    (i32.const 0) ;; length (0 bytes)
+                    (i32.const 1) ;; success status (1 = success)
+                )
+            )
+        )
 
         ;; Initialize loop counters
         (local.set $i (i32.const 0))

--- a/clar2wasm/src/words/consensus_buff.rs
+++ b/clar2wasm/src/words/consensus_buff.rs
@@ -285,6 +285,19 @@ mod tests {
     }
 
     #[test]
+    fn to_consensus_buff_string_utf8_empty() {
+        assert_eq!(
+            evaluate(r#"(to-consensus-buff? u"")"#),
+            Some(
+                Value::some(Value::Sequence(SequenceData::Buffer(BuffData {
+                    data: Vec::from_hex("0e00000000").unwrap()
+                })))
+                .unwrap()
+            )
+        );
+    }
+
+    #[test]
     fn to_consensus_buff_string_ascii() {
         assert_eq!(
             evaluate(r#"(to-consensus-buff? "Hello, World!")"#),
@@ -742,6 +755,14 @@ mod tests {
                 Value::some(Value::string_utf8_from_bytes("helŁo world 愛🦊".into()).unwrap())
                     .unwrap()
             )
+        );
+    }
+
+    #[test]
+    fn from_consensus_buff_string_utf8_empty() {
+        assert_eq!(
+            evaluate(r#"(from-consensus-buff? (string-utf8 20) 0x0e00000000)"#),
+            Some(Value::some(Value::string_utf8_from_bytes("".into()).unwrap()).unwrap())
         );
     }
 


### PR DESCRIPTION
Fix missing zero-length buffer handling for utf8 in `from-consensus-buff`