### PR TITLE
feat: add `crosscheck` binary

### DIFF
--- a/clar2wasm/Cargo.toml
+++ b/clar2wasm/Cargo.toml
@@ -45,6 +45,10 @@ path = "src/lib.rs"
 name = "clar2wasm"
 path = "src/bin/main.rs"
 
+[[bin]]
+name = "crosscheck"
+path = "src/bin/crosscheck.rs"
+
 [[bench]]
 name = "benchmark"
 harness = false

--- a/clar2wasm/src/bin/crosscheck.rs
+++ b/clar2wasm/src/bin/crosscheck.rs
@@ -1,0 +1,34 @@
+use std::fs;
+
+use clap::Parser;
+use clar2wasm::tools::crosscheck_compare_only;
+
+/// crosscheck is a tool to compare the results of the compiled and interpreted
+/// versions of a Clarity snippet.
+#[derive(Parser)]
+#[command(name = "crosscheck", version = env!("CARGO_PKG_VERSION"))]
+struct Args {
+    /// Clarity source file to compile
+    input: String,
+}
+
+fn main() {
+    let args = Args::parse();
+
+    // Require a .clar extension
+    if !args.input.ends_with(".clar") {
+        eprintln!("Input file must have a .clar extension");
+        std::process::exit(1);
+    }
+
+    // Read the file.
+    let source = match fs::read_to_string(args.input.as_str()) {
+        Ok(source) => source,
+        Err(error) => {
+            eprintln!("Error reading file: {}", error);
+            std::process::exit(1);
+        }
+    };
+
+    crosscheck_compare_only(&source);
+}


### PR DESCRIPTION
`crosscheck` takes the path to a clarity file as an argument and runs crosscheck, which evaluates the clarity code in both the interpreter and the Clarity-Wasm runtimes and compares the result. This will be used by @moodmosaic for the fuzz testing.