### PR TITLE
Name collisions

### DIFF
--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -192,9 +192,10 @@ pub fn crosscheck(snippet: &str, expected: Result<Option<Value>, ()>) {
     );
 
     assert_eq!(
-        compiled.map_err(|_| ()),
-        expected,
-        "Not the expected result"
+        compiled.as_ref().map_err(|_| &()),
+        expected.as_ref(),
+        "Not the expected result {:?}",
+        compiled.as_ref().unwrap_err()
     );
 }
 

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -1480,4 +1480,13 @@ impl WasmGenerator {
             .unop(UnaryOp::I64ExtendUI32)
             .call(self.func_by_name("log"));
     }
+
+    pub(crate) fn is_reserved_name(&self, name: &ClarityName) -> bool {
+        words::lookup_complex(name).is_some()
+            || words::lookup_simple(name).is_some()
+            || self
+                .contract_analysis
+                .get_public_function_type(name.as_str())
+                .is_some()
+    }
 }

--- a/clar2wasm/src/words/conditionals.rs
+++ b/clar2wasm/src/words/conditionals.rs
@@ -60,6 +60,14 @@ impl ComplexWord for Match {
     ) -> Result<(), GeneratorError> {
         let match_on = args.get_expr(0)?;
         let success_binding = args.get_name(1)?;
+
+        if generator.is_reserved_name(success_binding) {
+            return Err(GeneratorError::InternalError(format!(
+                "Name already used {:?}",
+                success_binding
+            )));
+        }
+
         let success_body = args.get_expr(2)?;
 
         // save the current set of named locals, for later restoration
@@ -93,6 +101,14 @@ impl ComplexWord for Match {
                 let (ok_ty, err_ty) = &*inner_types;
 
                 let err_binding = args.get_name(3)?;
+
+                if generator.is_reserved_name(err_binding) {
+                    return Err(GeneratorError::InternalError(format!(
+                        "Name already used {:?}",
+                        err_binding
+                    )));
+                }
+
                 let err_body = args.get_expr(4)?;
 
                 let err_locals = generator.save_to_locals(builder, err_ty, true);
@@ -857,14 +873,13 @@ mod tests {
         );
     }
 
-    #[ignore = "FIXME - check for name collisions"]
     #[test]
     fn clar_match_a() {
         const ADD_10: &str = "
 (define-private (add-10 (x (response int int)))
  (match x
    val (+ val 10)
-   err (+ err 107)))";
+   error (+ error 107)))";
 
         crosscheck(
             &format!("{ADD_10} (add-10 (ok 115))"),
@@ -877,21 +892,27 @@ mod tests {
     }
 
     #[test]
-    fn clar_match_cursed() {
-        const ADD_10: &str = "
-(define-private (add-10 (x (response int int)))
+    fn clar_match_disallow_builtin_names() {
+        // It's not allowed to use names of user-defined functions as bindings
+        const ERR: &str = "
+(define-private (test (x (response int int)))
  (match x
    val (+ val 10)
-   add-10 (+ add-10 107)))";
+   err (+ err 107)))";
 
-        crosscheck(
-            &format!("{ADD_10} (add-10 (ok 115))"),
-            Ok(Some(Value::Int(125))),
-        );
-        crosscheck(
-            &format!("{ADD_10} (add-10 (err 18))"),
-            Ok(Some(Value::Int(125))),
-        );
+        crosscheck(&format!("{ERR} (test (err 18))"), Err(()));
+    }
+
+    #[test]
+    fn clar_match_cursed() {
+        // It's not allowed to use names of user-defined functions as bindings
+        const CURSED: &str = "
+(define-private (cursed (x (response int int)))
+ (match x
+   val (+ val 10)
+   cursed (+ cursed 107)))";
+
+        crosscheck(&format!("{CURSED} (cursed (err 18))"), Err(()));
     }
 
     #[test]

--- a/clar2wasm/src/words/conditionals.rs
+++ b/clar2wasm/src/words/conditionals.rs
@@ -877,6 +877,24 @@ mod tests {
     }
 
     #[test]
+    fn clar_match_cursed() {
+        const ADD_10: &str = "
+(define-private (add-10 (x (response int int)))
+ (match x
+   val (+ val 10)
+   add-10 (+ add-10 107)))";
+
+        crosscheck(
+            &format!("{ADD_10} (add-10 (ok 115))"),
+            Ok(Some(Value::Int(125))),
+        );
+        crosscheck(
+            &format!("{ADD_10} (add-10 (err 18))"),
+            Ok(Some(Value::Int(125))),
+        );
+    }
+
+    #[test]
     fn clar_match_b() {
         const ADD_10: &str = "
 (define-private (add-10 (x (optional int)))


### PR DESCRIPTION
This adds checks for binding names not colliding with builtins or user defined functions, mirroring the behavior of the interpreter.