### PR TITLE
test: include analysis when interpreting in crosscheck

### DIFF
--- a/clar2wasm/tests/wasm-generation/bitwise.rs
+++ b/clar2wasm/tests/wasm-generation/bitwise.rs
@@ -1,0 +1,13 @@
+use clar2wasm::tools::crosscheck_compare_only;
+use proptest::proptest;
+
+use crate::{int, uint};
+
+proptest! {
+  #[test]
+  fn crossprop_bit_shift_left(val in int(), shamt in uint()) {
+    crosscheck_compare_only(
+        &format!("(bit-shift-left {val} {shamt})"),
+    )
+  }
+}

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -1,5 +1,6 @@
 pub mod arithmetic;
 pub mod bindings;
+pub mod bitwise;
 pub mod conditionals;
 pub mod default_to;
 pub mod equal;


### PR DESCRIPTION
The previous implementation doesn't include the proper analysis passes when running the interpreter, so if there is a failure in the type-checker for example, then the cross-checker could give a false negative.