### PR TITLE
Remove uses of `unimplemented`

### DIFF
--- a/clar2wasm/src/deserialize.rs
+++ b/clar2wasm/src/deserialize.rs
@@ -916,7 +916,7 @@ impl WasmGenerator {
         for local in inner_locals {
             loop_block.local_get(local);
         }
-        let bytes_written = self.write_to_memory(&mut loop_block, result_offset, 0, element_ty);
+        let bytes_written = self.write_to_memory(&mut loop_block, result_offset, 0, element_ty)?;
 
         // Increment the result offset by the number of bytes written
         loop_block

--- a/clar2wasm/src/serialize.rs
+++ b/clar2wasm/src/serialize.rs
@@ -519,7 +519,7 @@ impl WasmGenerator {
                 let mut loop_ = size_non_zero.dangling_instr_seq(None);
                 let loop_id = loop_.id();
 
-                self.read_from_memory(&mut loop_, read_ptr, 0, element_ty);
+                self.read_from_memory(&mut loop_, read_ptr, 0, element_ty)?;
 
                 self.serialize_to_memory(&mut loop_, write_ptr, 0, element_ty)?;
 

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -147,12 +147,14 @@ pub(crate) fn clar2wasm_ty(ty: &TypeSignature) -> Vec<ValType> {
             types.extend(clar2wasm_ty(&inner_types.1));
             types
         }
-        TypeSignature::SequenceType(_) => vec![
+        TypeSignature::SequenceType(_) | TypeSignature::ListUnionType(_) => vec![
             ValType::I32, // offset
             ValType::I32, // length
         ],
         TypeSignature::BoolType => vec![ValType::I32],
-        TypeSignature::PrincipalType | TypeSignature::CallableType(_) => vec![
+        TypeSignature::PrincipalType
+        | TypeSignature::CallableType(_)
+        | TypeSignature::TraitReferenceType(_) => vec![
             ValType::I32, // offset
             ValType::I32, // length
         ],
@@ -168,7 +170,6 @@ pub(crate) fn clar2wasm_ty(ty: &TypeSignature) -> Vec<ValType> {
             }
             types
         }
-        _ => unimplemented!("{:?}", ty),
     }
 }
 

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -115,15 +115,15 @@ impl ArgumentsExt for &[SymbolicExpression] {
 }
 
 /// Push a placeholder value for Wasm type `ty` onto the data stack.
+/// `unreachable!` is used for Wasm types that should never be used.
+#[allow(clippy::unreachable)]
 pub(crate) fn add_placeholder_for_type(builder: &mut InstrSeqBuilder, ty: ValType) {
     match ty {
         ValType::I32 => builder.i32_const(0),
         ValType::I64 => builder.i64_const(0),
-        ValType::F32 => builder.f32_const(0.0),
-        ValType::F64 => builder.f64_const(0.0),
-        ValType::V128 => unimplemented!("V128"),
-        ValType::Externref => unimplemented!("Externref"),
-        ValType::Funcref => unimplemented!("Funcref"),
+        ValType::F32 | ValType::F64 | ValType::V128 | ValType::Externref | ValType::Funcref => {
+            unreachable!("Use of Wasm type {}", ty);
+        }
     };
 }
 

--- a/clar2wasm/src/words/blockinfo.rs
+++ b/clar2wasm/src/words/blockinfo.rs
@@ -49,7 +49,7 @@ impl ComplexWord for GetBlockInfo {
 
         // Host interface fills the result into the specified memory. Read it
         // back out, and place the value on the data stack.
-        generator.read_from_memory(builder, return_offset, 0, &return_ty);
+        generator.read_from_memory(builder, return_offset, 0, &return_ty)?;
 
         Ok(())
     }
@@ -103,7 +103,7 @@ impl ComplexWord for GetBurnBlockInfo {
 
         // Host interface fills the result into the specified memory. Read it
         // back out, and place the value on the data stack.
-        generator.read_from_memory(builder, return_offset, 0, &return_ty);
+        generator.read_from_memory(builder, return_offset, 0, &return_ty)?;
 
         Ok(())
     }

--- a/clar2wasm/src/words/constants.rs
+++ b/clar2wasm/src/words/constants.rs
@@ -50,7 +50,7 @@ impl ComplexWord for DefineConstant {
             generator.literal_memory_end += len;
 
             // Write the initial value to the memory, to be read by the host.
-            generator.write_to_memory(builder, offset_local, 0, &ty);
+            generator.write_to_memory(builder, offset_local, 0, &ty)?;
 
             offset
         };

--- a/clar2wasm/src/words/constants.rs
+++ b/clar2wasm/src/words/constants.rs
@@ -26,7 +26,7 @@ impl ComplexWord for DefineConstant {
         // If the initial value is a literal, then we can directly add it to
         // the literal memory.
         let offset = if let SymbolicExpressionType::LiteralValue(value) = &value.expr {
-            let (offset, _len) = generator.add_literal(value);
+            let (offset, _len) = generator.add_literal(value)?;
             offset
         } else {
             // Traverse the initial value expression.

--- a/clar2wasm/src/words/contract.rs
+++ b/clar2wasm/src/words/contract.rs
@@ -59,7 +59,8 @@ impl ComplexWord for ContractCall {
             // This is a static contract call.
             // Push the contract identifier onto the stack
             // TODO(#111): These should be tracked for reuse, similar to the string literals
-            let (id_offset, id_length) = generator.add_literal(&contract_identifier.clone().into());
+            let (id_offset, id_length) =
+                generator.add_literal(&contract_identifier.clone().into())?;
             builder
                 .i32_const(id_offset as i32)
                 .i32_const(id_length as i32);

--- a/clar2wasm/src/words/contract.rs
+++ b/clar2wasm/src/words/contract.rs
@@ -120,7 +120,7 @@ impl ComplexWord for ContractCall {
 
         // Host interface fills the result into the specified memory. Read it
         // back out, and place the value on the data stack.
-        generator.read_from_memory(builder, return_offset, 0, &return_ty);
+        generator.read_from_memory(builder, return_offset, 0, &return_ty)?;
 
         Ok(())
     }

--- a/clar2wasm/src/words/contract.rs
+++ b/clar2wasm/src/words/contract.rs
@@ -96,7 +96,7 @@ impl ComplexWord for ContractCall {
                 })?
                 .clone();
 
-            arg_length += generator.write_to_memory(builder, arg_offset, arg_length, &arg_ty);
+            arg_length += generator.write_to_memory(builder, arg_offset, arg_length, &arg_ty)?;
         }
 
         // Push the arguments offset and length onto the data stack

--- a/clar2wasm/src/words/data_vars.rs
+++ b/clar2wasm/src/words/data_vars.rs
@@ -44,7 +44,7 @@ impl ComplexWord for DefineDataVar {
             .local_set(offset);
 
         // Write the initial value to the memory, to be read by the host.
-        let size = generator.write_to_memory(builder, offset, 0, &ty);
+        let size = generator.write_to_memory(builder, offset, 0, &ty)?;
 
         // Increment the literal memory end
         // FIXME: These initial values do not need to be saved in the literal
@@ -113,7 +113,7 @@ impl ComplexWord for SetDataVar {
         let (offset, size) = generator.create_call_stack_local(builder, &ty, true, false);
 
         // Write the value to the memory, to be read by the host
-        generator.write_to_memory(builder, offset, 0, &ty);
+        generator.write_to_memory(builder, offset, 0, &ty)?;
 
         // Push the identifier offset and length onto the data stack
         builder

--- a/clar2wasm/src/words/data_vars.rs
+++ b/clar2wasm/src/words/data_vars.rs
@@ -195,7 +195,7 @@ impl ComplexWord for GetDataVar {
 
         // Host interface fills the result into the specified memory. Read it
         // back out, and place the value on the data stack.
-        generator.read_from_memory(builder, offset, 0, &ty);
+        generator.read_from_memory(builder, offset, 0, &ty)?;
 
         Ok(())
     }

--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -196,7 +196,7 @@ impl ComplexWord for IndexOf {
                 let (elem_size, elem_locals) = match &elem_ty {
                     SequenceElementType::Other(elem_ty) => {
                         (
-                            generator.read_from_memory(loop_body, offset, 0, elem_ty),
+                            generator.read_from_memory(loop_body, offset, 0, elem_ty)?,
                             // STACK: [element]
                             generator.save_to_locals(loop_body, elem_ty, true),
                             // STACK: []
@@ -856,11 +856,11 @@ fn wasm_equal_list(
             let loop_id = loop_.id();
 
             // read an element from first list and assign it to locals
-            offset_delta_a = generator.read_from_memory(&mut loop_, *offset_a, 0, list_ty);
+            offset_delta_a = generator.read_from_memory(&mut loop_, *offset_a, 0, list_ty)?;
             assign_first_operand_to_locals(&mut loop_, list_ty, &first_locals)?;
 
             // same for nth list
-            offset_delta_b = generator.read_from_memory(&mut loop_, *offset_b, 0, nth_list_ty);
+            offset_delta_b = generator.read_from_memory(&mut loop_, *offset_b, 0, nth_list_ty)?;
             assign_to_locals(&mut loop_, list_ty, nth_list_ty, &nth_locals)?;
 
             // compare both elements

--- a/clar2wasm/src/words/hashing.rs
+++ b/clar2wasm/src/words/hashing.rs
@@ -108,7 +108,7 @@ impl SimpleWord for Keccak256 {
                 // Convert integers to buffers by storing them to memory
                 let (buffer_local, size) =
                     generator.create_call_stack_local(builder, ty, false, true);
-                generator.write_to_memory(builder, buffer_local, 0, ty);
+                generator.write_to_memory(builder, buffer_local, 0, ty)?;
 
                 // The load the offset and length onto the stack
                 builder.local_get(buffer_local).i32_const(size);
@@ -188,7 +188,7 @@ impl SimpleWord for Sha512_256 {
                 // Convert integers to buffers by storing them to memory
                 let (buffer_local, size) =
                     generator.create_call_stack_local(builder, ty, false, true);
-                generator.write_to_memory(builder, buffer_local, 0, ty);
+                generator.write_to_memory(builder, buffer_local, 0, ty)?;
 
                 // The load the offset and length onto the stack
                 builder.local_get(buffer_local).i32_const(size);

--- a/clar2wasm/src/words/maps.rs
+++ b/clar2wasm/src/words/maps.rs
@@ -86,7 +86,7 @@ impl ComplexWord for MapGet {
         generator.traverse_expr(builder, key)?;
 
         // Write the key to the memory (it's already on the data stack)
-        generator.write_to_memory(builder, key_offset, 0, &ty);
+        generator.write_to_memory(builder, key_offset, 0, &ty)?;
 
         // Push the key offset and size to the data stack
         builder.local_get(key_offset).i32_const(key_size);
@@ -159,7 +159,7 @@ impl ComplexWord for MapSet {
         generator.traverse_expr(builder, key)?;
 
         // Write the key to the memory (it's already on the data stack)
-        generator.write_to_memory(builder, key_offset, 0, &ty);
+        generator.write_to_memory(builder, key_offset, 0, &ty)?;
 
         // Push the key offset and size to the data stack
         builder.local_get(key_offset).i32_const(key_size);
@@ -177,7 +177,7 @@ impl ComplexWord for MapSet {
         generator.traverse_expr(builder, value)?;
 
         // Write the value to the memory (it's already on the data stack)
-        generator.write_to_memory(builder, val_offset, 0, &ty);
+        generator.write_to_memory(builder, val_offset, 0, &ty)?;
 
         // Push the value offset and size to the data stack
         builder.local_get(val_offset).i32_const(val_size);
@@ -233,7 +233,7 @@ impl ComplexWord for MapInsert {
         generator.traverse_expr(builder, key)?;
 
         // Write the key to the memory (it's already on the data stack)
-        generator.write_to_memory(builder, key_offset, 0, &ty);
+        generator.write_to_memory(builder, key_offset, 0, &ty)?;
 
         // Push the key offset and size to the data stack
         builder.local_get(key_offset).i32_const(key_size);
@@ -251,7 +251,7 @@ impl ComplexWord for MapInsert {
         generator.traverse_expr(builder, value)?;
 
         // Write the value to the memory (it's already on the data stack)
-        generator.write_to_memory(builder, val_offset, 0, &ty);
+        generator.write_to_memory(builder, val_offset, 0, &ty)?;
 
         // Push the value offset and size to the data stack
         builder.local_get(val_offset).i32_const(val_size);
@@ -307,7 +307,7 @@ impl ComplexWord for MapDelete {
         generator.traverse_expr(builder, key)?;
 
         // Write the key to the memory (it's already on the data stack)
-        generator.write_to_memory(builder, key_offset, 0, &ty);
+        generator.write_to_memory(builder, key_offset, 0, &ty)?;
 
         // Push the key offset and size to the data stack
         builder.local_get(key_offset).i32_const(key_size);

--- a/clar2wasm/src/words/maps.rs
+++ b/clar2wasm/src/words/maps.rs
@@ -109,7 +109,7 @@ impl ComplexWord for MapGet {
 
         // Host interface fills the result into the specified memory. Read it
         // back out, and place the value on the data stack.
-        generator.read_from_memory(builder, return_offset, 0, &ty);
+        generator.read_from_memory(builder, return_offset, 0, &ty)?;
 
         Ok(())
     }

--- a/clar2wasm/src/words/secp256k1.rs
+++ b/clar2wasm/src/words/secp256k1.rs
@@ -44,7 +44,7 @@ impl ComplexWord for Recover {
                 })?,
         );
 
-        generator.read_from_memory(builder, result_local, 0, &ret_ty);
+        generator.read_from_memory(builder, result_local, 0, &ret_ty)?;
 
         Ok(())
     }

--- a/clar2wasm/src/words/tokens.rs
+++ b/clar2wasm/src/words/tokens.rs
@@ -294,7 +294,7 @@ impl ComplexWord for BurnNonFungibleToken {
             generator.create_call_stack_local(builder, &identifier_ty, true, false);
 
         // Write the identifier to the stack (since the host needs to handle generic types)
-        generator.write_to_memory(builder, id_offset, 0, &identifier_ty);
+        generator.write_to_memory(builder, id_offset, 0, &identifier_ty)?;
 
         // Push the offset and size to the data stack
         builder.local_get(id_offset).i32_const(id_size);
@@ -348,7 +348,7 @@ impl ComplexWord for TransferNonFungibleToken {
             generator.create_call_stack_local(builder, &identifier_ty, true, false);
 
         // Write the identifier to the stack (since the host needs to handle generic types)
-        generator.write_to_memory(builder, id_offset, 0, &identifier_ty);
+        generator.write_to_memory(builder, id_offset, 0, &identifier_ty)?;
 
         // Push the offset and size to the data stack
         builder.local_get(id_offset).i32_const(id_size);
@@ -404,7 +404,7 @@ impl ComplexWord for MintNonFungibleToken {
             generator.create_call_stack_local(builder, &identifier_ty, true, false);
 
         // Write the identifier to the stack (since the host needs to handle generic types)
-        generator.write_to_memory(builder, id_offset, 0, &identifier_ty);
+        generator.write_to_memory(builder, id_offset, 0, &identifier_ty)?;
 
         // Push the offset and size to the data stack
         builder.local_get(id_offset).i32_const(id_size);
@@ -456,7 +456,7 @@ impl ComplexWord for GetOwnerOfNonFungibleToken {
             generator.create_call_stack_local(builder, &identifier_ty, true, false);
 
         // Write the identifier to the stack (since the host needs to handle generic types)
-        generator.write_to_memory(builder, id_offset, 0, &identifier_ty);
+        generator.write_to_memory(builder, id_offset, 0, &identifier_ty)?;
 
         // Push the offset and size to the data stack
         builder.local_get(id_offset).i32_const(id_size);


### PR DESCRIPTION
So far I removed the one in `write_to_memory`. I will remove the rest of the uses in this PR as well.