### PR TITLE
Fix README and add commented patch in .cargo/config

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,3 +1,7 @@
 [alias]
 clar2wasm-install = "install --path . --locked --force"
 fmt-stacks = "fmt -- --config group_imports=StdExternalCrate,imports_granularity=Module"
+
+# Uncomment the patch below to use a local version of the stacks-core modules
+# [patch.'https://github.com/stacks-network/stacks-core.git']
+# clarity = { path = "./stacks-core/clarity" }

--- a/README.md
+++ b/README.md
@@ -202,16 +202,8 @@ Add the following to *clarity-wasm/.cargo/config*
 
 ```toml
 [patch.'https://github.com/stacks-network/stacks-core.git']
-clarity = { path = "../stacks-core/clarity" }
+clarity = { path = "./stacks-core/clarity" }
 ``````
-
-Then do the same for the stacks-core repo, adding the following to *stacks-core/.cargo/config*
-
-```toml
-[patch.'https://github.com/stacks-network/stacks-core.git']
-clarity = { path = "stacks-core/clarity" }
-stacks-common = { path = "stacks-core/stacks-common" }
-```
 
 Similarly, in the stacks-core directory, you can add the following to *stacks-core/.cargo/config*
 


### PR DESCRIPTION
Simple docs change to help with using local paths instead of git branches for stacks-core dependencies.