### PR TITLE
Proptests for the Map type functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,7 +512,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#82d7bc3f470b751e48494580459f53943b98bd31"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#96aba4746c9db60200b26147a0b1368fae4664b2"
 dependencies = [
  "hashbrown 0.14.3",
  "integer-sqrt",
@@ -2676,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#82d7bc3f470b751e48494580459f53943b98bd31"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#96aba4746c9db60200b26147a0b1368fae4664b2"
 dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,7 +512,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#14732c012780ff2d15f3b81b9e3356fbedd22cc3"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#82d7bc3f470b751e48494580459f53943b98bd31"
 dependencies = [
  "hashbrown 0.14.3",
  "integer-sqrt",
@@ -2676,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#14732c012780ff2d15f3b81b9e3356fbedd22cc3"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#82d7bc3f470b751e48494580459f53943b98bd31"
 dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -46,6 +46,8 @@ pub struct WasmGenerator {
     pub(crate) return_type: Option<TypeSignature>,
     /// The types of defined data-vars
     pub(crate) datavars_types: HashMap<ClarityName, TypeSignature>,
+    /// The types of (key, value) in defined maps
+    pub(crate) maps_types: HashMap<ClarityName, (TypeSignature, TypeSignature)>,
 
     /// The locals for the current function.
     pub(crate) bindings: HashMap<String, Vec<LocalId>>,
@@ -244,6 +246,7 @@ impl WasmGenerator {
             return_type: None,
             frame_size: 0,
             datavars_types: HashMap::new(),
+            maps_types: HashMap::new(),
         })
     }
 

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -8,6 +8,7 @@ pub mod conditionals;
 pub mod control_flow;
 pub mod default_to;
 pub mod equal;
+pub mod maps;
 pub mod noop;
 pub mod optional;
 pub mod regression;

--- a/clar2wasm/tests/wasm-generation/maps.rs
+++ b/clar2wasm/tests/wasm-generation/maps.rs
@@ -36,7 +36,7 @@ proptest! {
     #[test]
     fn define_insert_get_map(
         (kty, vty, entries, random_key)
-            in (map_type(), 1usize..=20)
+            in (map_type(), 1usize..=8)
                 .prop_flat_map(|((kty, vty), size)| {
                     (Just(kty.clone()), Just(vty.clone()), map_entries(kty.clone(), vty, size), PropValue::from_type(kty))
     })) {
@@ -112,7 +112,7 @@ proptest! {
     #[test]
     fn define_set_get_map(
         (kty, vty, entries, random_key)
-            in (map_type(), 1usize..=20)
+            in (map_type(), 1usize..=8)
                 .prop_flat_map(|((kty, vty), size)| {
                     (Just(kty.clone()), Just(vty.clone()), map_entries(kty.clone(), vty, size), PropValue::from_type(kty))
     })) {
@@ -183,7 +183,7 @@ proptest! {
     #[test]
     fn define_set_delete_get_map(
         (kty, vty, entries)
-            in (map_type(), 1usize..=20)
+            in (map_type(), 1usize..=8)
                 .prop_flat_map(|((kty, vty), size)| {
                     (Just(kty.clone()), Just(vty.clone()), map_entries(kty, vty, size))
     })) {

--- a/clar2wasm/tests/wasm-generation/maps.rs
+++ b/clar2wasm/tests/wasm-generation/maps.rs
@@ -1,0 +1,111 @@
+use clar2wasm::tools::crosscheck;
+use clarity::vm::types::{TupleData, TypeSignature};
+use clarity::vm::{ClarityName, Value};
+use proptest::prelude::*;
+
+use crate::{prop_signature, type_string, PropValue};
+
+fn map_type() -> impl Strategy<Value = (TypeSignature, TypeSignature)> {
+    (prop_signature(), prop_signature())
+}
+
+fn map_entry(
+    key: TypeSignature,
+    value: TypeSignature,
+) -> impl Strategy<Value = (PropValue, PropValue)> {
+    (PropValue::from_type(key), PropValue::from_type(value))
+}
+
+fn map_entries(
+    key: TypeSignature,
+    value: TypeSignature,
+    items: usize,
+) -> impl Strategy<Value = Vec<(PropValue, PropValue)>> {
+    prop::collection::vec(map_entry(key, value), items)
+}
+
+proptest! {
+    #![proptest_config(super::runtime_config())]
+
+    #[test]
+    fn define_get_empty_map((kty, vty, k) in map_type().prop_flat_map(|(kty, vty)| (Just(kty.clone()), Just(vty), PropValue::from_type(kty)))) {
+        let snippet = format!("(define-map test-map {} {}) (map-get? test-map {k})", type_string(&kty), type_string(&vty));
+        crosscheck(&snippet, Ok(Some(Value::none())))
+    }
+
+    #[test]
+    fn define_insert_get_map(
+        (kty, vty, entries, random_key)
+            in (map_type(), 1usize..=20)
+                .prop_flat_map(|((kty, vty), size)| {
+                    (Just(kty.clone()), Just(vty.clone()), map_entries(kty.clone(), vty, size), PropValue::from_type(kty))
+    })) {
+        // We generate here a snippet that looks like
+        // ```
+        // (define-map test-map {key type} {value type})
+        // {
+        //    a: (list (map-insert test-map {key0} {value0}) (map-insert test-map {key1} {value1}) ...)
+        //    b: (list (map-get? test-map {key0}) (map-get? test-map {key1}) ... (map-get? test-map {random-key})))
+        // }
+
+        // will contain results of map-insert
+        let mut expected_insert: Vec<Value> = Vec::with_capacity(entries.len());
+        // will contain results of map-get?
+        let mut expected_get: Vec<Value> = Vec::with_capacity(entries.len() + 1);
+        // should be a hashset of the currently defined keys, but Value doesn't implement Hash
+        let mut defined_keys = Vec::with_capacity(entries.len());
+
+        let mut snippet_tuple_a = String::from("(list");
+        let mut snippet_tuple_b = String::from("(list");
+
+        for (i, (k, v)) in entries.iter().enumerate() {
+            snippet_tuple_a.push_str(&format!(" (map-insert test-map {k} {v})"));
+            snippet_tuple_b.push_str(&format!(" (map-get? test-map {k})"));
+            expected_insert.push(Value::Bool(if defined_keys.contains(&k.0) {
+                false
+            } else {
+                defined_keys.push(k.0.clone());
+                true
+            }));
+            expected_get.push(
+                entries[..=i]
+                    .iter()
+                    .find_map(|(ke, ve)| (k == ke).then(|| Value::some(ve.0.clone()).unwrap()))
+                    .unwrap(),
+            );
+        }
+
+        snippet_tuple_a.push(')');
+
+        // get a random key for fun
+        snippet_tuple_b.push_str(&format!(" (map-get? test-map {random_key}))"));
+        expected_get.push(
+            entries
+                .into_iter()
+                .find_map(|(key, val)| (random_key == key).then(|| Value::some(val.0).unwrap()))
+                .unwrap_or_else(Value::none),
+        );
+
+        let snippet = format!(
+            "(define-map test-map {} {}) {{a: {snippet_tuple_a}, b: {snippet_tuple_b}}}",
+            type_string(&kty),
+            type_string(&vty)
+        );
+
+        let expected = Value::from(
+            TupleData::from_data(vec![
+                (
+                    ClarityName::from("a"),
+                    Value::cons_list_unsanitized(expected_insert).unwrap(),
+                ),
+                (
+                    ClarityName::from("b"),
+                    Value::cons_list_unsanitized(expected_get).unwrap(),
+                ),
+            ])
+            .unwrap(),
+        );
+
+        crosscheck(&snippet, Ok(Some(expected)));
+    }
+}

--- a/clar2wasm/tests/wasm-generation/tuple.rs
+++ b/clar2wasm/tests/wasm-generation/tuple.rs
@@ -36,6 +36,7 @@ proptest! {
     #![proptest_config(super::runtime_config())]
 
     #[test]
+    #[ignore = "issue #359"]
     fn crosscheck_merge(t1 in tuple_gen(), t2 in tuple_gen()) {
 
         let expected = clarity::vm::functions::tuples::tuple_merge(t1.clone(), t2.clone()).unwrap();


### PR DESCRIPTION
This test adds property testing for `define-map`, `map-insert`, `map-set`, `map-get?` and `map-delete`.

It showed a big amount of bugs:

- the linked functions didn't dereference keys and values for in-memory types (in stacks-core)
- the computation of types sized was flawed for lists and buffer (in stacks-core)
- all the functions suffered from the typechecker issue

This PR is part of #261 
Fixes #304 
Fixes #345

~~THIS IS A DRAFT: fixing the size computation broke the `append` function.~~