### PR TITLE
Property test for simple sequence functions

### DIFF
--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -154,8 +154,11 @@ impl PropValue {
             });
         // TODO: add string-utf8
         prop_oneof![
+            // 10% chance for a buffer
             1 => buffer(size as u32),
+            // 10% chance for a string-ascii
             1 => string_ascii(size as u32),
+            // 80% chance for a list
             8 => any_list
         ]
         .prop_map_into()

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -274,7 +274,7 @@ fn response(ok_ty: TypeSignature, err_ty: TypeSignature) -> impl Strategy<Value 
 fn list(list_type_data: ListTypeData) -> impl Strategy<Value = Value> {
     prop::collection::vec(
         prop_value(list_type_data.get_list_item_type().clone()),
-        0..list_type_data.get_max_len() as usize,
+        0..=list_type_data.get_max_len() as usize,
     )
     .prop_map(move |v| {
         Value::Sequence(SequenceData::List(ListData {

--- a/clar2wasm/tests/wasm-generation/sequences.rs
+++ b/clar2wasm/tests/wasm-generation/sequences.rs
@@ -49,3 +49,17 @@ proptest! {
         crosscheck(&snippet, Ok(Some(expected)));
     }
 }
+
+proptest! {
+    #[test]
+    fn element_at_crosscheck((seq, idx) in (1usize..=32).prop_flat_map(|max_len| (PropValue::any_sequence(max_len), (0..max_len)))) {
+        let snippet = format!("(element-at? {seq} u{idx})");
+
+        let expected = {
+            let Value::Sequence(seq_data) = seq.into() else { unreachable!() };
+            seq_data.element_at(idx).map_or_else(Value::none, |v| Value::some(v).unwrap())
+        };
+
+        crosscheck(&snippet, Ok(Some(expected)));
+    }
+}

--- a/clar2wasm/tests/wasm-generation/sequences.rs
+++ b/clar2wasm/tests/wasm-generation/sequences.rs
@@ -1,8 +1,6 @@
 use clar2wasm::tools::crosscheck;
-use clarity::vm::{
-    types::{SequenceData, TypeSignature},
-    Value,
-};
+use clarity::vm::types::{SequenceData, TypeSignature};
+use clarity::vm::Value;
 use proptest::prelude::*;
 
 use crate::{prop_signature, PropValue};

--- a/clar2wasm/tests/wasm-generation/sequences.rs
+++ b/clar2wasm/tests/wasm-generation/sequences.rs
@@ -37,7 +37,7 @@ proptest! {
 
 proptest! {
     #[test]
-    fn concat_crosscheck((seq1, seq2) in (0usize..=16).prop_flat_map(PropValue::any_sequence).prop_ind_flat_map2(|seq1| PropValue::from_type(dbg!(TypeSignature::type_of(&seq1.into()))))) {
+    fn concat_crosscheck((seq1, seq2) in (0usize..=16).prop_flat_map(PropValue::any_sequence).prop_ind_flat_map2(|seq1| PropValue::from_type(TypeSignature::type_of(&seq1.into())))) {
         let snippet = format!("(concat {seq1} {seq2})");
 
         let expected = {

--- a/clar2wasm/tests/wasm-generation/sequences.rs
+++ b/clar2wasm/tests/wasm-generation/sequences.rs
@@ -1,7 +1,6 @@
 use clar2wasm::tools::crosscheck;
 use clarity::vm::Value;
-use proptest::proptest;
-use proptest::strategy::Strategy as _;
+use proptest::prelude::*;
 
 use crate::{prop_signature, PropValue};
 
@@ -14,5 +13,23 @@ proptest! {
         let values = PropValue::try_from(values).unwrap();
 
         crosscheck(&format!("(append {values} {elem})"), Ok(Some(expected)))
+    }
+}
+
+proptest! {
+    #[test]
+    fn as_max_len_equal_max_len_is_some((max_len, value) in (0usize..=16).prop_ind_flat_map2(PropValue::any_sequence)) {
+        crosscheck(
+            &format!("(as-max-len? {value} u{max_len})"),
+            Ok(Some(Value::some(value.into()).unwrap()))
+        )
+    }
+
+    #[test]
+    fn as_max_len_smaller_than_len_is_none((max_len, value) in (1usize..=16).prop_ind_flat_map2(PropValue::any_sequence)) {
+        crosscheck(
+            &format!("(as-max-len? {value} u{})", max_len-1),
+            Ok(Some(Value::none()))
+        )
     }
 }

--- a/clar2wasm/tests/wasm-generation/sequences.rs
+++ b/clar2wasm/tests/wasm-generation/sequences.rs
@@ -63,3 +63,17 @@ proptest! {
         crosscheck(&snippet, Ok(Some(expected)));
     }
 }
+
+proptest! {
+    #[test]
+    fn len_crosscheck(seq in (1usize..=32).prop_flat_map(PropValue::any_sequence)) {
+        let snippet = format!("(len {seq})");
+
+        let expected = {
+            let Value::Sequence(seq_data) = seq.into() else { unreachable!() };
+            Value::UInt(seq_data.len() as u128)
+        };
+
+        crosscheck(&snippet, Ok(Some(expected)));
+    }
+}

--- a/clar2wasm/tests/wasm-generation/sequences.rs
+++ b/clar2wasm/tests/wasm-generation/sequences.rs
@@ -37,7 +37,7 @@ proptest! {
 proptest! {
     #[test]
     fn concat_crosscheck((seq1, seq2) in (0usize..=16).prop_flat_map(PropValue::any_sequence).prop_ind_flat_map2(|seq1| PropValue::from_type(dbg!(TypeSignature::type_of(&seq1.into()))))) {
-        let snippet = dbg!(format!("(concat {seq1} {seq2})"));
+        let snippet = format!("(concat {seq1} {seq2})");
 
         let expected = {
             let Value::Sequence(mut seq_data1) = seq1.into() else { unreachable!() };


### PR DESCRIPTION
This PR adds property tests for `as-max-len?`, which is a part of #266.
UPDATE: adds also tests for `concat`, `element-at?`, `len` and `slice`.

There is the typechecker workaround fix for `concat`.

~~To be fair, this was mostly for adding a new method for `PropValue` which allows to generate any kind of sequence. This will be useful for the coming tests of the remaining functions in the linked issue.~~