### PR TITLE
Add a property test for `define-constant` and getting one

### DIFF
--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -4,9 +4,7 @@ use std::collections::HashMap;
 use clarity::vm::analysis::ContractAnalysis;
 use clarity::vm::clarity_wasm::{get_type_in_memory_size, get_type_size, is_in_memory_type};
 use clarity::vm::diagnostic::DiagnosableError;
-use clarity::vm::types::{
-    CharType, FunctionType, PrincipalData, SequenceData, SequenceSubtype, TypeSignature,
-};
+use clarity::vm::types::{CharType, FunctionType, PrincipalData, SequenceData, TypeSignature};
 use clarity::vm::variables::NativeVariables;
 use clarity::vm::{ClarityName, SymbolicExpression, SymbolicExpressionType};
 use walrus::ir::{BinaryOp, InstrSeqId, InstrSeqType, LoadKind, MemArg, StoreKind, UnaryOp};
@@ -1119,7 +1117,7 @@ impl WasmGenerator {
             if is_in_memory_type(&ty)
                 && !matches!(
                     &ty,
-                    TypeSignature::SequenceType(SequenceSubtype::ListType(_))
+                    TypeSignature::SequenceType(seq) if seq.is_list_type()
                 )
             {
                 builder

--- a/clar2wasm/src/words/constants.rs
+++ b/clar2wasm/src/words/constants.rs
@@ -29,6 +29,9 @@ impl ComplexWord for DefineConstant {
             let (offset, _len) = generator.add_literal(value);
             offset
         } else {
+            // Traverse the initial value expression.
+            generator.traverse_expr(builder, value)?;
+
             // If the initial expression is not a literal, then we need to
             // reserve the space for it, and then execute the expression and
             // write the result into the reserved space.
@@ -45,9 +48,6 @@ impl ComplexWord for DefineConstant {
 
             let len = get_type_in_memory_size(&ty, true) as u32;
             generator.literal_memory_end += len;
-
-            // Traverse the initial value expression.
-            generator.traverse_expr(builder, value)?;
 
             // Write the initial value to the memory, to be read by the host.
             generator.write_to_memory(builder, offset_local, 0, &ty);

--- a/clar2wasm/src/words/constants.rs
+++ b/clar2wasm/src/words/constants.rs
@@ -60,3 +60,63 @@ impl ComplexWord for DefineConstant {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use clarity::vm::types::{ListData, ListTypeData, SequenceData};
+    use clarity::vm::Value;
+
+    use crate::tools::TestEnvironment;
+
+    #[test]
+    fn define_constant_const() {
+        let mut env = TestEnvironment::default();
+        let val = env.init_contract_with_snippet(
+            "define_constant",
+            r#"
+(define-constant four 4)
+(define-private (go) (print four))
+(go)
+"#,
+        );
+        assert_eq!(val.unwrap(), Some(Value::Int(4)));
+    }
+
+    #[test]
+    fn define_constant_function() {
+        let mut env = TestEnvironment::default();
+        let val = env.init_contract_with_snippet(
+            "define_constant",
+            r#"
+(define-constant four (+ 2 2))
+(define-private (go) (print four))
+(go)
+"#,
+        );
+        assert_eq!(val.unwrap(), Some(Value::Int(4)));
+    }
+
+    #[test]
+    fn define_constant_list() {
+        let mut env = TestEnvironment::default();
+        let val = env.init_contract_with_snippet(
+            "define_constant",
+            r#"
+(define-constant list-of-2-int (list 1 1))
+(define-private (go) (print list-of-2-int))
+(go)
+"#,
+        );
+        assert_eq!(
+            val.unwrap(),
+            Some(Value::Sequence(SequenceData::List(ListData {
+                data: vec![Value::Int(1), Value::Int(1)],
+                type_signature: ListTypeData::new_list(
+                    clarity::vm::types::TypeSignature::IntType,
+                    2
+                )
+                .unwrap()
+            })))
+        );
+    }
+}

--- a/clar2wasm/src/words/constants.rs
+++ b/clar2wasm/src/words/constants.rs
@@ -66,57 +66,36 @@ mod tests {
     use clarity::vm::types::{ListData, ListTypeData, SequenceData};
     use clarity::vm::Value;
 
-    use crate::tools::TestEnvironment;
+    use crate::tools::crosscheck;
 
     #[test]
     fn define_constant_const() {
-        let mut env = TestEnvironment::default();
-        let val = env.init_contract_with_snippet(
-            "define_constant",
-            r#"
-(define-constant four 4)
-(define-private (go) (print four))
-(go)
-"#,
-        );
-        assert_eq!(val.unwrap(), Some(Value::Int(4)));
+        crosscheck(
+            r#"(define-constant four 4) (define-private (go) (print four)) (go)"#,
+            Ok(Some(Value::Int(4))),
+        )
     }
 
     #[test]
     fn define_constant_function() {
-        let mut env = TestEnvironment::default();
-        let val = env.init_contract_with_snippet(
-            "define_constant",
-            r#"
-(define-constant four (+ 2 2))
-(define-private (go) (print four))
-(go)
-"#,
-        );
-        assert_eq!(val.unwrap(), Some(Value::Int(4)));
+        crosscheck(
+            r#"(define-constant four (+ 2 2)) (define-private (go) (print four)) (go)"#,
+            Ok(Some(Value::Int(4))),
+        )
     }
 
     #[test]
     fn define_constant_list() {
-        let mut env = TestEnvironment::default();
-        let val = env.init_contract_with_snippet(
-            "define_constant",
-            r#"
-(define-constant list-of-2-int (list 1 1))
-(define-private (go) (print list-of-2-int))
-(go)
-"#,
-        );
-        assert_eq!(
-            val.unwrap(),
-            Some(Value::Sequence(SequenceData::List(ListData {
+        crosscheck(
+            r#"(define-constant list-of-2-int (list 1 1)) (define-private (go) (print list-of-2-int)) (go)"#,
+            Ok(Some(Value::Sequence(SequenceData::List(ListData {
                 data: vec![Value::Int(1), Value::Int(1)],
                 type_signature: ListTypeData::new_list(
                     clarity::vm::types::TypeSignature::IntType,
-                    2
+                    2,
                 )
-                .unwrap()
-            })))
-        );
+                .unwrap(),
+            })))),
+        )
     }
 }

--- a/clar2wasm/tests/wasm-generation/values.rs
+++ b/clar2wasm/tests/wasm-generation/values.rs
@@ -40,3 +40,13 @@ proptest! {
         )
     }
 }
+
+proptest! {
+    #[test]
+    fn constant_define_and_get(val in PropValue::any()) {
+        crosscheck(
+            &format!(r#"(define-constant cst {val}) cst"#),
+            Ok(Some(val.into()))
+        )
+    }
+}


### PR DESCRIPTION
This PR adds a property test for `define-constant`, which states that a defined constant should be equal to itself, and adds fixes.

One of the fix was a classic: evaluating the argument too late in the traverse function. The other was more subtle: when getting a constant, we can push the offset and length for all in-memory types, except for lists that needs to be dereferenced. I guess the way we write data to memory could be fixed later to remove this exception.

Fixes #205.
This PR also add tests in _words/constants.rs_ to check that issue 205 is correctly fixed.
Thanks @csgui for writing them.