### PR TITLE
Unify list element type extraction, support filtering of buffers

### DIFF
--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -1535,11 +1535,9 @@ impl WasmGenerator {
                     Ok(SequenceElementType::UnicodeScalar)
                 }
             },
-            _ => {
-                return Err(GeneratorError::TypeError(
-                    "expected sequence type".to_string(),
-                ));
-            }
+            _ => Err(GeneratorError::TypeError(
+                "expected sequence type".to_string(),
+            )),
         }
     }
 }

--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -5,9 +5,8 @@ use walrus::ir::{BinaryOp, IfElse, InstrSeqType, Loop, UnaryOp};
 use walrus::{InstrSeqBuilder, LocalId, ValType};
 
 use super::ComplexWord;
-use crate::wasm_generator::SequenceElementType;
 use crate::wasm_generator::{
-    clar2wasm_ty, drop_value, ArgumentsExt, GeneratorError, WasmGenerator,
+    clar2wasm_ty, drop_value, ArgumentsExt, GeneratorError, SequenceElementType, WasmGenerator,
 };
 
 #[derive(Debug)]


### PR DESCRIPTION
Support filtering over buffers.

This also de-duplicates quite a bit of code.

fixes #270