### PR TITLE
Fix issue #356

### DIFF
--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -1328,9 +1328,12 @@
 
         ;; if b > (a >= 0 ? 126 : 127) -> runtime error: overflow (since the biggest b that doesn't
         ;; overflow is in 2^126 and -2^127, and this is an edge case)
-        (if (i64.gt_u
-                (local.get $b_lo)
-                (i64.add (i64.const 126) (i64.extend_i32_u (i64.lt_s (local.get $a_hi) (i64.const 0))))
+        (if (i32.or
+                (i64.gt_u
+                    (local.get $b_lo)
+                    (i64.add (i64.const 126) (i64.extend_i32_u (i64.lt_s (local.get $a_hi) (i64.const 0))))
+                )
+                (i64.ne (local.get $b_hi) (i64.const 0))
             )
             (then (call $stdlib.runtime-error (i32.const 0)))
         )

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -2231,6 +2231,14 @@ fn pow_int() {
         &mut result,
     )
     .expect_err("expected overflow");
+
+    // 2^0x10000000000000000 overflows (correct branch overflows, issue #356)
+    pow.call(
+        &mut store,
+        &[Val::I64(2), Val::I64(0), Val::I64(0), Val::I64(1)],
+        &mut result,
+    )
+    .expect_err("expected overflow");
 }
 
 #[test]


### PR DESCRIPTION
Fixes #356 

`$stdlib.pow-int` omitted to check for the second operand higher part in its overflow check.