### PR TITLE
Fixes for some oopsies in sequences proptests

### DIFF
--- a/clar2wasm/tests/wasm-generation/sequences.rs
+++ b/clar2wasm/tests/wasm-generation/sequences.rs
@@ -117,6 +117,6 @@ proptest! {
 fn extract_sequence(sequence: PropValue) -> SequenceData {
     match Value::from(sequence) {
         Value::Sequence(seq_data) => seq_data,
-        _ => unreachable!(),
+        _ => panic!("Should only call this function on the result of PropValue::any_sequence"),
     }
 }

--- a/clar2wasm/tests/wasm-generation/sequences.rs
+++ b/clar2wasm/tests/wasm-generation/sequences.rs
@@ -7,6 +7,7 @@ use crate::{prop_signature, PropValue};
 
 proptest! {
     #![proptest_config(super::runtime_config())]
+
     #[test]
     fn append_value_to_list(mut values in (prop_signature(), 1usize..32).prop_flat_map(|(ty, size)| PropValue::many_from_type(ty, size))) {
         let expected = Value::cons_list_unsanitized(values.iter().cloned().map(Value::from).collect()).unwrap();
@@ -19,6 +20,8 @@ proptest! {
 }
 
 proptest! {
+    #![proptest_config(super::runtime_config())]
+
     #[test]
     fn as_max_len_equal_max_len_is_some((max_len, value) in (0usize..=16).prop_ind_flat_map2(PropValue::any_sequence)) {
         crosscheck(
@@ -37,6 +40,8 @@ proptest! {
 }
 
 proptest! {
+    #![proptest_config(super::runtime_config())]
+
     #[test]
     fn concat_crosscheck((seq1, seq2) in (0usize..=16).prop_flat_map(PropValue::any_sequence).prop_ind_flat_map2(|seq1| PropValue::from_type(TypeSignature::type_of(&seq1.into())))) {
         let snippet = format!("(concat {seq1} {seq2})");
@@ -53,6 +58,8 @@ proptest! {
 }
 
 proptest! {
+    #![proptest_config(super::runtime_config())]
+
     #[test]
     fn element_at_crosscheck((seq, idx) in (1usize..=32).prop_flat_map(|max_len| (PropValue::any_sequence(max_len), (0..max_len)))) {
         let snippet = format!("(element-at? {seq} u{idx})");
@@ -67,6 +74,8 @@ proptest! {
 }
 
 proptest! {
+    #![proptest_config(super::runtime_config())]
+
     #[test]
     fn len_crosscheck(seq in (1usize..=32).prop_flat_map(PropValue::any_sequence)) {
         let snippet = format!("(len {seq})");
@@ -81,6 +90,8 @@ proptest! {
 }
 
 proptest! {
+    #![proptest_config(super::runtime_config())]
+
     #[test]
     fn slice_crosscheck_valid_range(
         (seq, lo, hi) in (1usize..=32)

--- a/clar2wasm/tests/wasm-generation/sequences.rs
+++ b/clar2wasm/tests/wasm-generation/sequences.rs
@@ -61,7 +61,7 @@ proptest! {
     #![proptest_config(super::runtime_config())]
 
     #[test]
-    fn element_at_crosscheck((seq, idx) in (1usize..=32).prop_flat_map(|max_len| (PropValue::any_sequence(max_len), (0..max_len)))) {
+    fn element_at_crosscheck((seq, idx) in (1usize..=16).prop_flat_map(|max_len| (PropValue::any_sequence(max_len), (0..max_len)))) {
         let snippet = format!("(element-at? {seq} u{idx})");
 
         let expected = {
@@ -77,7 +77,7 @@ proptest! {
     #![proptest_config(super::runtime_config())]
 
     #[test]
-    fn len_crosscheck(seq in (1usize..=32).prop_flat_map(PropValue::any_sequence)) {
+    fn len_crosscheck(seq in (1usize..=16).prop_flat_map(PropValue::any_sequence)) {
         let snippet = format!("(len {seq})");
 
         let expected = {
@@ -94,7 +94,7 @@ proptest! {
 
     #[test]
     fn slice_crosscheck_valid_range(
-        (seq, lo, hi) in (1usize..=32)
+        (seq, lo, hi) in (1usize..=16)
         .prop_flat_map(PropValue::any_sequence)
         .prop_ind_flat_map2(|seq| 0..extract_sequence(seq).len())
         .prop_ind_flat_map2(|(seq, lo)| lo..extract_sequence(seq).len())


### PR DESCRIPTION
This PR fixes a few oopsies of mine in the sequences crossprop tests:
- I forgot to add the `proptest_config`
- I used an `unreachable!` instead of a `panic!`
- I tried to mitigate the `ValueTooLarge` errors by reducing the maximum number of elements per lists in generated `any_sequences`.