### PR TITLE
Add principal generation to `PropValue`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,7 +539,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.2.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=45843513a#45843513a18a44f7dd90f9dfb2756f6313249db1"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=345553357be556fe53474071d09cd453549ed02e#345553357be556fe53474071d09cd453549ed02e"
 dependencies = [
  "integer-sqrt",
  "lazy_static",
@@ -2721,7 +2721,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#45843513a18a44f7dd90f9dfb2756f6313249db1"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#345553357be556fe53474071d09cd453549ed02e"
 dependencies = [
  "chrono",
  "curve25519-dalek",

--- a/clar2wasm/Cargo.toml
+++ b/clar2wasm/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 build = "build.rs"
 
 [dependencies]
-clarity = { git = "https://github.com/stacks-network/stacks-core.git", rev = "45843513a" }
+clarity = { git = "https://github.com/stacks-network/stacks-core.git", rev = "345553357be556fe53474071d09cd453549ed02e" }
 clap = { version = "4.3.17", features = ["derive"] }
 regex = "1.9.1"
 walrus = "0.20.1"

--- a/clar2wasm/src/deserialize.rs
+++ b/clar2wasm/src/deserialize.rs
@@ -227,7 +227,7 @@ impl WasmGenerator {
 
                     // Push the offset and length onto the stack
                     then.local_get(result_offset)
-                        .i32_const(PRINCIPAL_BYTES as i32);
+                        .i32_const(STANDARD_PRINCIPAL_BYTES as i32);
 
                     // Break out of the block
                     then.br(block_id);

--- a/clar2wasm/src/lib.rs
+++ b/clar2wasm/src/lib.rs
@@ -95,6 +95,7 @@ pub fn compile(
 
     // Now that the typechecker pass is done, we can concretize the expressions types which
     // might contain `ListUnionType` or `CallableType`
+    #[allow(clippy::expect_used)]
     match contract_analysis.type_map.as_mut() {
         Some(typemap) => typemap.concretize().map_err(|e| {
             diagnostics.push(e.diagnostic);

--- a/clar2wasm/src/lib.rs
+++ b/clar2wasm/src/lib.rs
@@ -93,6 +93,25 @@ pub fn compile(
         }
     };
 
+    // Now that the typechecker pass is done, we can concretize the expressions types which
+    // might contain `ListUnionType` or `CallableType`
+    match contract_analysis.type_map.as_mut() {
+        Some(typemap) => typemap.concretize().map_err(|e| {
+            diagnostics.push(e.diagnostic);
+            CompileError::Generic {
+                ast: ast.clone(),
+                diagnostics: diagnostics.clone(),
+                cost_tracker: Box::new(
+                    contract_analysis
+                        .cost_track
+                        .take()
+                        .expect("Failed to take cost tracker from contract analysis"),
+                ),
+            }
+        })?,
+        None => unreachable!("Typechecker was called at that moment"),
+    }
+
     #[allow(clippy::expect_used)]
     match WasmGenerator::new(contract_analysis.clone()).and_then(WasmGenerator::generate) {
         Ok(module) => Ok(CompileResult {

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -13,7 +13,7 @@ pub mod values;
 
 use std::env;
 
-const DEFAULT_CASES: u32 = 100;
+const DEFAULT_CASES: u32 = 10;
 
 fn runtime_config() -> ProptestConfig {
     let cases_string = env::var("PROPTEST_CASES").unwrap_or_default();

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -212,10 +212,10 @@ fn prop_value(ty: TypeSignature) -> impl Strategy<Value = Value> {
         TypeSignature::PrincipalType => {
             prop_oneof![standard_principal(), qualified_principal()].boxed()
         }
+        TypeSignature::ListUnionType(_) => todo!(),
         // TODO
         TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::UTF8(_))) => todo!(),
         TypeSignature::CallableType(_) => todo!(),
-        TypeSignature::ListUnionType(_) => todo!(),
         TypeSignature::TraitReferenceType(_) => todo!(),
     }
 }
@@ -330,7 +330,7 @@ fn standard_principal() -> impl Strategy<Value = Value> {
         .no_shrink()
 }
 
-pub fn qualified_principal() -> impl Strategy<Value = Value> {
+fn qualified_principal() -> impl Strategy<Value = Value> {
     (standard_principal(), "[a-zA-Z]{1,40}").prop_map(|(issuer_value, name)| {
         let Value::Principal(PrincipalData::Standard(issuer)) = issuer_value else {
             unreachable!()

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -13,7 +13,7 @@ pub mod values;
 
 use std::env;
 
-const DEFAULT_CASES: u32 = 10;
+const DEFAULT_CASES: u32 = 100;
 
 fn runtime_config() -> ProptestConfig {
     let cases_string = env::var("PROPTEST_CASES").unwrap_or_default();
@@ -26,10 +26,12 @@ fn runtime_config() -> ProptestConfig {
 }
 
 use clarity::vm::types::{
-    ASCIIData, BuffData, CharType, ListData, ListTypeData, OptionalData, ResponseData,
-    SequenceData, SequenceSubtype, StringSubtype, StringUTF8Length, TupleData, TupleTypeSignature,
+    ASCIIData, BuffData, CharType, ListData, ListTypeData, OptionalData, PrincipalData,
+    QualifiedContractIdentifier, ResponseData, SequenceData, SequenceSubtype,
+    StandardPrincipalData, StringSubtype, StringUTF8Length, TupleData, TupleTypeSignature,
     TypeSignature, Value, MAX_VALUE_SIZE,
 };
+use clarity::vm::ContractName;
 use proptest::prelude::*;
 
 pub fn prop_signature() -> impl Strategy<Value = TypeSignature> {
@@ -43,7 +45,7 @@ pub fn prop_signature() -> impl Strategy<Value = TypeSignature> {
         (0u32..128).prop_map(|s| TypeSignature::SequenceType(SequenceSubtype::StringType(
             StringSubtype::ASCII(s.try_into().unwrap())
         ))),
-        // TODO: principal,
+        Just(TypeSignature::PrincipalType),
         // TODO: string-utf8
     ];
     leaf.prop_recursive(5, 64, 10, |inner| {
@@ -112,6 +114,7 @@ impl std::fmt::Display for PropValue {
                 }
                 write!(f, "\"")
             }
+            Value::Principal(p) => write!(f, "'{p}"),
             Value::Optional(OptionalData { data }) => match data {
                 Some(inner) => write!(f, "(some {})", PropValue(*inner.clone())),
                 None => write!(f, "none"),
@@ -206,9 +209,10 @@ fn prop_value(ty: TypeSignature) -> impl Strategy<Value = Value> {
             list(list_type_data).boxed()
         }
         TypeSignature::TupleType(tuple_ty) => tuple(tuple_ty).boxed(),
-
+        TypeSignature::PrincipalType => {
+            prop_oneof![standard_principal(), qualified_principal()].boxed()
+        }
         // TODO
-        TypeSignature::PrincipalType => todo!(),
         TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::UTF8(_))) => todo!(),
         TypeSignature::CallableType(_) => todo!(),
         TypeSignature::ListUnionType(_) => todo!(),
@@ -312,6 +316,30 @@ fn tuple(tuple_ty: TupleTypeSignature) -> impl Strategy<Value = Value> {
             data_map: fields.clone().into_iter().zip(vec_values).collect(),
         }
         .into()
+    })
+}
+
+fn standard_principal() -> impl Strategy<Value = Value> {
+    (0u8..32, prop::collection::vec(any::<u8>(), 20))
+        .prop_map(|(v, hash)| {
+            Value::Principal(PrincipalData::Standard(StandardPrincipalData(
+                v,
+                hash.try_into().unwrap(),
+            )))
+        })
+        .no_shrink()
+}
+
+pub fn qualified_principal() -> impl Strategy<Value = Value> {
+    (standard_principal(), "[a-zA-Z]{1,40}").prop_map(|(issuer_value, name)| {
+        let Value::Principal(PrincipalData::Standard(issuer)) = issuer_value else {
+            unreachable!()
+        };
+        let name = ContractName::from(&*name);
+        Value::Principal(PrincipalData::Contract(QualifiedContractIdentifier {
+            issuer,
+            name,
+        }))
     })
 }
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 path = "./src/lib.rs"
 
 [dependencies]
-clarity = { git = "https://github.com/stacks-network/stacks-core.git", rev = "45843513a" }
+clarity = { git = "https://github.com/stacks-network/stacks-core.git", rev = "345553357be556fe53474071d09cd453549ed02e" }
 clar2wasm = { path = "../clar2wasm", features = ["developer-mode"] }
 wasmtime = "15.0.0"
 


### PR DESCRIPTION
This PR adds the possibility to generate `principal` type for `PropValue`. Accidentally, it can also generate lists with their entry type set to `ListUnionType` when we generate a list of qualified principals.

This PR fixes the usage of principal:
- by fixing the memory issues in https://github.com/stacks-network/stacks-core/pull/4338
- by concretizing all `ListUnionType`s in expressions after the type checking
- by fixing the deserialization process, which pushed the wrong number of bytes to the reference result

Fixes #305 
Fixes #274