### PR TITLE
Property test for `define-data-var`/`get-var` + fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,7 +581,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.2.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#fd73fd58b16782836248e9b037fbac04f9238db7"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#863707b41f6ba028cfd19993b6d6243debec6f9b"
 dependencies = [
  "integer-sqrt",
  "lazy_static",
@@ -2814,7 +2814,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#fd73fd58b16782836248e9b037fbac04f9238db7"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#863707b41f6ba028cfd19993b6d6243debec6f9b"
 dependencies = [
  "chrono",
  "curve25519-dalek",
@@ -4042,9 +4042,9 @@ dependencies = [
 
 [[package]]
 name = "wsts"
-version = "5.0.0"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c250118354755b4abb091a83cb8d659b511c0ae211ccdb3b1254e3db199cb86"
+checksum = "6c7db3d3fe28c359e0cdb7f7ad83e3316bda0ba982b8cd1bf0fbe73ae4127e4b"
 dependencies = [
  "aes-gcm",
  "bs58 0.5.0",

--- a/clar2wasm/src/words/data_vars.rs
+++ b/clar2wasm/src/words/data_vars.rs
@@ -26,6 +26,10 @@ impl ComplexWord for DefineDataVar {
         // Store the identifier as a string literal in the memory
         let (name_offset, name_length) = generator.add_string_literal(name);
 
+        // Traverse the initial value for the data variable (result is on the
+        // data stack)
+        generator.traverse_expr(builder, initial)?;
+
         // The initial value can be placed on the top of the memory, since at
         // the top-level, we have not set up the call stack yet.
         let ty = generator
@@ -38,10 +42,6 @@ impl ComplexWord for DefineDataVar {
         builder
             .i32_const(generator.literal_memory_end as i32)
             .local_set(offset);
-
-        // Traverse the initial value for the data variable (result is on the
-        // data stack)
-        generator.traverse_expr(builder, initial)?;
 
         // Write the initial value to the memory, to be read by the host.
         let size = generator.write_to_memory(builder, offset, 0, &ty);

--- a/clar2wasm/tests/wasm-generation/values.rs
+++ b/clar2wasm/tests/wasm-generation/values.rs
@@ -34,9 +34,9 @@ proptest! {
 proptest! {
     #[test]
     fn data_var_define_and_get(val in PropValue::any()) {
-        assert_eq!(
-            evaluate(&format!(r##"(define-data-var v {} {val}) (var-get v)"##, val.type_string())),
-            evaluate(&val.to_string())
+        crosscheck(
+            &format!(r##"(define-data-var v {} {val}) (var-get v)"##, val.type_string()),
+            Ok(Some(val.into()))
         )
     }
 }

--- a/clar2wasm/tests/wasm-generation/values.rs
+++ b/clar2wasm/tests/wasm-generation/values.rs
@@ -30,3 +30,13 @@ proptest! {
         )
     }
 }
+
+proptest! {
+    #[test]
+    fn data_var_define_and_get(val in PropValue::any()) {
+        assert_eq!(
+            evaluate(&format!(r##"(define-data-var v {} {val}) (var-get v)"##, val.type_string())),
+            evaluate(&val.to_string())
+        )
+    }
+}


### PR DESCRIPTION
Fixes #249 

This PR adds a property test that check that if a we define a `data-var` to a value and read it right after, the result should be the same value.

This showed several bugs, mostly in the way we read/write values to the Wasm memory.

~~DRAFT PR: it depends on https://github.com/stacks-network/stacks-core/pull/4259~~
~~UPDATE: I found another bug, this is going back to draft~~