### PR TITLE
Improve PropValue formatting

### DIFF
--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -69,7 +69,10 @@ impl From<PropValue> for Value {
 
 impl std::fmt::Debug for PropValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(&self, f)
+        f.debug_struct("PropValue")
+            .field("value", &self.to_string())
+            .field("type", &self.type_string())
+            .finish()
     }
 }
 


### PR DESCRIPTION
The raw `PropValue` display after a failed test was unpractical and difficult to read.

This PR improves the display by printing a Clarity compatible value and its type.