### PR TITLE
Proptest for `var-set` + fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,7 +581,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.2.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#863707b41f6ba028cfd19993b6d6243debec6f9b"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#5956df38f851fa46204d4e57614bf77e633d553b"
 dependencies = [
  "integer-sqrt",
  "lazy_static",
@@ -2814,7 +2814,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#863707b41f6ba028cfd19993b6d6243debec6f9b"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#5956df38f851fa46204d4e57614bf77e633d553b"
 dependencies = [
  "chrono",
  "curve25519-dalek",

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -42,6 +42,8 @@ pub struct WasmGenerator {
     early_return_block_id: Option<InstrSeqId>,
     /// The return type of the current function.
     pub(crate) return_type: Option<TypeSignature>,
+    /// The types of defined data-vars
+    pub(crate) datavars_types: HashMap<ClarityName, TypeSignature>,
 
     /// The locals for the current function.
     pub(crate) bindings: HashMap<String, Vec<LocalId>>,
@@ -238,6 +240,7 @@ impl WasmGenerator {
             early_return_block_id: None,
             return_type: None,
             frame_size: 0,
+            datavars_types: HashMap::new(),
         })
     }
 

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -338,7 +338,7 @@ impl TypePrinter for TupleData {
     }
 }
 
-fn type_string(ty: &TypeSignature) -> String {
+pub fn type_string(ty: &TypeSignature) -> String {
     match ty {
         TypeSignature::IntType => "int".to_owned(),
         TypeSignature::UIntType => "uint".to_owned(),

--- a/clar2wasm/tests/wasm-generation/values.rs
+++ b/clar2wasm/tests/wasm-generation/values.rs
@@ -1,8 +1,8 @@
 use clar2wasm::tools::{crosscheck, TestEnvironment};
 use clarity::vm::Value;
+use proptest::prelude::ProptestConfig;
 use proptest::proptest;
-use proptest::strategy::Strategy;
-use proptest::{prelude::ProptestConfig, strategy::Just};
+use proptest::strategy::{Just, Strategy};
 
 use crate::{prop_signature, type_string, PropValue, TypePrinter};
 


### PR DESCRIPTION
This PR adds a property test for `var-set`: a data-var defined to a value then set to another value should be equal to this another value.

It showed two issues with this function:

1. just like `define-data-var`, it needs to dereference the value to read if it is an in-memory type
2. a typechecker issue, where we need to set the type of this value to the one set at the variable definition.