### PR TITLE
Fix top-level return value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,7 +539,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.2.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=345553357be556fe53474071d09cd453549ed02e#345553357be556fe53474071d09cd453549ed02e"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=75ee7718db5b251adf7bc3fcd769b78859310d54#75ee7718db5b251adf7bc3fcd769b78859310d54"
 dependencies = [
  "integer-sqrt",
  "lazy_static",

--- a/clar2wasm/Cargo.toml
+++ b/clar2wasm/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 build = "build.rs"
 
 [dependencies]
-clarity = { git = "https://github.com/stacks-network/stacks-core.git", rev = "345553357be556fe53474071d09cd453549ed02e" }
+clarity = { git = "https://github.com/stacks-network/stacks-core.git", rev = "75ee7718db5b251adf7bc3fcd769b78859310d54" }
 clap = { version = "4.3.17", features = ["derive"] }
 regex = "1.9.1"
 walrus = "0.20.1"

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -265,9 +265,9 @@ impl WasmGenerator {
 
     pub fn generate(mut self) -> Result<Module, GeneratorError> {
         let expressions = std::mem::take(&mut self.contract_analysis.expressions);
-        // println!("{:?}", expressions);
 
-        // Get the type of the last top-level expression
+        // Get the type of the last top-level expression with a return value
+        // or default to `None`.
         let return_ty = expressions
             .iter()
             .rev()
@@ -1698,7 +1698,20 @@ mod misc_tests {
     }
 
     #[test]
-    fn top_level_result_some() {
+    fn top_level_result_some_last() {
+        crosscheck(
+            "
+(define-private (foo) 42)
+(define-public (bar)
+  (ok true))
+(foo)
+",
+            evaluate("42"),
+        );
+    }
+
+    #[test]
+    fn top_level_result_some_not_last() {
         crosscheck(
             "
 (define-public (foo)

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -1084,7 +1084,6 @@ impl WasmGenerator {
         let mut last_ty = None;
         // Traverse the statements, saving the last non-none value.
         for stmt in statements {
-            self.traverse_expr(builder, stmt)?;
             // If stmt has a type, save that type. If there was a previous type
             // saved, then drop that value.
             if let Some(ty) = self.get_expr_type(stmt) {
@@ -1093,6 +1092,7 @@ impl WasmGenerator {
                 }
                 last_ty = Some(ty.clone());
             }
+            self.traverse_expr(builder, stmt)?;
         }
 
         Ok(())

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 path = "./src/lib.rs"
 
 [dependencies]
-clarity = { git = "https://github.com/stacks-network/stacks-core.git", rev = "345553357be556fe53474071d09cd453549ed02e" }
+clarity = { git = "https://github.com/stacks-network/stacks-core.git", rev = "75ee7718db5b251adf7bc3fcd769b78859310d54" }
 clar2wasm = { path = "../clar2wasm", features = ["developer-mode"] }
 wasmtime = "15.0.0"
 


### PR DESCRIPTION
This fixes #316. It will grab the last non-none return value from any top-level expressions and return that, even if the last statement in the top-level code has no return value (e.g. ` define-` function).