### PR TITLE
Property test for `append`

### DIFF
--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -270,7 +270,7 @@ impl ComplexWord for Append {
         // top of the stack.
         let list = args.get_expr(0)?;
         // WORKAROUND: setting types of list argument
-        generator.set_expr_type(list, ty.clone());
+        generator.set_expr_type(list, ty.clone())?;
         generator.traverse_expr(builder, list)?;
 
         // The stack now has the destination, source and length arguments in
@@ -292,7 +292,7 @@ impl ComplexWord for Append {
         // WORKAROUND: setting type of elem
         match ty {
             TypeSignature::SequenceType(SequenceSubtype::ListType(ltd)) => {
-                generator.set_expr_type(elem, ltd.get_list_item_type().clone())
+                generator.set_expr_type(elem, ltd.get_list_item_type().clone())?;
             }
             _ => {
                 return Err(GeneratorError::TypeError(

--- a/clar2wasm/tests/wasm-generation/sequences.rs
+++ b/clar2wasm/tests/wasm-generation/sequences.rs
@@ -1,0 +1,18 @@
+use clar2wasm::tools::crosscheck;
+use clarity::vm::Value;
+use proptest::proptest;
+use proptest::strategy::Strategy as _;
+
+use crate::{prop_signature, PropValue};
+
+proptest! {
+    #[test]
+    fn append_value_to_list(mut values in (prop_signature(), 1usize..32).prop_flat_map(|(ty, size)| PropValue::many_from_type(ty, size))) {
+        let expected = Value::cons_list_unsanitized(values.iter().cloned().map(Value::from).collect()).unwrap();
+
+        let elem = values.pop().unwrap();
+        let values = PropValue::try_from(values).unwrap();
+
+        crosscheck(&format!("(append {values} {elem})"), Ok(Some(expected)))
+    }
+}


### PR DESCRIPTION
Added a property test for `append`.
This is part of #266

It showed that the function needed the classic "typechecker workaround".