### PR TITLE
Property test framework improvement: testing against the interpreter

### DIFF
--- a/clar2wasm/tests/wasm-generation/default_to.rs
+++ b/clar2wasm/tests/wasm-generation/default_to.rs
@@ -1,15 +1,11 @@
-use clar2wasm::tools::evaluate;
 use proptest::{prop_compose, proptest};
 
-use crate::{prop_signature, PropValue};
+use crate::{check_against_interpreter, prop_signature, PropValue};
 
 proptest! {
     #[test]
     fn default_to_with_none_is_always_default(val in PropValue::any()) {
-        assert_eq!(
-            evaluate(&format!(r#"(default-to {val} none)"#)),
-            Ok(Some(val.into()))
-        )
+        check_against_interpreter(&format!(r#"(default-to {val} none)"#), Some(val.into()));
     }
 }
 
@@ -25,9 +21,9 @@ prop_compose! {
 proptest! {
     #[test]
     fn default_to_with_some_is_always_value((default, value) in default_and_value_of_same_type()) {
-        assert_eq!(
-            evaluate(&format!(r#"(default-to {default} (some {value}))"#)),
-            Ok(Some(value.into()))
-        )
+        check_against_interpreter(
+            &format!(r#"(default-to {default} (some {value}))"#),
+            Some(value.into())
+        );
     }
 }

--- a/clar2wasm/tests/wasm-generation/default_to.rs
+++ b/clar2wasm/tests/wasm-generation/default_to.rs
@@ -1,11 +1,12 @@
+use clar2wasm::tools::crosscheck;
 use proptest::{prop_compose, proptest};
 
-use crate::{check_against_interpreter, prop_signature, PropValue};
+use crate::{prop_signature, PropValue};
 
 proptest! {
     #[test]
     fn default_to_with_none_is_always_default(val in PropValue::any()) {
-        check_against_interpreter(&format!(r#"(default-to {val} none)"#), Some(val.into()));
+        crosscheck(&format!(r#"(default-to {val} none)"#), Ok(Some(val.into())));
     }
 }
 
@@ -21,9 +22,9 @@ prop_compose! {
 proptest! {
     #[test]
     fn default_to_with_some_is_always_value((default, value) in default_and_value_of_same_type()) {
-        check_against_interpreter(
+        crosscheck(
             &format!(r#"(default-to {default} (some {value}))"#),
-            Some(value.into())
+            Ok(Some(value.into()))
         );
     }
 }

--- a/clar2wasm/tests/wasm-generation/equal.rs
+++ b/clar2wasm/tests/wasm-generation/equal.rs
@@ -1,13 +1,14 @@
+use clar2wasm::tools::crosscheck;
 use proptest::proptest;
 
-use crate::{check_against_interpreter, PropValue};
+use crate::PropValue;
 
 proptest! {
     #[test]
     fn is_eq_one_argument_always_true(val in PropValue::any()) {
-        check_against_interpreter(
+        crosscheck(
             &format!(r#"(is-eq {val})"#),
-            Some(clarity::vm::Value::Bool(true))
+            Ok(Some(clarity::vm::Value::Bool(true)))
         );
     }
 }
@@ -15,9 +16,9 @@ proptest! {
 proptest! {
     #[test]
     fn is_eq_value_with_itself_always_true(val in PropValue::any()) {
-        check_against_interpreter(
+        crosscheck(
             &format!(r#"(is-eq {val} {val})"#),
-            Some(clarity::vm::Value::Bool(true))
+            Ok(Some(clarity::vm::Value::Bool(true)))
         );
     }
 }
@@ -25,9 +26,9 @@ proptest! {
 proptest! {
     #[test]
     fn is_eq_value_with_itself_always_true_3(val in PropValue::any()) {
-        check_against_interpreter(
+        crosscheck(
             &format!(r#"(is-eq {val} {val} {val})"#),
-            Some(clarity::vm::Value::Bool(true))
+            Ok(Some(clarity::vm::Value::Bool(true)))
         );
     }
 }

--- a/clar2wasm/tests/wasm-generation/equal.rs
+++ b/clar2wasm/tests/wasm-generation/equal.rs
@@ -1,33 +1,33 @@
-use clar2wasm::tools::evaluate;
 use proptest::proptest;
 
-use crate::PropValue;
+use crate::{check_against_interpreter, PropValue};
 
 proptest! {
     #[test]
     fn is_eq_one_argument_always_true(val in PropValue::any()) {
-        assert_eq!(
-            evaluate(&format!(r#"(is-eq {val})"#)).unwrap(),
+        check_against_interpreter(
+            &format!(r#"(is-eq {val})"#),
             Some(clarity::vm::Value::Bool(true))
-        )
+        );
     }
 }
+
 proptest! {
     #[test]
     fn is_eq_value_with_itself_always_true(val in PropValue::any()) {
-        assert_eq!(
-            evaluate(&format!(r#"(is-eq {val} {val})"#)).unwrap(),
+        check_against_interpreter(
+            &format!(r#"(is-eq {val} {val})"#),
             Some(clarity::vm::Value::Bool(true))
-        )
+        );
     }
 }
 
 proptest! {
     #[test]
     fn is_eq_value_with_itself_always_true_3(val in PropValue::any()) {
-        assert_eq!(
-            evaluate(&format!(r#"(is-eq {val} {val} {val})"#)).unwrap(),
+        check_against_interpreter(
+            &format!(r#"(is-eq {val} {val} {val})"#),
             Some(clarity::vm::Value::Bool(true))
-        )
+        );
     }
 }

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -5,7 +5,6 @@ pub mod regression;
 pub mod response;
 pub mod values;
 
-use clar2wasm::tools::crosscheck;
 use clarity::vm::types::{
     ASCIIData, BuffData, CharType, ListData, ListTypeData, OptionalData, ResponseData,
     SequenceData, SequenceSubtype, StringSubtype, StringUTF8Length, TupleData, TupleTypeSignature,
@@ -52,10 +51,6 @@ pub fn prop_signature() -> impl Strategy<Value = TypeSignature> {
             (8u32..32, inner.clone()).prop_map(|(s, ty)| (ListTypeData::new_list(ty, s).unwrap()).into()),
         ]
     })
-}
-
-pub fn check_against_interpreter(snippet: &str, expected: Option<Value>) {
-    crosscheck(snippet, Ok(expected));
 }
 
 pub struct PropValue(Value);

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -5,6 +5,7 @@ pub mod regression;
 pub mod response;
 pub mod values;
 
+use clar2wasm::tools::crosscheck;
 use clarity::vm::types::{
     ASCIIData, BuffData, CharType, ListData, ListTypeData, OptionalData, ResponseData,
     SequenceData, SequenceSubtype, StringSubtype, StringUTF8Length, TupleData, TupleTypeSignature,
@@ -51,6 +52,10 @@ pub fn prop_signature() -> impl Strategy<Value = TypeSignature> {
             (8u32..32, inner.clone()).prop_map(|(s, ty)| (ListTypeData::new_list(ty, s).unwrap()).into()),
         ]
     })
+}
+
+pub fn check_against_interpreter(snippet: &str, expected: Option<Value>) {
+    crosscheck(snippet, Ok(expected));
 }
 
 pub struct PropValue(Value);

--- a/clar2wasm/tests/wasm-generation/optional.rs
+++ b/clar2wasm/tests/wasm-generation/optional.rs
@@ -1,13 +1,14 @@
+use clar2wasm::tools::crosscheck;
 use proptest::proptest;
 
-use crate::{check_against_interpreter, PropValue};
+use crate::PropValue;
 
 proptest! {
     #[test]
     fn is_some_always_true(val in PropValue::any()) {
-        check_against_interpreter(
+        crosscheck(
             &format!(r#"(is-some (some {val}))"#),
-            Some(clarity::vm::Value::Bool(true))
+            Ok(Some(clarity::vm::Value::Bool(true)))
         );
     }
 }
@@ -15,9 +16,9 @@ proptest! {
 proptest! {
     #[test]
     fn is_none_always_false(val in PropValue::any()) {
-        check_against_interpreter(
+        crosscheck(
             &format!(r#"(is-none (some {val}))"#),
-            Some(clarity::vm::Value::Bool(false))
+            Ok(Some(clarity::vm::Value::Bool(false)))
         );
     }
 }

--- a/clar2wasm/tests/wasm-generation/optional.rs
+++ b/clar2wasm/tests/wasm-generation/optional.rs
@@ -1,24 +1,23 @@
-use clar2wasm::tools::evaluate;
 use proptest::proptest;
 
-use crate::PropValue;
+use crate::{check_against_interpreter, PropValue};
 
 proptest! {
     #[test]
     fn is_some_always_true(val in PropValue::any()) {
-        assert_eq!(
-            evaluate(&format!(r#"(is-some (some {val}))"#)),
-            Ok(Some(clarity::vm::Value::Bool(true)))
-        )
+        check_against_interpreter(
+            &format!(r#"(is-some (some {val}))"#),
+            Some(clarity::vm::Value::Bool(true))
+        );
     }
 }
 
 proptest! {
     #[test]
     fn is_none_always_false(val in PropValue::any()) {
-        assert_eq!(
-            evaluate(&format!(r#"(is-none (some {val}))"#)),
-            Ok(Some(clarity::vm::Value::Bool(false)))
-        )
+        check_against_interpreter(
+            &format!(r#"(is-none (some {val}))"#),
+            Some(clarity::vm::Value::Bool(false))
+        );
     }
 }

--- a/clar2wasm/tests/wasm-generation/regression.rs
+++ b/clar2wasm/tests/wasm-generation/regression.rs
@@ -1,12 +1,12 @@
 /// This files purpose is to add examples of generated values that failed,
 /// so that we can be sure they won't fail again after some random refactor
 /// in the future.
-use clar2wasm::tools::evaluate;
+use clar2wasm::tools::{crosscheck, evaluate};
 use clarity::vm::types::{ListData, ListTypeData, ResponseData, SequenceData, TypeSignature};
 use clarity::vm::Value;
 use hex::FromHex as _;
 
-use crate::{check_against_interpreter, PropValue};
+use crate::PropValue;
 
 fn evaluate_expression(expr: &str) {
     let v: PropValue = evaluate(expr)
@@ -39,9 +39,9 @@ fn list_some_response() {
 
 #[test]
 fn to_consensus_buff_1() {
-    check_against_interpreter(
+    crosscheck(
         "(to-consensus-buff? (err {a: 1}))",
-        Some(
+        Ok(Some(
             Value::some(
                 Value::buff_from(
                     Vec::from_hex("080c0000000101610000000000000000000000000000000001").unwrap(),
@@ -49,34 +49,34 @@ fn to_consensus_buff_1() {
                 .unwrap(),
             )
             .unwrap(),
-        ),
+        )),
     );
 }
 
 #[test]
 fn is_eq_list_opt_resp() {
     let l = "(list none (some (ok 1)))";
-    check_against_interpreter(&format!(r#"(is-eq {l} {l})"#), Some(Value::Bool(true)));
+    crosscheck(&format!(r#"(is-eq {l} {l})"#), Ok(Some(Value::Bool(true))));
 }
 
 #[test]
 fn default_to() {
-    check_against_interpreter(
+    crosscheck(
         "(default-to (list 100) (some (list 1 2 3)))",
-        Some(Value::Sequence(SequenceData::List(ListData {
+        Ok(Some(Value::Sequence(SequenceData::List(ListData {
             data: vec![Value::Int(1), Value::Int(2), Value::Int(3)],
             type_signature: ListTypeData::new_list(TypeSignature::IntType, 3).unwrap(),
-        }))),
+        })))),
     );
 }
 
 #[test]
 fn default_to_2() {
-    check_against_interpreter(
+    crosscheck(
         "(default-to (err -8865319038999812741356205373046857778) (some (ok 94740629357611018681632671610045749418)))",
-        Some(Value::Response(ResponseData{
+        Ok(Some(Value::Response(ResponseData{
             committed: true,
             data: Box::new(Value::Int(94740629357611018681632671610045749418))
-        }))
+        })))
     );
 }

--- a/clar2wasm/tests/wasm-generation/regression.rs
+++ b/clar2wasm/tests/wasm-generation/regression.rs
@@ -2,11 +2,11 @@
 /// so that we can be sure they won't fail again after some random refactor
 /// in the future.
 use clar2wasm::tools::evaluate;
-use clarity::vm::types::ResponseData;
+use clarity::vm::types::{ListData, ListTypeData, ResponseData, SequenceData, TypeSignature};
 use clarity::vm::Value;
 use hex::FromHex as _;
 
-use crate::PropValue;
+use crate::{check_against_interpreter, PropValue};
 
 fn evaluate_expression(expr: &str) {
     let v: PropValue = evaluate(expr)
@@ -39,44 +39,44 @@ fn list_some_response() {
 
 #[test]
 fn to_consensus_buff_1() {
-    assert_eq!(
-        evaluate(r#"(to-consensus-buff? (err {a: 1}))"#),
-        Ok(Some(
+    check_against_interpreter(
+        "(to-consensus-buff? (err {a: 1}))",
+        Some(
             Value::some(
                 Value::buff_from(
-                    Vec::from_hex("080c0000000101610000000000000000000000000000000001").unwrap()
+                    Vec::from_hex("080c0000000101610000000000000000000000000000000001").unwrap(),
                 )
-                .unwrap()
+                .unwrap(),
             )
-            .unwrap()
-        ))
+            .unwrap(),
+        ),
     );
 }
 
 #[test]
 fn is_eq_list_opt_resp() {
     let l = "(list none (some (ok 1)))";
-    assert_eq!(
-        evaluate(&format!(r#"(is-eq {l} {l})"#)),
-        Ok(Some(Value::Bool(true)))
-    );
+    check_against_interpreter(&format!(r#"(is-eq {l} {l})"#), Some(Value::Bool(true)));
 }
 
 #[test]
 fn default_to() {
-    assert_eq!(
-        evaluate("(default-to (list 100) (some (list 1 2 3)))"),
-        evaluate("(list 1 2 3)")
+    check_against_interpreter(
+        "(default-to (list 100) (some (list 1 2 3)))",
+        Some(Value::Sequence(SequenceData::List(ListData {
+            data: vec![Value::Int(1), Value::Int(2), Value::Int(3)],
+            type_signature: ListTypeData::new_list(TypeSignature::IntType, 3).unwrap(),
+        }))),
     );
 }
 
 #[test]
 fn default_to_2() {
-    assert_eq!(
-        evaluate("(default-to (err -8865319038999812741356205373046857778) (some (ok 94740629357611018681632671610045749418)))"),
-        Ok(Some(Value::Response(ResponseData{
+    check_against_interpreter(
+        "(default-to (err -8865319038999812741356205373046857778) (some (ok 94740629357611018681632671610045749418)))",
+        Some(Value::Response(ResponseData{
             committed: true,
             data: Box::new(Value::Int(94740629357611018681632671610045749418))
-        })))
+        }))
     );
 }

--- a/clar2wasm/tests/wasm-generation/response.rs
+++ b/clar2wasm/tests/wasm-generation/response.rs
@@ -1,14 +1,13 @@
-use clar2wasm::tools::evaluate;
 use proptest::proptest;
 
-use crate::PropValue;
+use crate::{check_against_interpreter, PropValue};
 
 proptest! {
     #[test]
     fn is_ok_always_true(val in PropValue::any()) {
-        assert_eq!(
-            evaluate(&format!(r#"(is-ok (ok {val}))"#)),
-            Ok(Some(clarity::vm::Value::Bool(true)))
+        check_against_interpreter(
+            &format!(r#"(is-ok (ok {val}))"#),
+            Some(clarity::vm::Value::Bool(true))
         )
     }
 }
@@ -16,9 +15,9 @@ proptest! {
 proptest! {
     #[test]
     fn is_ok_always_false(val in PropValue::any()) {
-        assert_eq!(
-            evaluate(&format!(r#"(is-ok (err {val}))"#)),
-            Ok(Some(clarity::vm::Value::Bool(false)))
+        check_against_interpreter(
+            &format!(r#"(is-ok (err {val}))"#),
+            Some(clarity::vm::Value::Bool(false))
         )
     }
 }
@@ -26,9 +25,9 @@ proptest! {
 proptest! {
     #[test]
     fn is_err_always_true(val in PropValue::any()) {
-        assert_eq!(
-            evaluate(&format!(r#"(is-err (err {val}))"#)),
-            Ok(Some(clarity::vm::Value::Bool(true)))
+        check_against_interpreter(
+            &format!(r#"(is-err (err {val}))"#),
+            Some(clarity::vm::Value::Bool(true))
         )
     }
 }
@@ -36,9 +35,9 @@ proptest! {
 proptest! {
     #[test]
     fn is_err_always_false(val in PropValue::any()) {
-        assert_eq!(
-            evaluate(&format!(r#"(is-err (ok {val}))"#)),
-            Ok(Some(clarity::vm::Value::Bool(false)))
+        check_against_interpreter(
+            &format!(r#"(is-err (ok {val}))"#),
+            Some(clarity::vm::Value::Bool(false))
         )
     }
 }

--- a/clar2wasm/tests/wasm-generation/response.rs
+++ b/clar2wasm/tests/wasm-generation/response.rs
@@ -1,13 +1,14 @@
+use clar2wasm::tools::crosscheck;
 use proptest::proptest;
 
-use crate::{check_against_interpreter, PropValue};
+use crate::PropValue;
 
 proptest! {
     #[test]
     fn is_ok_always_true(val in PropValue::any()) {
-        check_against_interpreter(
+        crosscheck(
             &format!(r#"(is-ok (ok {val}))"#),
-            Some(clarity::vm::Value::Bool(true))
+            Ok(Some(clarity::vm::Value::Bool(true)))
         )
     }
 }
@@ -15,9 +16,9 @@ proptest! {
 proptest! {
     #[test]
     fn is_ok_always_false(val in PropValue::any()) {
-        check_against_interpreter(
+        crosscheck(
             &format!(r#"(is-ok (err {val}))"#),
-            Some(clarity::vm::Value::Bool(false))
+            Ok(Some(clarity::vm::Value::Bool(false)))
         )
     }
 }
@@ -25,9 +26,9 @@ proptest! {
 proptest! {
     #[test]
     fn is_err_always_true(val in PropValue::any()) {
-        check_against_interpreter(
+        crosscheck(
             &format!(r#"(is-err (err {val}))"#),
-            Some(clarity::vm::Value::Bool(true))
+            Ok(Some(clarity::vm::Value::Bool(true)))
         )
     }
 }
@@ -35,9 +36,9 @@ proptest! {
 proptest! {
     #[test]
     fn is_err_always_false(val in PropValue::any()) {
-        check_against_interpreter(
+        crosscheck(
             &format!(r#"(is-err (ok {val}))"#),
-            Some(clarity::vm::Value::Bool(false))
+            Ok(Some(clarity::vm::Value::Bool(false)))
         )
     }
 }

--- a/clar2wasm/tests/wasm-generation/values.rs
+++ b/clar2wasm/tests/wasm-generation/values.rs
@@ -1,10 +1,10 @@
-use clar2wasm::tools::{evaluate, TestEnvironment};
+use clar2wasm::tools::TestEnvironment;
 use clarity::vm::Value;
 use proptest::prelude::ProptestConfig;
 use proptest::proptest;
 use proptest::strategy::Strategy;
 
-use crate::{PropValue, TypePrinter};
+use crate::{check_against_interpreter, PropValue, TypePrinter};
 
 proptest! {
     #![proptest_config(ProptestConfig {
@@ -13,8 +13,8 @@ proptest! {
     })]
     #[test]
     fn evaluated_value_is_the_value_itself(val in PropValue::any()) {
-        assert_eq!(
-            evaluate(&val.to_string()).unwrap(),
+        check_against_interpreter(
+            &val.to_string(),
             Some(val.into())
         )
     }
@@ -24,9 +24,9 @@ proptest! {
         let mut env = TestEnvironment::default();
         env.evaluate(&format!("(to-consensus-buff? {val})")).is_ok()
     })) {
-        assert_eq!(
-            evaluate(&format!("(from-consensus-buff? {} (unwrap-panic (to-consensus-buff? {})))", val.type_string() ,val)),
-            Ok(Some(Value::some(val.into()).unwrap()))
+        check_against_interpreter(
+            &format!("(from-consensus-buff? {} (unwrap-panic (to-consensus-buff? {})))", val.type_string() ,val),
+            Some(Value::some(val.into()).unwrap())
         )
     }
 }

--- a/clar2wasm/tests/wasm-generation/values.rs
+++ b/clar2wasm/tests/wasm-generation/values.rs
@@ -1,10 +1,10 @@
-use clar2wasm::tools::TestEnvironment;
+use clar2wasm::tools::{crosscheck, TestEnvironment};
 use clarity::vm::Value;
 use proptest::prelude::ProptestConfig;
 use proptest::proptest;
 use proptest::strategy::Strategy;
 
-use crate::{check_against_interpreter, PropValue, TypePrinter};
+use crate::{PropValue, TypePrinter};
 
 proptest! {
     #![proptest_config(ProptestConfig {
@@ -13,9 +13,9 @@ proptest! {
     })]
     #[test]
     fn evaluated_value_is_the_value_itself(val in PropValue::any()) {
-        check_against_interpreter(
+        crosscheck(
             &val.to_string(),
-            Some(val.into())
+            Ok(Some(val.into()))
         )
     }
 
@@ -24,9 +24,9 @@ proptest! {
         let mut env = TestEnvironment::default();
         env.evaluate(&format!("(to-consensus-buff? {val})")).is_ok()
     })) {
-        check_against_interpreter(
+        crosscheck(
             &format!("(from-consensus-buff? {} (unwrap-panic (to-consensus-buff? {})))", val.type_string() ,val),
-            Some(Value::some(val.into()).unwrap())
+            Ok(Some(Value::some(val.into()).unwrap()))
         )
     }
 }


### PR DESCRIPTION
`check_against_interpreter()` added for property testing. Interpreter and WASM results will be compared, then expected result will be compared.

fixes #243 