### PR TITLE
Fix: functions return types fail for lists of principal

### DIFF
--- a/clar2wasm/src/words/functions.rs
+++ b/clar2wasm/src/words/functions.rs
@@ -195,4 +195,28 @@ mod tests {
             evaluate("(ok none)"),
         );
     }
+
+    #[test]
+    fn private_function_with_list_union_type() {
+        crosscheck(
+            "(define-private (foo) (list 'S33GG8QRVWKM7AR8EFN0KZHWD5ZXPHKCWPCZ07BHE.A 'S530MSMK2C8KCDN61ZFMYKFXBHKAP6P32P4S74CJ3.a)) (foo)",
+            evaluate("(list 'S33GG8QRVWKM7AR8EFN0KZHWD5ZXPHKCWPCZ07BHE.A 'S530MSMK2C8KCDN61ZFMYKFXBHKAP6P32P4S74CJ3.a)")
+        );
+    }
+
+    #[test]
+    fn public_function_with_list_union_type() {
+        crosscheck(
+            "(define-public (foo) (ok (list 'S33GG8QRVWKM7AR8EFN0KZHWD5ZXPHKCWPCZ07BHE.A 'S530MSMK2C8KCDN61ZFMYKFXBHKAP6P32P4S74CJ3.a))) (foo)",
+            evaluate("(ok (list 'S33GG8QRVWKM7AR8EFN0KZHWD5ZXPHKCWPCZ07BHE.A 'S530MSMK2C8KCDN61ZFMYKFXBHKAP6P32P4S74CJ3.a))")
+        );
+    }
+
+    #[test]
+    fn read_only_function_with_list_union_type() {
+        crosscheck(
+            "(define-read-only (foo) (list 'S33GG8QRVWKM7AR8EFN0KZHWD5ZXPHKCWPCZ07BHE.A 'S530MSMK2C8KCDN61ZFMYKFXBHKAP6P32P4S74CJ3.a)) (foo)",
+            evaluate("(list 'S33GG8QRVWKM7AR8EFN0KZHWD5ZXPHKCWPCZ07BHE.A 'S530MSMK2C8KCDN61ZFMYKFXBHKAP6P32P4S74CJ3.a)")
+        );
+    }
 }


### PR DESCRIPTION
Fixes #364 

This fix adds a concretization pass for functions to the `ContractAnalysis` type after the type checking pass in `compile`.

The functions added in the new module _utils_ could have been methods on `ContractAnalysis` and `FunctionType`, but since we only need those for clarity-wasm, I preferred to write them here.