### PR TITLE
Add debug symbols to bench profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,6 @@
 members = ["clar2wasm", "tests"]
 exclude = ["stacks-core"]
 resolver = "2"
+
+[profile.bench]
+debug = true


### PR DESCRIPTION
With Cargo, the default *bench* profile inherits from the *release* profile, which doesn't generate all the debug info.

This PR adds the debug info to bench profiles, so that generated flamegraphs can be more accurate and complete.