### PR TITLE
feat: Accept optional as argument to `get`

### DIFF
--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -195,7 +195,7 @@ pub fn crosscheck(snippet: &str, expected: Result<Option<Value>, ()>) {
         compiled.as_ref().map_err(|_| &()),
         expected.as_ref(),
         "Not the expected result {:?}",
-        compiled.as_ref().unwrap_err()
+        compiled.as_ref()
     );
 }
 


### PR DESCRIPTION
This allows the argument to get to be an optional tuple.

The fix is very simple, and might warrant some explanation, it was not clear to me at first that this should work.

The Optional is stored on the stack as `[ discriminant , value/placeholder ]`

Since the logic of getting  data works on the top level, it makes no difference if there is a discriminant underneath it. And since the placeholder is needed in the return value, copying it from the full tuple placeholder solves this problem.