### PR TITLE
Crossprop tests for bitwise and blockinfo

### DIFF
--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -316,7 +316,7 @@ pub fn crosscheck_compare_only(snippet: &str) {
     );
 }
 
-/// Advance the block height to `count`, and uses the same TestEnvironment instance
+/// Advance the block height to `count`, and uses identical TestEnvironment copies
 /// to assert the results of a contract snippet running against the compiler and the interpreter.
 pub fn crosscheck_compare_only_advancing_tip(snippet: &str, count: u32) {
     let mut compiler_env = TestEnvironment::new(StacksEpochId::latest(), ClarityVersion::latest());

--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -316,6 +316,8 @@ pub fn crosscheck_compare_only(snippet: &str) {
     );
 }
 
+/// Advance the block height to `count`, and uses the same TestEnvironment instance
+/// to assert the results of a contract snippet running against the compiler and the interpreter.
 pub fn crosscheck_compare_only_advancing_tip(snippet: &str, count: u32) {
     let mut compiler_env = TestEnvironment::new(StacksEpochId::latest(), ClarityVersion::latest());
     compiler_env.advance_chain_tip(count);

--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -263,6 +263,35 @@ pub fn evaluate(snippet: &str) -> Result<Option<Value>, ()> {
     evaluate_at(snippet, StacksEpochId::latest(), ClarityVersion::latest()).map_err(|_| ())
 }
 
+/// Evaluate a Clarity snippet at the latest epoch and clarity version,
+/// advancing the chain tip `count` time.
+/// Returns an optional value -- the result of the evaluation.
+#[allow(clippy::result_unit_err)]
+pub fn evaluate_advancing_tip(snippet: &str, count: u32) -> Result<Option<Value>, ()> {
+    evaluate_advancing_tip_at(
+        snippet,
+        StacksEpochId::latest(),
+        ClarityVersion::latest(),
+        count,
+    )
+    .map_err(|_| ())
+}
+
+/// Evaluate a Clarity snippet at a specific epoch and version,
+/// advancing the chain tip `count` times.
+/// Returns an optional value -- the result of the evaluation.
+pub fn evaluate_advancing_tip_at(
+    snippet: &str,
+    epoch: StacksEpochId,
+    version: ClarityVersion,
+    count: u32,
+) -> Result<Option<Value>, Error> {
+    let mut env = TestEnvironment::new(epoch, version);
+    env.advance_chain_tip(count);
+
+    env.evaluate(snippet)
+}
+
 /// Interpret a Clarity snippet at a specific epoch and version.
 /// Returns an optional value -- the result of the evaluation.
 pub fn interpret_at(
@@ -279,6 +308,35 @@ pub fn interpret_at(
 #[allow(clippy::result_unit_err)]
 pub fn interpret(snippet: &str) -> Result<Option<Value>, ()> {
     interpret_at(snippet, StacksEpochId::latest(), ClarityVersion::latest()).map_err(|_| ())
+}
+
+/// Interpret a Clarity snippet at a specific epoch and version,
+/// advancing the chain tip `count` times.
+/// Returns an optional value -- the result of the evaluation.
+pub fn interpret_advancing_tip_at(
+    snippet: &str,
+    epoch: StacksEpochId,
+    version: ClarityVersion,
+    count: u32,
+) -> Result<Option<Value>, Error> {
+    let mut env = TestEnvironment::new(epoch, version);
+    env.advance_chain_tip(count);
+
+    env.interpret(snippet)
+}
+
+/// Interprets a Clarity snippet at the latest epoch and clarity version,
+/// advancing the chain tip `count` times.
+/// Returns an optional value -- the result of the evaluation.
+#[allow(clippy::result_unit_err)]
+pub fn interpret_advancing_tip(snippet: &str, count: u32) -> Result<Option<Value>, ()> {
+    interpret_advancing_tip_at(
+        snippet,
+        StacksEpochId::latest(),
+        ClarityVersion::latest(),
+        count,
+    )
+    .map_err(|_| ())
 }
 
 pub fn crosscheck(snippet: &str, expected: Result<Option<Value>, ()>) {
@@ -305,6 +363,21 @@ pub fn crosscheck_compare_only(snippet: &str) {
     let compiled = evaluate(snippet);
     let interpreted = interpret(snippet);
 
+    crosscheck_compare_assertion(snippet, compiled, interpreted);
+}
+
+pub fn crosscheck_compare_advancing_tip_by(snippet: &str, count: u32) {
+    let compiled = evaluate_advancing_tip(snippet, count);
+    let interpreted = interpret_advancing_tip(snippet, count);
+
+    crosscheck_compare_assertion(snippet, compiled, interpreted);
+}
+
+fn crosscheck_compare_assertion(
+    snippet: &str,
+    compiled: Result<Option<Value>, ()>,
+    interpreted: Result<Option<Value>, ()>,
+) {
     assert_eq!(
         compiled.as_ref().map_err(|_| &()),
         interpreted.as_ref().map_err(|_| &()),

--- a/clar2wasm/tests/wasm-generation/bitwise.rs
+++ b/clar2wasm/tests/wasm-generation/bitwise.rs
@@ -8,6 +8,8 @@ const TWO_OPS: [&str; 2] = ["bit-shift-left", "bit-shift-right"];
 const MULTI_OPS: [&str; 3] = ["bit-and", "bit-or", "bit-xor"];
 
 proptest! {
+    #![proptest_config(super::runtime_config())]
+
     #[test]
     fn crossprop_bitwise_one_op_int(val in int()) {
         for op in &ONE_OP {
@@ -19,6 +21,8 @@ proptest! {
 }
 
 proptest! {
+    #![proptest_config(super::runtime_config())]
+
     #[test]
     fn crossprop_bitwise_one_op_uint(val in uint()) {
         for op in &ONE_OP {
@@ -30,8 +34,10 @@ proptest! {
 }
 
 proptest! {
+    #![proptest_config(super::runtime_config())]
+
     #[test]
-    fn crossprop_bitwise_two_ops_int(val1 in int(), val2 in uint()) {
+    fn crossprop_bitwise_two_ops(val1 in int(), val2 in uint()) {
         for op in &TWO_OPS {
             crosscheck_compare_only(
                 &format!("({op} {val1} {val2})")
@@ -41,6 +47,8 @@ proptest! {
 }
 
 proptest! {
+    #![proptest_config(super::runtime_config())]
+
     #[test]
     fn crossprop_bitwise_two_ops_uint(val1 in uint(), val2 in uint()) {
         for op in &TWO_OPS {
@@ -52,6 +60,8 @@ proptest! {
 }
 
 proptest! {
+    #![proptest_config(super::runtime_config())]
+
     #[test]
     fn crossprop_bitwise_multi_ops_int(values in proptest::collection::vec(int(), 1..=10)) {
         for op in &MULTI_OPS {
@@ -64,6 +74,8 @@ proptest! {
 }
 
 proptest! {
+    #![proptest_config(super::runtime_config())]
+
     #[test]
     fn crossprop_bitwise_multi_ops_uint(values in proptest::collection::vec(uint(), 1..=10)) {
         for op in &MULTI_OPS {
@@ -72,5 +84,27 @@ proptest! {
                 &format!("({op} {values_str})")
             )
         }
+    }
+}
+
+proptest! {
+    #![proptest_config(super::runtime_config())]
+
+    #[test]
+    fn crossprop_xor_int(val1 in int(), val2 in int()) {
+        crosscheck_compare_only(
+            &format!("(xor {val1} {val2})")
+        )
+    }
+}
+
+proptest! {
+    #![proptest_config(super::runtime_config())]
+
+    #[test]
+    fn crossprop_xor_uint(val1 in uint(), val2 in uint()) {
+        crosscheck_compare_only(
+            &format!("(xor {val1} {val2})")
+        )
     }
 }

--- a/clar2wasm/tests/wasm-generation/bitwise.rs
+++ b/clar2wasm/tests/wasm-generation/bitwise.rs
@@ -3,11 +3,74 @@ use proptest::proptest;
 
 use crate::{int, uint};
 
+const ONE_OP: [&str; 1] = ["bit-not"];
+const TWO_OPS: [&str; 2] = ["bit-shift-left", "bit-shift-right"];
+const MULTI_OPS: [&str; 3] = ["bit-and", "bit-or", "bit-xor"];
+
 proptest! {
   #[test]
-  fn crossprop_bit_shift_left(val in int(), shamt in uint()) {
-    crosscheck_compare_only(
-        &format!("(bit-shift-left {val} {shamt})"),
-    )
+  fn crossprop_bitwise_one_op_int(val in int()) {
+    for op in &ONE_OP {
+        crosscheck_compare_only(
+            &format!("({op} {val})")
+        )
+    }
+  }
+}
+
+proptest! {
+  #[test]
+  fn crossprop_bitwise_one_op_uint(val in uint()) {
+    for op in &ONE_OP {
+        crosscheck_compare_only(
+            &format!("({op} {val})")
+        )
+    }
+  }
+}
+
+proptest! {
+  #[test]
+  fn crossprop_bitwise_two_ops_int(val1 in int(), val2 in int()) {
+    for op in &TWO_OPS {
+        crosscheck_compare_only(
+            &format!("({op} {val1} {val2})")
+        )
+    }
+  }
+}
+
+proptest! {
+  #[test]
+  fn crossprop_bitwise_two_ops_uint(val1 in uint(), val2 in uint()) {
+    for op in &TWO_OPS {
+        crosscheck_compare_only(
+            &format!("({op} {val1} {val2})")
+        )
+    }
+  }
+}
+
+proptest! {
+  #[test]
+  fn crossprop_bitwise_multi_ops_int(values in proptest::collection::vec(int(), 1..=10)) {
+    for op in &MULTI_OPS {
+      let values_str = values.iter().map(|v| v.to_string()).collect::<Vec<_>>().join(" ");
+      crosscheck_compare_only(
+          &format!("({op} {values_str})")
+      )
+    }
+  }
+}
+
+proptest! {
+  #[test]
+  fn crossprop_bitwise_multi_ops_uint(values in proptest::collection::vec(uint(), 1..=10)) {
+    for op in &MULTI_OPS {
+      let values_str = values.iter().map(|v| v.to_string()).collect::<Vec<_>>().join(" ");
+      crosscheck_compare_only(
+          &format!("({op} {values_str})")
+      )
+    }
   }
 }

--- a/clar2wasm/tests/wasm-generation/bitwise.rs
+++ b/clar2wasm/tests/wasm-generation/bitwise.rs
@@ -8,69 +8,69 @@ const TWO_OPS: [&str; 2] = ["bit-shift-left", "bit-shift-right"];
 const MULTI_OPS: [&str; 3] = ["bit-and", "bit-or", "bit-xor"];
 
 proptest! {
-  #[test]
-  fn crossprop_bitwise_one_op_int(val in int()) {
-    for op in &ONE_OP {
-        crosscheck_compare_only(
-            &format!("({op} {val})")
-        )
+    #[test]
+    fn crossprop_bitwise_one_op_int(val in int()) {
+        for op in &ONE_OP {
+            crosscheck_compare_only(
+                &format!("({op} {val})")
+            )
+        }
     }
-  }
 }
 
 proptest! {
-  #[test]
-  fn crossprop_bitwise_one_op_uint(val in uint()) {
-    for op in &ONE_OP {
-        crosscheck_compare_only(
-            &format!("({op} {val})")
-        )
+    #[test]
+    fn crossprop_bitwise_one_op_uint(val in uint()) {
+        for op in &ONE_OP {
+            crosscheck_compare_only(
+                &format!("({op} {val})")
+            )
+        }
     }
-  }
 }
 
 proptest! {
-  #[test]
-  fn crossprop_bitwise_two_ops_int(val1 in int(), val2 in int()) {
-    for op in &TWO_OPS {
-        crosscheck_compare_only(
-            &format!("({op} {val1} {val2})")
-        )
+    #[test]
+    fn crossprop_bitwise_two_ops_int(val1 in int(), val2 in uint()) {
+        for op in &TWO_OPS {
+            crosscheck_compare_only(
+                &format!("({op} {val1} {val2})")
+            )
+        }
     }
-  }
 }
 
 proptest! {
-  #[test]
-  fn crossprop_bitwise_two_ops_uint(val1 in uint(), val2 in uint()) {
-    for op in &TWO_OPS {
-        crosscheck_compare_only(
-            &format!("({op} {val1} {val2})")
-        )
+    #[test]
+    fn crossprop_bitwise_two_ops_uint(val1 in uint(), val2 in uint()) {
+        for op in &TWO_OPS {
+            crosscheck_compare_only(
+                &format!("({op} {val1} {val2})")
+            )
+        }
     }
-  }
 }
 
 proptest! {
-  #[test]
-  fn crossprop_bitwise_multi_ops_int(values in proptest::collection::vec(int(), 1..=10)) {
-    for op in &MULTI_OPS {
-      let values_str = values.iter().map(|v| v.to_string()).collect::<Vec<_>>().join(" ");
-      crosscheck_compare_only(
-          &format!("({op} {values_str})")
-      )
+    #[test]
+    fn crossprop_bitwise_multi_ops_int(values in proptest::collection::vec(int(), 1..=10)) {
+        for op in &MULTI_OPS {
+            let values_str = values.iter().map(|v| v.to_string()).collect::<Vec<_>>().join(" ");
+            crosscheck_compare_only(
+                &format!("({op} {values_str})")
+            )
+        }
     }
-  }
 }
 
 proptest! {
-  #[test]
-  fn crossprop_bitwise_multi_ops_uint(values in proptest::collection::vec(uint(), 1..=10)) {
-    for op in &MULTI_OPS {
-      let values_str = values.iter().map(|v| v.to_string()).collect::<Vec<_>>().join(" ");
-      crosscheck_compare_only(
-          &format!("({op} {values_str})")
-      )
+    #[test]
+    fn crossprop_bitwise_multi_ops_uint(values in proptest::collection::vec(uint(), 1..=10)) {
+        for op in &MULTI_OPS {
+            let values_str = values.iter().map(|v| v.to_string()).collect::<Vec<_>>().join(" ");
+            crosscheck_compare_only(
+                &format!("({op} {values_str})")
+            )
+        }
     }
-  }
 }

--- a/clar2wasm/tests/wasm-generation/blockinfo.rs
+++ b/clar2wasm/tests/wasm-generation/blockinfo.rs
@@ -1,7 +1,7 @@
-use clar2wasm::tools::{crosscheck_compare_only, TestEnvironment};
+use clar2wasm::tools::{crosscheck_compare_advancing_tip_by, crosscheck_compare_only};
 use proptest::proptest;
 
-use crate::{block_range, uint};
+use crate::uint;
 
 const BLOCK_INFO: [&str; 8] = [
     "burnchain-header-hash",
@@ -19,13 +19,10 @@ const BURN_BLOCK_HEIGHT_LIMIT: u32 = 100;
 
 proptest! {
     #[test]
-    fn crossprop_blockinfo_within_controlled_range(block_height in block_range(STACKS_BLOCK_HEIGHT_LIMIT)) {
-        let mut env = TestEnvironment::default();
-        env.advance_chain_tip(STACKS_BLOCK_HEIGHT_LIMIT);
-
+    fn crossprop_blockinfo_within_controlled_range(block_height in 1..=STACKS_BLOCK_HEIGHT_LIMIT) {
         for info in &BLOCK_INFO {
-            crosscheck_compare_only(
-                &format!("(get-block-info? {info} {block_height})")
+            crosscheck_compare_advancing_tip_by(
+                &format!("(get-block-info? {info} u{block_height})"), 80
             )
         }
     }
@@ -35,7 +32,6 @@ proptest! {
     #[test]
     fn crossprop_blockinfo(block_height in uint()) {
         for info in &BLOCK_INFO {
-            println!("Here!");
             crosscheck_compare_only(
                 &format!("(get-block-info? {info} {block_height})")
             )
@@ -45,13 +41,10 @@ proptest! {
 
 proptest! {
     #[test]
-    fn crossprop_blockinfo_burnchain_within_controlled_range(block_height in block_range(BURN_BLOCK_HEIGHT_LIMIT)) {
-        let mut env = TestEnvironment::default();
-        env.advance_chain_tip(STACKS_BLOCK_HEIGHT_LIMIT);
-
+    fn crossprop_blockinfo_burnchain_within_controlled_range(block_height in 1..=BURN_BLOCK_HEIGHT_LIMIT) {
         for info in &BURN_BLOCK_INFO {
-            crosscheck_compare_only(
-                &format!("(get-burn-block-info? {info} {block_height})")
+            crosscheck_compare_advancing_tip_by(
+                &format!("(get-burn-block-info? {info} u{block_height})"), 80
             )
         }
     }

--- a/clar2wasm/tests/wasm-generation/blockinfo.rs
+++ b/clar2wasm/tests/wasm-generation/blockinfo.rs
@@ -1,0 +1,69 @@
+use clar2wasm::tools::{crosscheck_compare_only, TestEnvironment};
+use proptest::proptest;
+
+use crate::{block_range, uint};
+
+const BLOCK_INFO: [&str; 8] = [
+    "burnchain-header-hash",
+    "id-header-hash",
+    "header-hash",
+    "miner-address",
+    "block-reward",
+    "miner-spend-total",
+    "miner-spend-winner",
+    "time",
+];
+const BURN_BLOCK_INFO: [&str; 2] = ["header-hash", "pox-addrs"];
+const STACKS_BLOCK_HEIGHT_LIMIT: u32 = 100;
+const BURN_BLOCK_HEIGHT_LIMIT: u32 = 100;
+
+proptest! {
+    #[test]
+    fn crossprop_blockinfo_within_controlled_range(block_height in block_range(STACKS_BLOCK_HEIGHT_LIMIT)) {
+        let mut env = TestEnvironment::default();
+        env.advance_chain_tip(STACKS_BLOCK_HEIGHT_LIMIT);
+
+        for info in &BLOCK_INFO {
+            crosscheck_compare_only(
+                &format!("(get-block-info? {info} {block_height})")
+            )
+        }
+    }
+}
+
+proptest! {
+    #[test]
+    fn crossprop_blockinfo(block_height in uint()) {
+        for info in &BLOCK_INFO {
+            println!("Here!");
+            crosscheck_compare_only(
+                &format!("(get-block-info? {info} {block_height})")
+            )
+        }
+    }
+}
+
+proptest! {
+    #[test]
+    fn crossprop_blockinfo_burnchain_within_controlled_range(block_height in block_range(BURN_BLOCK_HEIGHT_LIMIT)) {
+        let mut env = TestEnvironment::default();
+        env.advance_chain_tip(STACKS_BLOCK_HEIGHT_LIMIT);
+
+        for info in &BURN_BLOCK_INFO {
+            crosscheck_compare_only(
+                &format!("(get-burn-block-info? {info} {block_height})")
+            )
+        }
+    }
+}
+
+proptest! {
+    #[test]
+    fn crossprop_blockinfo_burnchain(block_height in uint()) {
+        for info in &BURN_BLOCK_INFO {
+            crosscheck_compare_only(
+                &format!("(get-burn-block-info? {info} {block_height})")
+            )
+        }
+    }
+}

--- a/clar2wasm/tests/wasm-generation/blockinfo.rs
+++ b/clar2wasm/tests/wasm-generation/blockinfo.rs
@@ -1,4 +1,4 @@
-use clar2wasm::tools::{crosscheck_compare_advancing_tip_by, crosscheck_compare_only};
+use clar2wasm::tools::{crosscheck_compare_only, crosscheck_compare_only_advancing_tip};
 use proptest::proptest;
 
 use crate::uint;
@@ -23,9 +23,7 @@ proptest! {
     #[test]
     fn crossprop_blockinfo_within_controlled_range(block_height in 1..=STACKS_BLOCK_HEIGHT_LIMIT) {
         for info in &BLOCK_INFO {
-            crosscheck_compare_advancing_tip_by(
-                &format!("(get-block-info? {info} u{block_height})"), 80
-            )
+            crosscheck_compare_only_advancing_tip(&format!("(get-block-info? {info} u{block_height})"), 80)
         }
     }
 }
@@ -49,7 +47,7 @@ proptest! {
     # [test]
     fn crossprop_blockinfo_burnchain_within_controlled_range(block_height in 1..=BURN_BLOCK_HEIGHT_LIMIT) {
         for info in &BURN_BLOCK_INFO {
-            crosscheck_compare_advancing_tip_by(
+            crosscheck_compare_only_advancing_tip(
                 &format!("(get-burn-block-info? {info} u{block_height})"), 80
             )
         }

--- a/clar2wasm/tests/wasm-generation/blockinfo.rs
+++ b/clar2wasm/tests/wasm-generation/blockinfo.rs
@@ -1,7 +1,5 @@
-use clar2wasm::tools::{crosscheck_compare_only, crosscheck_compare_only_advancing_tip};
+use clar2wasm::tools::crosscheck_compare_only_advancing_tip;
 use proptest::proptest;
-
-use crate::uint;
 
 const BLOCK_INFO: [&str; 8] = [
     "burnchain-header-hash",
@@ -31,37 +29,11 @@ proptest! {
 proptest! {
     #![proptest_config(super::runtime_config())]
 
-    #[test]
-    fn crossprop_blockinfo(block_height in uint()) {
-        for info in &BLOCK_INFO {
-            crosscheck_compare_only(
-                &format!("(get-block-info? {info} {block_height})")
-            )
-        }
-    }
-}
-
-proptest! {
-    #![proptest_config(super::runtime_config())]
-
     # [test]
     fn crossprop_blockinfo_burnchain_within_controlled_range(block_height in 1..=BURN_BLOCK_HEIGHT_LIMIT, tip in 1..=80u32) {
         for info in &BURN_BLOCK_INFO {
             crosscheck_compare_only_advancing_tip(
                 &format!("(get-burn-block-info? {info} u{block_height})"), tip
-            )
-        }
-    }
-}
-
-proptest! {
-    #![proptest_config(super::runtime_config())]
-
-    #[test]
-    fn crossprop_blockinfo_burnchain(block_height in uint()) {
-        for info in &BURN_BLOCK_INFO {
-            crosscheck_compare_only(
-                &format!("(get-burn-block-info? {info} {block_height})")
             )
         }
     }

--- a/clar2wasm/tests/wasm-generation/blockinfo.rs
+++ b/clar2wasm/tests/wasm-generation/blockinfo.rs
@@ -21,9 +21,9 @@ proptest! {
     #![proptest_config(super::runtime_config())]
 
     #[test]
-    fn crossprop_blockinfo_within_controlled_range(block_height in 1..=STACKS_BLOCK_HEIGHT_LIMIT) {
+    fn crossprop_blockinfo_within_controlled_range(block_height in 1..=STACKS_BLOCK_HEIGHT_LIMIT, tip in 1..=80u32) {
         for info in &BLOCK_INFO {
-            crosscheck_compare_only_advancing_tip(&format!("(get-block-info? {info} u{block_height})"), 80)
+            crosscheck_compare_only_advancing_tip(&format!("(get-block-info? {info} u{block_height})"), tip)
         }
     }
 }
@@ -45,10 +45,10 @@ proptest! {
     #![proptest_config(super::runtime_config())]
 
     # [test]
-    fn crossprop_blockinfo_burnchain_within_controlled_range(block_height in 1..=BURN_BLOCK_HEIGHT_LIMIT) {
+    fn crossprop_blockinfo_burnchain_within_controlled_range(block_height in 1..=BURN_BLOCK_HEIGHT_LIMIT, tip in 1..=80u32) {
         for info in &BURN_BLOCK_INFO {
             crosscheck_compare_only_advancing_tip(
-                &format!("(get-burn-block-info? {info} u{block_height})"), 80
+                &format!("(get-burn-block-info? {info} u{block_height})"), tip
             )
         }
     }

--- a/clar2wasm/tests/wasm-generation/blockinfo.rs
+++ b/clar2wasm/tests/wasm-generation/blockinfo.rs
@@ -18,6 +18,8 @@ const STACKS_BLOCK_HEIGHT_LIMIT: u32 = 100;
 const BURN_BLOCK_HEIGHT_LIMIT: u32 = 100;
 
 proptest! {
+    #![proptest_config(super::runtime_config())]
+
     #[test]
     fn crossprop_blockinfo_within_controlled_range(block_height in 1..=STACKS_BLOCK_HEIGHT_LIMIT) {
         for info in &BLOCK_INFO {
@@ -29,6 +31,8 @@ proptest! {
 }
 
 proptest! {
+    #![proptest_config(super::runtime_config())]
+
     #[test]
     fn crossprop_blockinfo(block_height in uint()) {
         for info in &BLOCK_INFO {
@@ -40,7 +44,9 @@ proptest! {
 }
 
 proptest! {
-    #[test]
+    #![proptest_config(super::runtime_config())]
+
+    # [test]
     fn crossprop_blockinfo_burnchain_within_controlled_range(block_height in 1..=BURN_BLOCK_HEIGHT_LIMIT) {
         for info in &BURN_BLOCK_INFO {
             crosscheck_compare_advancing_tip_by(
@@ -51,6 +57,8 @@ proptest! {
 }
 
 proptest! {
+    #![proptest_config(super::runtime_config())]
+
     #[test]
     fn crossprop_blockinfo_burnchain(block_height in uint()) {
         for info in &BURN_BLOCK_INFO {

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -2,6 +2,7 @@
 pub mod arithmetic;
 pub mod bindings;
 pub mod bitwise;
+pub mod blockinfo;
 pub mod conditionals;
 pub mod default_to;
 pub mod equal;


### PR DESCRIPTION
Initial pull request with some `crossprop` tests:

- bitwise
- blockinfo

I would like to validate the approach in this PR to make it the base for other implementations.