### PR TITLE
Migrate code from stacks-core to clar2wasm

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "stacks-core"]
-	path = stacks-core
-	url = https://github.com/stacks-network/stacks-core.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,6 +489,7 @@ dependencies = [
  "regex",
  "rusqlite",
  "sha2",
+ "stacks-common",
  "walrus",
  "wasmtime",
  "wat",

--- a/clar2wasm/Cargo.toml
+++ b/clar2wasm/Cargo.toml
@@ -5,11 +5,13 @@ edition = "2021"
 build = "build.rs"
 
 [dependencies]
-clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-next" }
+clarity = { path = "../../stacks-core/clarity" }
 clap = { version = "4.3.17", features = ["derive"] }
 regex = "1.9.1"
 walrus = "0.20.1"
 lazy_static = "1.4.0"
+wasmtime = "15.0.0"
+stacks-common = { path = "../../stacks-core/stacks-common" }
 
 # For developer mode
 sha2 = { version = "0.10.7", optional = true }
@@ -25,7 +27,6 @@ flamegraph = []
 pb = []
 
 [dev-dependencies]
-wasmtime = "15.0.0"
 criterion = "0.5.1"
 proptest = "1.2.0"
 num-integer = { version = "0.1.45", default-features = false }

--- a/clar2wasm/Cargo.toml
+++ b/clar2wasm/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2021"
 build = "build.rs"
 
 [dependencies]
-clarity = { path = "../../stacks-core/clarity" }
+clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-next" }
 clap = { version = "4.3.17", features = ["derive"] }
 regex = "1.9.1"
 walrus = "0.20.1"
 lazy_static = "1.4.0"
 wasmtime = "15.0.0"
-stacks-common = { path = "../../stacks-core/stacks-common" }
+stacks-common = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-next" }
 
 # For developer mode
 sha2 = { version = "0.10.7", optional = true }

--- a/clar2wasm/src/initialize.rs
+++ b/clar2wasm/src/initialize.rs
@@ -360,9 +360,9 @@ pub fn initialize_contract(
 
     // Get the return type of the top-level expressions function
     let ty = top_level.ty(&mut store);
-    let mut results_iter = ty.results();
+    let results_iter = ty.results();
     let mut results = vec![];
-    while let Some(result_ty) = results_iter.next() {
+    for result_ty in results_iter {
         results.push(placeholder_for_type(result_ty));
     }
 

--- a/clar2wasm/src/initialize.rs
+++ b/clar2wasm/src/initialize.rs
@@ -1,14 +1,11 @@
 use clarity::vm::analysis::ContractAnalysis;
-use clarity::vm::errors::RuntimeErrorType;
+use clarity::vm::contexts::GlobalContext;
+use clarity::vm::errors::{Error, RuntimeErrorType, WasmError};
 use clarity::vm::events::*;
 use clarity::vm::types::{AssetIdentifier, BuffData, PrincipalData, QualifiedContractIdentifier};
-use clarity::vm::CallStack;
+use clarity::vm::{CallStack, ContractContext, Value};
 use stacks_common::types::chainstate::StacksBlockId;
 use wasmtime::{Engine, Linker, Module, Store};
-
-use clarity::vm::contexts::GlobalContext;
-use clarity::vm::errors::{Error, WasmError};
-use clarity::vm::{ContractContext, Value};
 
 use crate::linker::link_host_functions;
 use crate::wasm_utils::*;

--- a/clar2wasm/src/initialize.rs
+++ b/clar2wasm/src/initialize.rs
@@ -60,6 +60,30 @@ impl<'a, 'b> ClarityWasmContext<'a, 'b> {
         }
     }
 
+    pub fn new_run(
+        global_context: &'a mut GlobalContext<'b>,
+        contract_context: &'a ContractContext,
+        call_stack: &'a mut CallStack,
+        sender: Option<PrincipalData>,
+        caller: Option<PrincipalData>,
+        sponsor: Option<PrincipalData>,
+        contract_analysis: Option<&'a ContractAnalysis>,
+    ) -> Self {
+        ClarityWasmContext {
+            global_context,
+            contract_context: Some(contract_context),
+            contract_context_mut: None,
+            call_stack,
+            sender,
+            caller,
+            sponsor,
+            sender_stack: vec![],
+            caller_stack: vec![],
+            bhh_stack: vec![],
+            contract_analysis,
+        }
+    }
+
     pub fn push_sender(&mut self, sender: PrincipalData) {
         if let Some(current) = self.sender.take() {
             self.sender_stack.push(current);

--- a/clar2wasm/src/initialize.rs
+++ b/clar2wasm/src/initialize.rs
@@ -1,0 +1,375 @@
+use clarity::vm::analysis::ContractAnalysis;
+use clarity::vm::errors::RuntimeErrorType;
+use clarity::vm::events::*;
+use clarity::vm::types::{AssetIdentifier, BuffData, PrincipalData, QualifiedContractIdentifier};
+use clarity::vm::CallStack;
+use stacks_common::types::chainstate::StacksBlockId;
+use wasmtime::{Engine, Linker, Module, Store};
+
+use clarity::vm::contexts::GlobalContext;
+use clarity::vm::errors::{Error, WasmError};
+use clarity::vm::{ContractContext, Value};
+
+use crate::linker::link_host_functions;
+use crate::wasm_utils::*;
+
+// The context used when making calls into the Wasm module.
+pub struct ClarityWasmContext<'a, 'b> {
+    pub global_context: &'a mut GlobalContext<'b>,
+    contract_context: Option<&'a ContractContext>,
+    contract_context_mut: Option<&'a mut ContractContext>,
+    pub call_stack: &'a mut CallStack,
+    pub sender: Option<PrincipalData>,
+    pub caller: Option<PrincipalData>,
+    pub sponsor: Option<PrincipalData>,
+    // Stack of senders, used for `as-contract` expressions.
+    sender_stack: Vec<PrincipalData>,
+    /// Stack of callers, used for `contract-call?` and `as-contract` expressions.
+    caller_stack: Vec<PrincipalData>,
+    /// Stack of block hashes, used for `at-block` expressions.
+    bhh_stack: Vec<StacksBlockId>,
+
+    /// Contract analysis data, used for typing information, and only available
+    /// when initializing a contract. Should always be `Some` when initializing
+    /// a contract, and `None` otherwise.
+    pub contract_analysis: Option<&'a ContractAnalysis>,
+}
+
+impl<'a, 'b> ClarityWasmContext<'a, 'b> {
+    pub fn new_init(
+        global_context: &'a mut GlobalContext<'b>,
+        contract_context: &'a mut ContractContext,
+        call_stack: &'a mut CallStack,
+        sender: Option<PrincipalData>,
+        caller: Option<PrincipalData>,
+        sponsor: Option<PrincipalData>,
+        contract_analysis: Option<&'a ContractAnalysis>,
+    ) -> Self {
+        ClarityWasmContext {
+            global_context,
+            contract_context: None,
+            contract_context_mut: Some(contract_context),
+            call_stack,
+            sender,
+            caller,
+            sponsor,
+            sender_stack: vec![],
+            caller_stack: vec![],
+            bhh_stack: vec![],
+            contract_analysis,
+        }
+    }
+
+    pub fn push_sender(&mut self, sender: PrincipalData) {
+        if let Some(current) = self.sender.take() {
+            self.sender_stack.push(current);
+        }
+        self.sender = Some(sender);
+    }
+
+    pub fn pop_sender(&mut self) -> Result<PrincipalData, Error> {
+        self.sender
+            .take()
+            .ok_or(RuntimeErrorType::NoSenderInContext.into())
+            .map(|sender| {
+                self.sender = self.sender_stack.pop();
+                sender
+            })
+    }
+
+    pub fn push_caller(&mut self, caller: PrincipalData) {
+        if let Some(current) = self.caller.take() {
+            self.caller_stack.push(current);
+        }
+        self.caller = Some(caller);
+    }
+
+    pub fn pop_caller(&mut self) -> Result<PrincipalData, Error> {
+        self.caller
+            .take()
+            .ok_or(RuntimeErrorType::NoCallerInContext.into())
+            .map(|caller| {
+                self.caller = self.caller_stack.pop();
+                caller
+            })
+    }
+
+    pub fn push_at_block(&mut self, bhh: StacksBlockId) {
+        self.bhh_stack.push(bhh);
+    }
+
+    pub fn pop_at_block(&mut self) -> StacksBlockId {
+        self.bhh_stack
+            .pop()
+            .expect("called pop_at_block without calling push_at_block")
+    }
+
+    /// Return an immutable reference to the contract_context
+    pub fn contract_context(&self) -> &ContractContext {
+        if let Some(contract_context) = &self.contract_context {
+            contract_context
+        } else if let Some(contract_context) = &self.contract_context_mut {
+            contract_context
+        } else {
+            unreachable!("contract_context and contract_context_mut are both None")
+        }
+    }
+
+    /// Return a mutable reference to the contract_context if we are currently
+    /// initializing a contract, else, return an error.
+    pub fn contract_context_mut(&mut self) -> Result<&mut ContractContext, Error> {
+        match &mut self.contract_context_mut {
+            Some(contract_context) => Ok(contract_context),
+            None => Err(Error::Wasm(WasmError::DefineFunctionCalledInRunMode)),
+        }
+    }
+
+    pub fn push_to_event_batch(&mut self, event: StacksTransactionEvent) {
+        if let Some(batch) = self.global_context.event_batches.last_mut() {
+            batch.events.push(event);
+        }
+    }
+
+    pub fn construct_print_transaction_event(
+        contract_id: &QualifiedContractIdentifier,
+        value: &Value,
+    ) -> StacksTransactionEvent {
+        let print_event = SmartContractEventData {
+            key: (contract_id.clone(), "print".to_string()),
+            value: value.clone(),
+        };
+
+        StacksTransactionEvent::SmartContractEvent(print_event)
+    }
+
+    pub fn register_print_event(&mut self, value: Value) -> Result<(), Error> {
+        let event = Self::construct_print_transaction_event(
+            &self.contract_context().contract_identifier,
+            &value,
+        );
+
+        self.push_to_event_batch(event);
+        Ok(())
+    }
+
+    pub fn register_stx_transfer_event(
+        &mut self,
+        sender: PrincipalData,
+        recipient: PrincipalData,
+        amount: u128,
+        memo: BuffData,
+    ) -> Result<(), Error> {
+        let event_data = STXTransferEventData {
+            sender,
+            recipient,
+            amount,
+            memo,
+        };
+        let event = StacksTransactionEvent::STXEvent(STXEventType::STXTransferEvent(event_data));
+
+        self.push_to_event_batch(event);
+        Ok(())
+    }
+
+    pub fn register_stx_burn_event(
+        &mut self,
+        sender: PrincipalData,
+        amount: u128,
+    ) -> Result<(), Error> {
+        let event_data = STXBurnEventData { sender, amount };
+        let event = StacksTransactionEvent::STXEvent(STXEventType::STXBurnEvent(event_data));
+
+        self.push_to_event_batch(event);
+        Ok(())
+    }
+
+    pub fn register_nft_transfer_event(
+        &mut self,
+        sender: PrincipalData,
+        recipient: PrincipalData,
+        value: Value,
+        asset_identifier: AssetIdentifier,
+    ) -> Result<(), Error> {
+        let event_data = NFTTransferEventData {
+            sender,
+            recipient,
+            asset_identifier,
+            value,
+        };
+        let event = StacksTransactionEvent::NFTEvent(NFTEventType::NFTTransferEvent(event_data));
+
+        self.push_to_event_batch(event);
+        Ok(())
+    }
+
+    pub fn register_nft_mint_event(
+        &mut self,
+        recipient: PrincipalData,
+        value: Value,
+        asset_identifier: AssetIdentifier,
+    ) -> Result<(), Error> {
+        let event_data = NFTMintEventData {
+            recipient,
+            asset_identifier,
+            value,
+        };
+        let event = StacksTransactionEvent::NFTEvent(NFTEventType::NFTMintEvent(event_data));
+
+        self.push_to_event_batch(event);
+        Ok(())
+    }
+
+    pub fn register_nft_burn_event(
+        &mut self,
+        sender: PrincipalData,
+        value: Value,
+        asset_identifier: AssetIdentifier,
+    ) -> Result<(), Error> {
+        let event_data = NFTBurnEventData {
+            sender,
+            asset_identifier,
+            value,
+        };
+        let event = StacksTransactionEvent::NFTEvent(NFTEventType::NFTBurnEvent(event_data));
+
+        self.push_to_event_batch(event);
+        Ok(())
+    }
+
+    pub fn register_ft_transfer_event(
+        &mut self,
+        sender: PrincipalData,
+        recipient: PrincipalData,
+        amount: u128,
+        asset_identifier: AssetIdentifier,
+    ) -> Result<(), Error> {
+        let event_data = FTTransferEventData {
+            sender,
+            recipient,
+            asset_identifier,
+            amount,
+        };
+        let event = StacksTransactionEvent::FTEvent(FTEventType::FTTransferEvent(event_data));
+
+        self.push_to_event_batch(event);
+        Ok(())
+    }
+
+    pub fn register_ft_mint_event(
+        &mut self,
+        recipient: PrincipalData,
+        amount: u128,
+        asset_identifier: AssetIdentifier,
+    ) -> Result<(), Error> {
+        let event_data = FTMintEventData {
+            recipient,
+            asset_identifier,
+            amount,
+        };
+        let event = StacksTransactionEvent::FTEvent(FTEventType::FTMintEvent(event_data));
+
+        self.push_to_event_batch(event);
+        Ok(())
+    }
+
+    pub fn register_ft_burn_event(
+        &mut self,
+        sender: PrincipalData,
+        amount: u128,
+        asset_identifier: AssetIdentifier,
+    ) -> Result<(), Error> {
+        let event_data = FTBurnEventData {
+            sender,
+            asset_identifier,
+            amount,
+        };
+        let event = StacksTransactionEvent::FTEvent(FTEventType::FTBurnEvent(event_data));
+
+        self.push_to_event_batch(event);
+        Ok(())
+    }
+}
+
+/// Initialize a contract, executing all of the top-level expressions and
+/// registering all of the definitions in the context. Returns the value
+/// returned from the last top-level expression.
+pub fn initialize_contract(
+    global_context: &mut GlobalContext,
+    contract_context: &mut ContractContext,
+    sponsor: Option<PrincipalData>,
+    contract_analysis: &ContractAnalysis,
+) -> Result<Option<Value>, Error> {
+    let publisher: PrincipalData = contract_context.contract_identifier.issuer.clone().into();
+
+    let mut call_stack = CallStack::new();
+    let epoch = global_context.epoch_id;
+    let init_context = ClarityWasmContext::new_init(
+        global_context,
+        contract_context,
+        &mut call_stack,
+        Some(publisher.clone()),
+        Some(publisher),
+        sponsor.clone(),
+        Some(contract_analysis),
+    );
+    let engine = Engine::default();
+    let module = init_context
+        .contract_context()
+        .with_wasm_module(|wasm_module| {
+            Module::from_binary(&engine, wasm_module)
+                .map_err(|e| Error::Wasm(WasmError::UnableToLoadModule(e)))
+        })?;
+    let mut store = Store::new(&engine, init_context);
+    let mut linker = Linker::new(&engine);
+
+    // Link in the host interface functions.
+    link_host_functions(&mut linker)?;
+
+    let instance = linker
+        .instantiate(&mut store, &module)
+        .map_err(|e| Error::Wasm(WasmError::UnableToLoadModule(e)))?;
+
+    // Call the `.top-level` function, which contains all top-level expressions
+    // from the contract.
+    let top_level = instance
+        .get_func(&mut store, ".top-level")
+        .ok_or(Error::Wasm(WasmError::DefinesNotFound))?;
+
+    // Get the return type of the top-level expressions function
+    let ty = top_level.ty(&mut store);
+    let mut results_iter = ty.results();
+    let mut results = vec![];
+    while let Some(result_ty) = results_iter.next() {
+        results.push(placeholder_for_type(result_ty));
+    }
+
+    top_level
+        .call(&mut store, &[], results.as_mut_slice())
+        .map_err(|e| Error::Wasm(WasmError::Runtime(e)))?;
+
+    // Save the compiled Wasm module into the contract context
+    store.data_mut().contract_context_mut()?.set_wasm_module(
+        module
+            .serialize()
+            .map_err(|e| Error::Wasm(WasmError::WasmCompileFailed(e)))?,
+    );
+
+    // Get the type of the last top-level expression with a return value
+    // or default to `None`.
+    let return_type = contract_analysis.expressions.iter().rev().find_map(|expr| {
+        contract_analysis
+            .type_map
+            .as_ref()
+            .and_then(|type_map| type_map.get_type(expr))
+    });
+
+    if let Some(return_type) = return_type {
+        let memory = instance
+            .get_memory(&mut store, "memory")
+            .ok_or(Error::Wasm(WasmError::MemoryNotFound))?;
+        wasm_to_clarity_value(return_type, 0, &results, memory, &mut &mut store, epoch)
+            .map(|(val, _offset)| val)
+    } else {
+        Ok(None)
+    }
+}

--- a/clar2wasm/src/initialize.rs
+++ b/clar2wasm/src/initialize.rs
@@ -119,10 +119,12 @@ impl<'a, 'b> ClarityWasmContext<'a, 'b> {
         self.bhh_stack.push(bhh);
     }
 
-    pub fn pop_at_block(&mut self) -> StacksBlockId {
+    pub fn pop_at_block(&mut self) -> Result<StacksBlockId, Error> {
         self.bhh_stack
             .pop()
-            .expect("called pop_at_block without calling push_at_block")
+            .ok_or(Error::Wasm(WasmError::WasmGeneratorError(
+                "Could not pop at_block".to_string(),
+            )))
     }
 
     /// Return an immutable reference to the contract_context

--- a/clar2wasm/src/lib.rs
+++ b/clar2wasm/src/lib.rs
@@ -11,8 +11,11 @@ pub use walrus::Module;
 use wasm_generator::{GeneratorError, WasmGenerator};
 
 mod deserialize;
+mod initialize;
+mod linker;
 mod serialize;
 pub mod wasm_generator;
+mod wasm_utils;
 mod words;
 
 #[cfg(feature = "developer-mode")]

--- a/clar2wasm/src/lib.rs
+++ b/clar2wasm/src/lib.rs
@@ -11,11 +11,11 @@ pub use walrus::Module;
 use wasm_generator::{GeneratorError, WasmGenerator};
 
 mod deserialize;
-mod initialize;
+pub mod initialize;
 mod linker;
 mod serialize;
 pub mod wasm_generator;
-mod wasm_utils;
+pub mod wasm_utils;
 mod words;
 
 #[cfg(feature = "developer-mode")]

--- a/clar2wasm/src/linker.rs
+++ b/clar2wasm/src/linker.rs
@@ -2,22 +2,19 @@ use clarity::vm::analysis::CheckErrors;
 use clarity::vm::callables::{DefineType, DefinedFunction};
 use clarity::vm::costs::{constants as cost_constants, CostTracker};
 use clarity::vm::database::STXBalance;
-use clarity::vm::errors::RuntimeErrorType;
-use clarity::vm::errors::{Error, WasmError};
+use clarity::vm::errors::{Error, RuntimeErrorType, WasmError};
 use clarity::vm::functions::crypto::{pubkey_to_address_v1, pubkey_to_address_v2};
-use clarity::vm::types::{BufferLength, SequenceSubtype, StacksAddressExtensions, TypeSignature};
-use clarity::vm::{ClarityName, Value};
-use clarity::vm::{ClarityVersion, Environment, SymbolicExpression};
+use clarity::vm::types::{
+    AssetIdentifier, BlockInfoProperty, BuffData, BufferLength, BurnBlockInfoProperty,
+    FunctionType, ListTypeData, PrincipalData, SequenceData, SequenceSubtype,
+    StacksAddressExtensions, TraitIdentifier, TupleData, TupleTypeSignature, TypeSignature, BUFF_1,
+    BUFF_32, BUFF_33,
+};
+use clarity::vm::{ClarityName, ClarityVersion, Environment, SymbolicExpression, Value};
 use stacks_common::types::chainstate::StacksBlockId;
 use stacks_common::util::hash::{Keccak256Hash, Sha512Sum, Sha512Trunc256Sum};
 use stacks_common::util::secp256k1::{secp256k1_recover, secp256k1_verify, Secp256k1PublicKey};
 use wasmtime::{Caller, Linker};
-
-use clarity::vm::types::{
-    AssetIdentifier, BlockInfoProperty, BuffData, BurnBlockInfoProperty, FunctionType,
-    ListTypeData, PrincipalData, SequenceData, TraitIdentifier, TupleData, TupleTypeSignature,
-    BUFF_1, BUFF_32, BUFF_33,
-};
 
 use crate::initialize::ClarityWasmContext;
 use crate::wasm_utils::*;

--- a/clar2wasm/src/linker.rs
+++ b/clar2wasm/src/linker.rs
@@ -141,13 +141,13 @@ fn link_define_variable_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<()
                     .data_mut()
                     .global_context
                     .add_memory(value_type.type_size()? as u64)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
 
                 caller
                     .data_mut()
                     .global_context
                     .add_memory(value.size()? as u64)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
 
                 // Create the variable in the global context
                 let data_types = caller.data_mut().global_context.database.create_variable(
@@ -234,7 +234,7 @@ fn link_define_ft_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Erro
                             .expect("type size should be realizable")
                             as u64,
                     )
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
                 let data_type = caller
                     .data_mut()
                     .global_context
@@ -307,7 +307,7 @@ fn link_define_nft_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Err
                             .expect("type size should be realizable")
                             as u64,
                     )
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
 
                 let data_type = caller
                     .data_mut()
@@ -383,7 +383,7 @@ fn link_define_map_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Err
                             .expect("type size should be realizable")
                             as u64,
                     )
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
                 caller
                     .data_mut()
                     .global_context
@@ -393,7 +393,7 @@ fn link_define_map_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Err
                             .expect("type size should be realizable")
                             as u64,
                     )
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
 
                 let data_type = caller.data_mut().global_context.database.create_map(
                     &contract_identifier,
@@ -741,7 +741,7 @@ fn link_set_variable_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), E
                     .global_context
                     .database
                     .set_variable(&contract, var_name.as_str(), value, &data_types, &epoch)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
 
                 Ok(())
             },
@@ -1264,12 +1264,12 @@ fn link_stx_burn_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error
                     .data_mut()
                     .global_context
                     .add_memory(TypeSignature::PrincipalType.size()? as u64)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
                 caller
                     .data_mut()
                     .global_context
                     .add_memory(STXBalance::unlocked_and_v1_size as u64)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
 
                 let mut burner_snapshot = caller
                     .data_mut()
@@ -1395,12 +1395,12 @@ fn link_stx_transfer_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), E
                     .data_mut()
                     .global_context
                     .add_memory(TypeSignature::PrincipalType.size()? as u64)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
                 caller
                     .data_mut()
                     .global_context
                     .add_memory(TypeSignature::PrincipalType.size()? as u64)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
                 // loading sender's locked amount and height
                 // TODO: this does not count the inner stacks block header load, but arguably,
                 // this could be optimized away, so it shouldn't penalize the caller.
@@ -1408,12 +1408,12 @@ fn link_stx_transfer_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), E
                     .data_mut()
                     .global_context
                     .add_memory(STXBalance::unlocked_and_v1_size as u64)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
                 caller
                     .data_mut()
                     .global_context
                     .add_memory(STXBalance::unlocked_and_v1_size as u64)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
 
                 let mut sender_snapshot = caller
                     .data_mut()
@@ -1659,12 +1659,12 @@ fn link_ft_burn_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error>
                     .data_mut()
                     .global_context
                     .add_memory(TypeSignature::PrincipalType.size()? as u64)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
                 caller
                     .data_mut()
                     .global_context
                     .add_memory(TypeSignature::UIntType.size()? as u64)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
 
                 caller.data_mut().global_context.log_token_transfer(
                     burner,
@@ -1772,12 +1772,12 @@ fn link_ft_mint_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error>
                     .data_mut()
                     .global_context
                     .add_memory(TypeSignature::PrincipalType.size()? as u64)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
                 caller
                     .data_mut()
                     .global_context
                     .add_memory(TypeSignature::UIntType.size()? as u64)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
 
                 caller.data_mut().global_context.database.set_ft_balance(
                     &contract_identifier,
@@ -1925,22 +1925,22 @@ fn link_ft_transfer_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Er
                     .data_mut()
                     .global_context
                     .add_memory(TypeSignature::PrincipalType.size()? as u64)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
                 caller
                     .data_mut()
                     .global_context
                     .add_memory(TypeSignature::PrincipalType.size()? as u64)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
                 caller
                     .data_mut()
                     .global_context
                     .add_memory(TypeSignature::UIntType.size()? as u64)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
                 caller
                     .data_mut()
                     .global_context
                     .add_memory(TypeSignature::UIntType.size()? as u64)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
 
                 caller.data_mut().global_context.database.set_ft_balance(
                     &contract_identifier,
@@ -2172,12 +2172,12 @@ fn link_nft_burn_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error
                     .data_mut()
                     .global_context
                     .add_memory(TypeSignature::PrincipalType.size()? as u64)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
                 caller
                     .data_mut()
                     .global_context
                     .add_memory(asset_size)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
 
                 caller.data_mut().global_context.database.burn_nft(
                     &contract_identifier,
@@ -2302,12 +2302,12 @@ fn link_nft_mint_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error
                     .data_mut()
                     .global_context
                     .add_memory(TypeSignature::PrincipalType.size()? as u64)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
                 caller
                     .data_mut()
                     .global_context
                     .add_memory(asset_size)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
 
                 caller.data_mut().global_context.database.set_nft_owner(
                     &contract_identifier,
@@ -2462,12 +2462,12 @@ fn link_nft_transfer_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), E
                     .data_mut()
                     .global_context
                     .add_memory(TypeSignature::PrincipalType.size()? as u64)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
                 caller
                     .data_mut()
                     .global_context
                     .add_memory(asset_size)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
 
                 caller.data_mut().global_context.database.set_nft_owner(
                     &contract_identifier,
@@ -2681,7 +2681,7 @@ fn link_map_set_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error>
                     .data_mut()
                     .global_context
                     .add_memory(result_size)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
 
                 let value = result.map(|data| data.value)?;
                 if let Value::Bool(true) = value {
@@ -2783,7 +2783,7 @@ fn link_map_insert_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Err
                     .data_mut()
                     .global_context
                     .add_memory(result_size)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
 
                 let value = result.map(|data| data.value)?;
                 if let Value::Bool(true) = value {
@@ -2871,7 +2871,7 @@ fn link_map_delete_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Err
                     .data_mut()
                     .global_context
                     .add_memory(result_size)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
 
                 let value = result.map(|data| data.value)?;
                 if let Value::Bool(true) = value {
@@ -3560,7 +3560,7 @@ fn link_enter_at_block_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(),
                     .data_mut()
                     .global_context
                     .add_memory(cost_constants::AT_BLOCK_MEMORY)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
 
                 caller.data_mut().global_context.begin_read_only();
 

--- a/clar2wasm/src/linker.rs
+++ b/clar2wasm/src/linker.rs
@@ -2501,8 +2501,8 @@ fn link_map_get_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error>
             |mut caller: Caller<'_, ClarityWasmContext>,
              name_offset: i32,
              name_length: i32,
-             key_offset: i32,
-             key_length: i32,
+             mut key_offset: i32,
+             mut key_length: i32,
              return_offset: i32,
              _return_length: i32| {
                 // Get the memory from the caller
@@ -2528,6 +2528,10 @@ fn link_map_get_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error>
                     .clone();
 
                 // Read in the key from the Wasm memory
+                if is_in_memory_type(&data_types.key_type) {
+                    (key_offset, key_length) =
+                        read_indirect_offset_and_length(memory, &mut caller, key_offset)?;
+                }
                 let key = read_from_wasm(
                     memory,
                     &mut caller,
@@ -2590,10 +2594,10 @@ fn link_map_set_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error>
             |mut caller: Caller<'_, ClarityWasmContext>,
              name_offset: i32,
              name_length: i32,
-             key_offset: i32,
-             key_length: i32,
-             value_offset: i32,
-             value_length: i32| {
+             mut key_offset: i32,
+             mut key_length: i32,
+             mut value_offset: i32,
+             mut value_length: i32| {
                 if caller.data().global_context.is_read_only() {
                     return Err(CheckErrors::WriteAttemptedInReadOnly.into());
                 }
@@ -2623,6 +2627,10 @@ fn link_map_set_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error>
                     .clone();
 
                 // Read in the key from the Wasm memory
+                if is_in_memory_type(&data_types.key_type) {
+                    (key_offset, key_length) =
+                        read_indirect_offset_and_length(memory, &mut caller, key_offset)?;
+                }
                 let key = read_from_wasm(
                     memory,
                     &mut caller,
@@ -2633,6 +2641,10 @@ fn link_map_set_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error>
                 )?;
 
                 // Read in the value from the Wasm memory
+                if is_in_memory_type(&data_types.value_type) {
+                    (value_offset, value_length) =
+                        read_indirect_offset_and_length(memory, &mut caller, value_offset)?;
+                }
                 let value = read_from_wasm(
                     memory,
                     &mut caller,
@@ -2663,7 +2675,7 @@ fn link_map_set_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error>
                     .data_mut()
                     .global_context
                     .add_memory(result_size)
-                    .map_err(Error::from)?;
+                    .map_err(|e| Error::from(e))?;
 
                 let value = result.map(|data| data.value)?;
                 if let Value::Bool(true) = value {
@@ -2692,10 +2704,10 @@ fn link_map_insert_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Err
             |mut caller: Caller<'_, ClarityWasmContext>,
              name_offset: i32,
              name_length: i32,
-             key_offset: i32,
-             key_length: i32,
-             value_offset: i32,
-             value_length: i32| {
+             mut key_offset: i32,
+             mut key_length: i32,
+             mut value_offset: i32,
+             mut value_length: i32| {
                 if caller.data().global_context.is_read_only() {
                     return Err(CheckErrors::WriteAttemptedInReadOnly.into());
                 }
@@ -2725,6 +2737,10 @@ fn link_map_insert_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Err
                     .clone();
 
                 // Read in the key from the Wasm memory
+                if is_in_memory_type(&data_types.key_type) {
+                    (key_offset, key_length) =
+                        read_indirect_offset_and_length(memory, &mut caller, key_offset)?;
+                }
                 let key = read_from_wasm(
                     memory,
                     &mut caller,
@@ -2735,6 +2751,10 @@ fn link_map_insert_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Err
                 )?;
 
                 // Read in the value from the Wasm memory
+                if is_in_memory_type(&data_types.value_type) {
+                    (value_offset, value_length) =
+                        read_indirect_offset_and_length(memory, &mut caller, value_offset)?;
+                }
                 let value = read_from_wasm(
                     memory,
                     &mut caller,
@@ -2765,7 +2785,7 @@ fn link_map_insert_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Err
                     .data_mut()
                     .global_context
                     .add_memory(result_size)
-                    .map_err(Error::from)?;
+                    .map_err(|e| Error::from(e))?;
 
                 let value = result.map(|data| data.value)?;
                 if let Value::Bool(true) = value {
@@ -2794,8 +2814,8 @@ fn link_map_delete_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Err
             |mut caller: Caller<'_, ClarityWasmContext>,
              name_offset: i32,
              name_length: i32,
-             key_offset: i32,
-             key_length: i32| {
+             mut key_offset: i32,
+             mut key_length: i32| {
                 if caller.data().global_context.is_read_only() {
                     return Err(CheckErrors::WriteAttemptedInReadOnly.into());
                 }
@@ -2824,6 +2844,10 @@ fn link_map_delete_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Err
                     .clone();
 
                 // Read in the key from the Wasm memory
+                if is_in_memory_type(&data_types.key_type) {
+                    (key_offset, key_length) =
+                        read_indirect_offset_and_length(memory, &mut caller, key_offset)?;
+                }
                 let key = read_from_wasm(
                     memory,
                     &mut caller,
@@ -2853,7 +2877,7 @@ fn link_map_delete_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Err
                     .data_mut()
                     .global_context
                     .add_memory(result_size)
-                    .map_err(Error::from)?;
+                    .map_err(|e| Error::from(e))?;
 
                 let value = result.map(|data| data.value)?;
                 if let Value::Bool(true) = value {
@@ -3854,7 +3878,7 @@ fn link_principal_of_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), E
                     _ => return Err(CheckErrors::TypeValueError(BUFF_33.clone(), key_val).into()),
                 };
 
-                if let Ok(pub_key) = Secp256k1PublicKey::from_slice(pub_key) {
+                if let Ok(pub_key) = Secp256k1PublicKey::from_slice(&pub_key) {
                     // Note: Clarity1 had a bug in how the address is computed (issues/2619).
                     // We want to preserve the old behavior unless the version is greater.
                     let addr = if *caller.data().contract_context().get_clarity_version()

--- a/clar2wasm/src/linker.rs
+++ b/clar2wasm/src/linker.rs
@@ -2675,7 +2675,7 @@ fn link_map_set_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error>
                     .data_mut()
                     .global_context
                     .add_memory(result_size)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
 
                 let value = result.map(|data| data.value)?;
                 if let Value::Bool(true) = value {
@@ -2785,7 +2785,7 @@ fn link_map_insert_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Err
                     .data_mut()
                     .global_context
                     .add_memory(result_size)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
 
                 let value = result.map(|data| data.value)?;
                 if let Value::Bool(true) = value {
@@ -2877,7 +2877,7 @@ fn link_map_delete_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Err
                     .data_mut()
                     .global_context
                     .add_memory(result_size)
-                    .map_err(|e| Error::from(e))?;
+                    .map_err(Error::from)?;
 
                 let value = result.map(|data| data.value)?;
                 if let Value::Bool(true) = value {
@@ -3878,7 +3878,7 @@ fn link_principal_of_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), E
                     _ => return Err(CheckErrors::TypeValueError(BUFF_33.clone(), key_val).into()),
                 };
 
-                if let Ok(pub_key) = Secp256k1PublicKey::from_slice(&pub_key) {
+                if let Ok(pub_key) = Secp256k1PublicKey::from_slice(pub_key) {
                     // Note: Clarity1 had a bug in how the address is computed (issues/2619).
                     // We want to preserve the old behavior unless the version is greater.
                     let addr = if *caller.data().contract_context().get_clarity_version()

--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -20,7 +20,6 @@ use clarity::vm::{eval_all, ClarityVersion, ContractContext, Value};
 
 use crate::compile;
 use crate::datastore::{BurnDatastore, Datastore, StacksConstants};
-
 use crate::initialize::initialize_contract;
 
 #[derive(Clone)]

--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -10,7 +10,6 @@ use clarity::consts::CHAIN_ID_TESTNET;
 use clarity::types::StacksEpochId;
 use clarity::vm::analysis::run_analysis;
 use clarity::vm::ast::build_ast;
-use clarity::vm::clarity_wasm::initialize_contract;
 use clarity::vm::contexts::GlobalContext;
 use clarity::vm::contracts::Contract;
 use clarity::vm::costs::LimitedCostTracker;
@@ -21,6 +20,8 @@ use clarity::vm::{eval_all, ClarityVersion, ContractContext, Value};
 
 use crate::compile;
 use crate::datastore::{BurnDatastore, Datastore, StacksConstants};
+
+use crate::initialize::initialize_contract;
 
 #[derive(Clone)]
 pub struct TestEnvironment {

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -2,7 +2,6 @@ use std::borrow::BorrowMut;
 use std::collections::HashMap;
 
 use clarity::vm::analysis::ContractAnalysis;
-use clarity::vm::clarity_wasm::{get_type_in_memory_size, get_type_size, is_in_memory_type};
 use clarity::vm::diagnostic::DiagnosableError;
 use clarity::vm::types::signatures::{StringUTF8Length, BUFF_1};
 use clarity::vm::types::{
@@ -18,6 +17,8 @@ use walrus::{
     ActiveData, DataKind, FunctionBuilder, FunctionId, GlobalId, InstrSeqBuilder, LocalId,
     MemoryId, Module, ValType,
 };
+
+use crate::wasm_utils::{get_type_in_memory_size, get_type_size, is_in_memory_type};
 
 use crate::words;
 

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -19,7 +19,6 @@ use walrus::{
 };
 
 use crate::wasm_utils::{get_type_in_memory_size, get_type_size, is_in_memory_type};
-
 use crate::words;
 
 // First free position after data directly defined in standard.wat

--- a/clar2wasm/src/wasm_utils.rs
+++ b/clar2wasm/src/wasm_utils.rs
@@ -257,8 +257,14 @@ pub fn wasm_to_clarity_value(
             memory
                 .read(&mut store, offset as usize + 21, &mut buffer)
                 .map_err(|e| Error::Wasm(WasmError::UnableToReadMemory(e.into())))?;
-            let standard =
-                StandardPrincipalData(principal_bytes[0], principal_bytes[1..].try_into()?);
+            let standard = StandardPrincipalData(
+                principal_bytes[0],
+                principal_bytes[1..].try_into().map_err(|_| {
+                    Error::Wasm(WasmError::WasmGeneratorError(
+                        "Could not decode principal".into(),
+                    ))
+                })?,
+            );
             let contract_name_length = buffer[0] as usize;
             if contract_name_length == 0 {
                 Ok((Some(Value::Principal(PrincipalData::Standard(standard))), 2))

--- a/clar2wasm/src/wasm_utils.rs
+++ b/clar2wasm/src/wasm_utils.rs
@@ -620,17 +620,22 @@ pub fn get_type_in_memory_size(ty: &TypeSignature, include_repr: bool) -> i32 {
             }
             size
         }
-        TypeSignature::OptionalType(inner) => 4 + get_type_in_memory_size(inner, true),
+        TypeSignature::OptionalType(inner) => 4 + get_type_in_memory_size(inner, include_repr),
         TypeSignature::SequenceType(SequenceSubtype::ListType(list_data)) => {
-            let mut size =
-                list_data.get_max_len() as i32 * get_type_size(list_data.get_list_item_type());
+            if include_repr {
+                8 // offset + length
+                 + list_data.get_max_len() as i32
+                    * get_type_in_memory_size(list_data.get_list_item_type(), true)
+            } else {
+                list_data.get_max_len() as i32 * get_type_size(list_data.get_list_item_type())
+            }
+        }
+        TypeSignature::SequenceType(SequenceSubtype::BufferType(length)) => {
+            let mut size = u32::from(length) as i32;
             if include_repr {
                 size += 8; // offset + length
             }
             size
-        }
-        TypeSignature::SequenceType(SequenceSubtype::BufferType(length)) => {
-            u32::from(length) as i32
         }
         TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::UTF8(length))) => {
             let mut size = u32::from(length) as i32 * 4;
@@ -644,14 +649,14 @@ pub fn get_type_in_memory_size(ty: &TypeSignature, include_repr: bool) -> i32 {
         TypeSignature::TupleType(tuple_ty) => {
             let mut size = 0;
             for inner_type in tuple_ty.get_type_map().values() {
-                size += get_type_in_memory_size(inner_type, true);
+                size += get_type_in_memory_size(inner_type, include_repr);
             }
             size
         }
         TypeSignature::ResponseType(res_types) => {
             // indicator: i32, ok_val: inner_types.0, err_val: inner_types.1
-            4 + get_type_in_memory_size(&res_types.0, true)
-                + get_type_in_memory_size(&res_types.1, true)
+            4 + get_type_in_memory_size(&res_types.0, include_repr)
+                + get_type_in_memory_size(&res_types.1, include_repr)
         }
         TypeSignature::ListUnionType(_) => unreachable!("not a value type"),
     }

--- a/clar2wasm/src/wasm_utils.rs
+++ b/clar2wasm/src/wasm_utils.rs
@@ -6,15 +6,11 @@ use clarity::vm::analysis::CheckErrors;
 use clarity::vm::contexts::GlobalContext;
 use clarity::vm::errors::{Error, WasmError};
 use clarity::vm::types::{
-    ASCIIData, BuffData, CharType, ListData, OptionalData, PrincipalData,
-    QualifiedContractIdentifier, ResponseData, SequenceData, StandardPrincipalData, TupleData,
+    ASCIIData, BuffData, BufferLength, CharType, ListData, OptionalData, PrincipalData,
+    QualifiedContractIdentifier, ResponseData, SequenceData, SequenceSubtype, SequencedValue,
+    StandardPrincipalData, StringSubtype, TupleData, TypeSignature,
 };
-use clarity::vm::types::{
-    BufferLength, SequenceSubtype, SequencedValue, StringSubtype, TypeSignature,
-};
-use clarity::vm::CallStack;
-use clarity::vm::Value;
-use clarity::vm::{ContractContext, ContractName};
+use clarity::vm::{CallStack, ContractContext, ContractName, Value};
 use stacks_common::types::StacksEpochId;
 use wasmtime::{AsContextMut, Engine, Linker, Memory, Module, Store, Val, ValType};
 

--- a/clar2wasm/src/wasm_utils.rs
+++ b/clar2wasm/src/wasm_utils.rs
@@ -258,7 +258,7 @@ pub fn wasm_to_clarity_value(
                 .read(&mut store, offset as usize + 21, &mut buffer)
                 .map_err(|e| Error::Wasm(WasmError::UnableToReadMemory(e.into())))?;
             let standard =
-                StandardPrincipalData(principal_bytes[0], principal_bytes[1..].try_into().unwrap());
+                StandardPrincipalData(principal_bytes[0], principal_bytes[1..].try_into()?);
             let contract_name_length = buffer[0] as usize;
             if contract_name_length == 0 {
                 Ok((Some(Value::Principal(PrincipalData::Standard(standard))), 2))
@@ -681,7 +681,7 @@ pub fn write_to_wasm(
     match ty {
         TypeSignature::IntType => {
             let mut buffer: [u8; 8] = [0; 8];
-            let i = value_as_i128(&value)?;
+            let i = value_as_i128(value)?;
             let high = (i >> 64) as u64;
             let low = (i & 0xffff_ffff_ffff_ffff) as u64;
             buffer.copy_from_slice(&low.to_le_bytes());
@@ -1136,6 +1136,7 @@ pub fn is_in_memory_type(ty: &TypeSignature) -> bool {
     }
 }
 
+#[allow(clippy::unimplemented)]
 fn clar2wasm_ty(ty: &TypeSignature) -> Vec<ValType> {
     match ty {
         TypeSignature::NoType => vec![ValType::I32], // TODO: can this just be empty?

--- a/clar2wasm/src/wasm_utils.rs
+++ b/clar2wasm/src/wasm_utils.rs
@@ -1,0 +1,1170 @@
+#![allow(non_camel_case_types)]
+
+use clarity::vm::analysis::CheckErrors;
+use clarity::vm::errors::{Error, WasmError};
+use clarity::vm::types::{
+    ASCIIData, BuffData, CharType, ListData, OptionalData, PrincipalData,
+    QualifiedContractIdentifier, ResponseData, SequenceData, StandardPrincipalData, TupleData,
+};
+use clarity::vm::types::{
+    BufferLength, SequenceSubtype, SequencedValue, StringSubtype, TypeSignature,
+};
+use clarity::vm::ContractName;
+use clarity::vm::Value;
+use stacks_common::types::StacksEpochId;
+use wasmtime::{AsContextMut, Memory, Val, ValType};
+
+#[allow(non_snake_case)]
+pub enum MintAssetErrorCodes {
+    ALREADY_EXIST = 1,
+}
+
+pub enum MintTokenErrorCodes {
+    NON_POSITIVE_AMOUNT = 1,
+}
+
+#[allow(non_snake_case)]
+pub enum TransferAssetErrorCodes {
+    NOT_OWNED_BY = 1,
+    SENDER_IS_RECIPIENT = 2,
+    DOES_NOT_EXIST = 3,
+}
+
+#[allow(non_snake_case)]
+pub enum TransferTokenErrorCodes {
+    NOT_ENOUGH_BALANCE = 1,
+    SENDER_IS_RECIPIENT = 2,
+    NON_POSITIVE_AMOUNT = 3,
+}
+
+#[allow(non_snake_case)]
+pub enum BurnAssetErrorCodes {
+    NOT_OWNED_BY = 1,
+    DOES_NOT_EXIST = 3,
+}
+
+#[allow(non_snake_case)]
+pub enum BurnTokenErrorCodes {
+    NOT_ENOUGH_BALANCE_OR_NON_POSITIVE = 1,
+}
+
+pub enum StxErrorCodes {
+    NOT_ENOUGH_BALANCE = 1,
+    SENDER_IS_RECIPIENT = 2,
+    NON_POSITIVE_AMOUNT = 3,
+    SENDER_IS_NOT_TX_SENDER = 4,
+}
+
+// Bytes for principal version
+pub const PRINCIPAL_VERSION_BYTES: usize = 1;
+// Number of bytes in principal hash
+pub const PRINCIPAL_HASH_BYTES: usize = 20;
+// Standard principal version + hash
+pub const PRINCIPAL_BYTES: usize = PRINCIPAL_VERSION_BYTES + PRINCIPAL_HASH_BYTES;
+// Number of bytes used to store the length of the contract name
+pub const CONTRACT_NAME_LENGTH_BYTES: usize = 1;
+// 1 byte for version, 20 bytes for hash, 4 bytes for contract name length (0)
+pub const STANDARD_PRINCIPAL_BYTES: usize = PRINCIPAL_BYTES + CONTRACT_NAME_LENGTH_BYTES;
+// Max length of a contract name
+pub const CONTRACT_NAME_MAX_LENGTH: usize = 128;
+// Standard principal, but at most 128 character function name
+pub const PRINCIPAL_BYTES_MAX: usize = STANDARD_PRINCIPAL_BYTES + CONTRACT_NAME_MAX_LENGTH;
+
+/// Convert a Wasm value into a Clarity `Value`. Depending on the type, the
+/// values may be directly passed in the Wasm `Val`s or may be read from the
+/// Wasm memory, via an offset and size.
+/// - `type_sig` is the Clarity type of the value.
+/// - `value_index` is the index of the value in the array of Wasm `Val`s.
+/// - `buffer` is the array of Wasm `Val`s.
+/// - `memory` is the Wasm memory.
+/// - `store` is the Wasm store.
+/// Returns the Clarity `Value` and the number of Wasm `Val`s that were used.
+pub fn wasm_to_clarity_value(
+    type_sig: &TypeSignature,
+    value_index: usize,
+    buffer: &[Val],
+    memory: Memory,
+    mut store: &mut impl AsContextMut,
+    epoch: StacksEpochId,
+) -> Result<(Option<Value>, usize), Error> {
+    match type_sig {
+        TypeSignature::IntType => {
+            let lower = buffer[value_index]
+                .i64()
+                .ok_or(Error::Wasm(WasmError::ValueTypeMismatch))?;
+            let upper = buffer[value_index + 1]
+                .i64()
+                .ok_or(Error::Wasm(WasmError::ValueTypeMismatch))?;
+            Ok((
+                Some(Value::Int(((upper as i128) << 64) | (lower as u64) as i128)),
+                2,
+            ))
+        }
+        TypeSignature::UIntType => {
+            let lower = buffer[value_index]
+                .i64()
+                .ok_or(Error::Wasm(WasmError::ValueTypeMismatch))?;
+            let upper = buffer[value_index + 1]
+                .i64()
+                .ok_or(Error::Wasm(WasmError::ValueTypeMismatch))?;
+            Ok((
+                Some(Value::UInt(
+                    ((upper as u128) << 64) | (lower as u64) as u128,
+                )),
+                2,
+            ))
+        }
+        TypeSignature::BoolType => Ok((
+            Some(Value::Bool(
+                buffer[value_index]
+                    .i32()
+                    .ok_or(Error::Wasm(WasmError::ValueTypeMismatch))?
+                    != 0,
+            )),
+            1,
+        )),
+        TypeSignature::OptionalType(optional) => {
+            let value_types = clar2wasm_ty(optional);
+            Ok((
+                if buffer[value_index]
+                    .i32()
+                    .ok_or(Error::Wasm(WasmError::ValueTypeMismatch))?
+                    == 1
+                {
+                    let (value, _) = wasm_to_clarity_value(
+                        optional,
+                        value_index + 1,
+                        buffer,
+                        memory,
+                        store,
+                        epoch,
+                    )?;
+                    Some(Value::some(value.ok_or(Error::Unchecked(
+                        CheckErrors::CouldNotDetermineType,
+                    ))?)?)
+                } else {
+                    Some(Value::none())
+                },
+                1 + value_types.len(),
+            ))
+        }
+        TypeSignature::ResponseType(response) => {
+            let ok_types = clar2wasm_ty(&response.0);
+            let err_types = clar2wasm_ty(&response.1);
+
+            Ok((
+                if buffer[value_index]
+                    .i32()
+                    .ok_or(Error::Wasm(WasmError::ValueTypeMismatch))?
+                    == 1
+                {
+                    let (ok, _) = wasm_to_clarity_value(
+                        &response.0,
+                        value_index + 1,
+                        buffer,
+                        memory,
+                        store,
+                        epoch,
+                    )?;
+                    Some(Value::okay(ok.ok_or(Error::Unchecked(
+                        CheckErrors::CouldNotDetermineResponseOkType,
+                    ))?)?)
+                } else {
+                    let (err, _) = wasm_to_clarity_value(
+                        &response.1,
+                        value_index + 1 + ok_types.len(),
+                        buffer,
+                        memory,
+                        store,
+                        epoch,
+                    )?;
+                    Some(Value::error(err.ok_or(Error::Unchecked(
+                        CheckErrors::CouldNotDetermineResponseErrType,
+                    ))?)?)
+                },
+                1 + ok_types.len() + err_types.len(),
+            ))
+        }
+        TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::ASCII(_))) => {
+            let offset = buffer[value_index]
+                .i32()
+                .ok_or(Error::Wasm(WasmError::ValueTypeMismatch))?;
+            let length = buffer[value_index + 1]
+                .i32()
+                .ok_or(Error::Wasm(WasmError::ValueTypeMismatch))?;
+            let mut string_buffer: Vec<u8> = vec![0; length as usize];
+            memory
+                .read(store, offset as usize, &mut string_buffer)
+                .map_err(|e| Error::Wasm(WasmError::UnableToReadMemory(e.into())))?;
+            Ok((Some(Value::string_ascii_from_bytes(string_buffer)?), 2))
+        }
+        // A `NoType` will be a dummy value that should not be used.
+        TypeSignature::NoType => Ok((None, 1)),
+        TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::UTF8(_))) => {
+            let offset = buffer[value_index]
+                .i32()
+                .ok_or(Error::Wasm(WasmError::ValueTypeMismatch))?;
+            let length = buffer[value_index + 1]
+                .i32()
+                .ok_or(Error::Wasm(WasmError::ValueTypeMismatch))?;
+            let mut string_buffer: Vec<u8> = vec![0; length as usize];
+            memory
+                .read(store, offset as usize, &mut string_buffer)
+                .map_err(|e| Error::Wasm(WasmError::UnableToReadMemory(e.into())))?;
+            Ok((
+                Some(Value::string_utf8_from_unicode_scalars(string_buffer)?),
+                2,
+            ))
+        }
+        TypeSignature::SequenceType(SequenceSubtype::BufferType(_buffer_length)) => {
+            let offset = buffer[value_index]
+                .i32()
+                .ok_or(Error::Wasm(WasmError::ValueTypeMismatch))?;
+            let length = buffer[value_index + 1]
+                .i32()
+                .ok_or(Error::Wasm(WasmError::ValueTypeMismatch))?;
+            let mut buff: Vec<u8> = vec![0; length as usize];
+            memory
+                .read(store, offset as usize, &mut buff)
+                .map_err(|e| Error::Wasm(WasmError::UnableToReadMemory(e.into())))?;
+            Ok((Some(Value::buff_from(buff)?), 2))
+        }
+        TypeSignature::SequenceType(SequenceSubtype::ListType(_)) => {
+            let offset = buffer[value_index]
+                .i32()
+                .ok_or(Error::Wasm(WasmError::ValueTypeMismatch))?;
+            let length = buffer[value_index + 1]
+                .i32()
+                .ok_or(Error::Wasm(WasmError::ValueTypeMismatch))?;
+
+            let value = read_from_wasm(memory, store, type_sig, offset, length, epoch)?;
+            Ok((Some(value), 2))
+        }
+        TypeSignature::PrincipalType
+        | TypeSignature::CallableType(_)
+        | TypeSignature::TraitReferenceType(_) => {
+            let offset = buffer[value_index]
+                .i32()
+                .ok_or(Error::Wasm(WasmError::ValueTypeMismatch))?;
+            let mut principal_bytes: [u8; 1 + PRINCIPAL_HASH_BYTES] = [0; 1 + PRINCIPAL_HASH_BYTES];
+            memory
+                .read(&mut store, offset as usize, &mut principal_bytes)
+                .map_err(|e| Error::Wasm(WasmError::UnableToReadMemory(e.into())))?;
+            let mut buffer: [u8; CONTRACT_NAME_LENGTH_BYTES] = [0; CONTRACT_NAME_LENGTH_BYTES];
+            memory
+                .read(&mut store, offset as usize + 21, &mut buffer)
+                .map_err(|e| Error::Wasm(WasmError::UnableToReadMemory(e.into())))?;
+            let standard =
+                StandardPrincipalData(principal_bytes[0], principal_bytes[1..].try_into().unwrap());
+            let contract_name_length = buffer[0] as usize;
+            if contract_name_length == 0 {
+                Ok((Some(Value::Principal(PrincipalData::Standard(standard))), 2))
+            } else {
+                let mut contract_name: Vec<u8> = vec![0; contract_name_length];
+                memory
+                    .read(
+                        store,
+                        (offset + STANDARD_PRINCIPAL_BYTES as i32) as usize,
+                        &mut contract_name,
+                    )
+                    .map_err(|e| Error::Wasm(WasmError::UnableToReadMemory(e.into())))?;
+                Ok((
+                    Some(Value::Principal(PrincipalData::Contract(
+                        QualifiedContractIdentifier {
+                            issuer: standard,
+                            name: ContractName::try_from(
+                                String::from_utf8(contract_name).map_err(|e| {
+                                    Error::Wasm(WasmError::UnableToReadIdentifier(e))
+                                })?,
+                            )?,
+                        },
+                    ))),
+                    2,
+                ))
+            }
+        }
+        TypeSignature::TupleType(t) => {
+            let mut index = value_index;
+            let mut data_map = Vec::new();
+            for (name, ty) in t.get_type_map() {
+                let (value, increment) =
+                    wasm_to_clarity_value(ty, index, buffer, memory, store, epoch)?;
+                data_map.push((
+                    name.clone(),
+                    value.ok_or(Error::Unchecked(CheckErrors::BadTupleConstruction))?,
+                ));
+                index += increment;
+            }
+            let tuple = TupleData::from_data(data_map)?;
+            Ok((Some(tuple.into()), index - value_index))
+        }
+        TypeSignature::ListUnionType(_lu) => {
+            todo!("Wasm value type not implemented: {:?}", type_sig)
+        }
+    }
+}
+
+/// Read a value from the Wasm memory at `offset` with `length` given the
+/// provided Clarity `TypeSignature`. In-memory values require one extra level
+/// of indirection, so this function will read the offset and length from the
+/// memory, then read the actual value.
+pub fn read_from_wasm_indirect(
+    memory: Memory,
+    store: &mut impl AsContextMut,
+    ty: &TypeSignature,
+    mut offset: i32,
+    epoch: StacksEpochId,
+) -> Result<Value, Error> {
+    let mut length = get_type_size(ty);
+
+    // For in-memory types, first read the offset and length from the memory,
+    // then read the actual value.
+    if is_in_memory_type(ty) {
+        (offset, length) = read_indirect_offset_and_length(memory, store, offset)?;
+    };
+
+    read_from_wasm(memory, store, ty, offset, length, epoch)
+}
+
+/// Read a value from the Wasm memory at `offset` with `length`, given the
+/// provided Clarity `TypeSignature`.
+pub fn read_from_wasm(
+    memory: Memory,
+    mut store: &mut impl AsContextMut,
+    ty: &TypeSignature,
+    offset: i32,
+    length: i32,
+    epoch: StacksEpochId,
+) -> Result<Value, Error> {
+    match ty {
+        TypeSignature::UIntType => {
+            debug_assert!(
+                length == 16,
+                "expected uint length to be 16 bytes, found {length}"
+            );
+            let mut buffer: [u8; 8] = [0; 8];
+            memory
+                .read(&mut store, offset as usize, &mut buffer)
+                .map_err(|e| Error::Wasm(WasmError::Runtime(e.into())))?;
+            let low = u64::from_le_bytes(buffer) as u128;
+            memory
+                .read(store, (offset + 8) as usize, &mut buffer)
+                .map_err(|e| Error::Wasm(WasmError::Runtime(e.into())))?;
+            let high = u64::from_le_bytes(buffer) as u128;
+            Ok(Value::UInt((high << 64) | low))
+        }
+        TypeSignature::IntType => {
+            debug_assert!(
+                length == 16,
+                "expected int length to be 16 bytes, found {length}"
+            );
+            let mut buffer: [u8; 8] = [0; 8];
+            memory
+                .read(&mut store, offset as usize, &mut buffer)
+                .map_err(|e| Error::Wasm(WasmError::Runtime(e.into())))?;
+            let low = u64::from_le_bytes(buffer) as u128;
+            memory
+                .read(store, (offset + 8) as usize, &mut buffer)
+                .map_err(|e| Error::Wasm(WasmError::Runtime(e.into())))?;
+            let high = u64::from_le_bytes(buffer) as u128;
+            Ok(Value::Int(((high << 64) | low) as i128))
+        }
+        TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::ASCII(
+            type_length,
+        ))) => {
+            debug_assert!(
+                type_length >= &BufferLength::try_from(length as u32)?,
+                "expected string length to be less than the type length"
+            );
+            let mut buffer: Vec<u8> = vec![0; length as usize];
+            memory
+                .read(store, offset as usize, &mut buffer)
+                .map_err(|e| Error::Wasm(WasmError::Runtime(e.into())))?;
+            Value::string_ascii_from_bytes(buffer)
+        }
+        TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::UTF8(_s))) => {
+            let mut buffer: Vec<u8> = vec![0; length as usize];
+            memory
+                .read(store, offset as usize, &mut buffer)
+                .map_err(|e| Error::Wasm(WasmError::Runtime(e.into())))?;
+            Value::string_utf8_from_unicode_scalars(buffer)
+        }
+        TypeSignature::PrincipalType
+        | TypeSignature::CallableType(_)
+        | TypeSignature::TraitReferenceType(_) => {
+            debug_assert!(
+                length >= STANDARD_PRINCIPAL_BYTES as i32 && length <= PRINCIPAL_BYTES_MAX as i32
+            );
+            let mut current_offset = offset as usize;
+            let mut version: [u8; PRINCIPAL_VERSION_BYTES] = [0; PRINCIPAL_VERSION_BYTES];
+            let mut hash: [u8; PRINCIPAL_HASH_BYTES] = [0; PRINCIPAL_HASH_BYTES];
+            memory
+                .read(&mut store, current_offset, &mut version)
+                .map_err(|e| Error::Wasm(WasmError::Runtime(e.into())))?;
+            current_offset += PRINCIPAL_VERSION_BYTES;
+            memory
+                .read(&mut store, current_offset, &mut hash)
+                .map_err(|e| Error::Wasm(WasmError::Runtime(e.into())))?;
+            current_offset += PRINCIPAL_HASH_BYTES;
+            let principal = StandardPrincipalData(version[0], hash);
+            let mut contract_length_buf: [u8; CONTRACT_NAME_LENGTH_BYTES] =
+                [0; CONTRACT_NAME_LENGTH_BYTES];
+            memory
+                .read(&mut store, current_offset, &mut contract_length_buf)
+                .map_err(|e| Error::Wasm(WasmError::Runtime(e.into())))?;
+            current_offset += CONTRACT_NAME_LENGTH_BYTES;
+            let contract_length = contract_length_buf[0];
+            if contract_length == 0 {
+                Ok(Value::Principal(principal.into()))
+            } else {
+                let mut contract_name: Vec<u8> = vec![0; contract_length as usize];
+                memory
+                    .read(store, current_offset, &mut contract_name)
+                    .map_err(|e| Error::Wasm(WasmError::Runtime(e.into())))?;
+                let contract_name = String::from_utf8(contract_name)
+                    .map_err(|e| Error::Wasm(WasmError::Runtime(e.into())))?;
+                Ok(Value::Principal(PrincipalData::Contract(
+                    QualifiedContractIdentifier {
+                        issuer: principal,
+                        name: ContractName::try_from(contract_name)?,
+                    },
+                )))
+            }
+        }
+        TypeSignature::SequenceType(SequenceSubtype::BufferType(_b)) => {
+            let mut buffer: Vec<u8> = vec![0; length as usize];
+            memory
+                .read(store, offset as usize, &mut buffer)
+                .map_err(|e| Error::Wasm(WasmError::Runtime(e.into())))?;
+            Value::buff_from(buffer)
+        }
+        TypeSignature::SequenceType(SequenceSubtype::ListType(list)) => {
+            let elem_ty = list.get_list_item_type();
+            let elem_length = get_type_size(elem_ty);
+            let end = offset + length;
+            let mut buffer: Vec<Value> = Vec::new();
+            let mut current_offset = offset;
+            while current_offset < end {
+                let elem = read_from_wasm_indirect(memory, store, elem_ty, current_offset, epoch)?;
+                buffer.push(elem);
+                current_offset += elem_length;
+            }
+            Value::cons_list_unsanitized(buffer)
+        }
+        TypeSignature::BoolType => {
+            debug_assert!(
+                length == 4,
+                "expected bool length to be 4 bytes, found {length}"
+            );
+            let mut buffer: [u8; 4] = [0; 4];
+            memory
+                .read(&mut store, offset as usize, &mut buffer)
+                .map_err(|e| Error::Wasm(WasmError::Runtime(e.into())))?;
+            let bool_val = u32::from_le_bytes(buffer);
+            Ok(Value::Bool(bool_val != 0))
+        }
+        TypeSignature::TupleType(type_sig) => {
+            let mut data = Vec::new();
+            let mut current_offset = offset;
+            for (field_key, field_ty) in type_sig.get_type_map() {
+                let field_length = get_type_size(field_ty);
+                let field_value =
+                    read_from_wasm_indirect(memory, store, field_ty, current_offset, epoch)?;
+                data.push((field_key.clone(), field_value));
+                current_offset += field_length;
+            }
+            Ok(Value::Tuple(TupleData::from_data(data)?))
+        }
+        TypeSignature::ResponseType(response_type) => {
+            let mut current_offset = offset;
+
+            // Read the indicator
+            let mut indicator_bytes = [0u8; 4];
+            memory
+                .read(&mut store, current_offset as usize, &mut indicator_bytes)
+                .map_err(|e| Error::Wasm(WasmError::Runtime(e.into())))?;
+            current_offset += 4;
+            let indicator = i32::from_le_bytes(indicator_bytes);
+
+            // Read the ok or err value, depending on the indicator
+            match indicator {
+                0 => {
+                    current_offset += get_type_size(&response_type.0);
+                    let err_value = read_from_wasm_indirect(
+                        memory,
+                        store,
+                        &response_type.1,
+                        current_offset,
+                        epoch,
+                    )?;
+                    Value::error(err_value).map_err(|_| Error::Wasm(WasmError::ValueTypeMismatch))
+                }
+                1 => {
+                    let ok_value = read_from_wasm_indirect(
+                        memory,
+                        store,
+                        &response_type.0,
+                        current_offset,
+                        epoch,
+                    )?;
+                    Value::okay(ok_value).map_err(|_| Error::Wasm(WasmError::ValueTypeMismatch))
+                }
+                _ => Err(Error::Wasm(WasmError::InvalidIndicator(indicator))),
+            }
+        }
+        TypeSignature::OptionalType(type_sig) => {
+            let mut current_offset = offset;
+
+            // Read the indicator
+            let mut indicator_bytes = [0u8; 4];
+            memory
+                .read(&mut store, current_offset as usize, &mut indicator_bytes)
+                .map_err(|e| Error::Wasm(WasmError::Runtime(e.into())))?;
+            current_offset += 4;
+            let indicator = i32::from_le_bytes(indicator_bytes);
+
+            match indicator {
+                0 => Ok(Value::none()),
+                1 => {
+                    let value =
+                        read_from_wasm_indirect(memory, store, type_sig, current_offset, epoch)?;
+                    Ok(
+                        Value::some(value)
+                            .map_err(|_| Error::Wasm(WasmError::ValueTypeMismatch))?,
+                    )
+                }
+                _ => Err(Error::Wasm(WasmError::InvalidIndicator(indicator))),
+            }
+        }
+        TypeSignature::NoType => todo!("type not yet implemented: {:?}", ty),
+        TypeSignature::ListUnionType(_subtypes) => todo!("type not yet implemented: {:?}", ty),
+    }
+}
+
+pub fn read_indirect_offset_and_length(
+    memory: Memory,
+    mut store: &mut impl AsContextMut,
+    offset: i32,
+) -> Result<(i32, i32), Error> {
+    let mut buffer: [u8; 4] = [0; 4];
+    memory
+        .read(&mut store, offset as usize, &mut buffer)
+        .map_err(|e| Error::Wasm(WasmError::Runtime(e.into())))?;
+    let indirect_offset = i32::from_le_bytes(buffer);
+    memory
+        .read(&mut store, (offset + 4) as usize, &mut buffer)
+        .map_err(|e| Error::Wasm(WasmError::Runtime(e.into())))?;
+    let length = i32::from_le_bytes(buffer);
+    Ok((indirect_offset, length))
+}
+
+/// Return the number of bytes required to representation of a value of the
+/// type `ty`. For in-memory types, this is just the size of the offset and
+/// length. For non-in-memory types, this is the size of the value itself.
+pub fn get_type_size(ty: &TypeSignature) -> i32 {
+    match ty {
+        TypeSignature::IntType | TypeSignature::UIntType => 16, // low: i64, high: i64
+        TypeSignature::BoolType => 4,                           // i32
+        TypeSignature::PrincipalType
+        | TypeSignature::SequenceType(_)
+        | TypeSignature::CallableType(_)
+        | TypeSignature::TraitReferenceType(_) => 8, // offset: i32, length: i32
+        TypeSignature::OptionalType(inner) => 4 + get_type_size(inner), // indicator: i32, value: inner
+        TypeSignature::TupleType(tuple_ty) => {
+            let mut size = 0;
+            for inner_type in tuple_ty.get_type_map().values() {
+                size += get_type_size(inner_type);
+            }
+            size
+        }
+        TypeSignature::ResponseType(inner_types) => {
+            // indicator: i32, ok_val: inner_types.0, err_val: inner_types.1
+            4 + get_type_size(&inner_types.0) + get_type_size(&inner_types.1)
+        }
+        TypeSignature::NoType => 4, // i32
+        TypeSignature::ListUnionType(_) => {
+            unreachable!("not a value type")
+        }
+    }
+}
+
+/// Return the number of bytes required to store a value of the type `ty`.
+pub fn get_type_in_memory_size(ty: &TypeSignature, include_repr: bool) -> i32 {
+    match ty {
+        TypeSignature::IntType | TypeSignature::UIntType => 16, // i64_low + i64_high
+        TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::ASCII(length))) => {
+            let mut size = u32::from(length) as i32;
+            if include_repr {
+                size += 8; // offset + length
+            }
+            size
+        }
+        TypeSignature::PrincipalType
+        | TypeSignature::CallableType(_)
+        | TypeSignature::TraitReferenceType(_) => {
+            // Standard principal is a 1 byte version and a 20 byte Hash160.
+            // Then there is an int32 for the contract name length, followed by
+            // the contract name, which has a max length of 128.
+            let mut size = PRINCIPAL_BYTES_MAX as i32;
+            if include_repr {
+                size += 8; // offset + length
+            }
+            size
+        }
+        TypeSignature::OptionalType(inner) => 4 + get_type_in_memory_size(inner, true),
+        TypeSignature::SequenceType(SequenceSubtype::ListType(list_data)) => {
+            let mut size =
+                list_data.get_max_len() as i32 * get_type_size(list_data.get_list_item_type());
+            if include_repr {
+                size += 8; // offset + length
+            }
+            size
+        }
+        TypeSignature::SequenceType(SequenceSubtype::BufferType(length)) => {
+            u32::from(length) as i32
+        }
+        TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::UTF8(length))) => {
+            let mut size = u32::from(length) as i32 * 4;
+            if include_repr {
+                size += 8; // offset + length
+            }
+            size
+        }
+        TypeSignature::NoType => 4,   // i32
+        TypeSignature::BoolType => 4, // i32
+        TypeSignature::TupleType(tuple_ty) => {
+            let mut size = 0;
+            for inner_type in tuple_ty.get_type_map().values() {
+                size += get_type_in_memory_size(inner_type, true);
+            }
+            size
+        }
+        TypeSignature::ResponseType(res_types) => {
+            // indicator: i32, ok_val: inner_types.0, err_val: inner_types.1
+            4 + get_type_in_memory_size(&res_types.0, true)
+                + get_type_in_memory_size(&res_types.1, true)
+        }
+        TypeSignature::ListUnionType(_) => unreachable!("not a value type"),
+    }
+}
+
+/// Push a placeholder value for Wasm type `ty` onto the data stack.
+pub fn placeholder_for_type(ty: ValType) -> Val {
+    match ty {
+        ValType::I32 => Val::I32(0),
+        ValType::I64 => Val::I64(0),
+        ValType::F32 => Val::F32(0),
+        ValType::F64 => Val::F64(0),
+        ValType::V128 => Val::V128(0.into()),
+        ValType::ExternRef => unimplemented!("ExternRef"),
+        ValType::FuncRef => unimplemented!("FuncRef"),
+    }
+}
+
+/// Write a value to the Wasm memory at `offset` given the provided Clarity
+/// `TypeSignature`. If the value is an in-memory type, then it will be written
+/// to the memory at `in_mem_offset`, and if `include_repr` is true, the offset
+/// and length of the value will be written to the memory at `offset`.
+/// Returns the number of bytes written at `offset` and at `in_mem_offset`.
+pub fn write_to_wasm(
+    mut store: impl AsContextMut,
+    memory: Memory,
+    ty: &TypeSignature,
+    offset: i32,
+    in_mem_offset: i32,
+    value: &Value,
+    include_repr: bool,
+) -> Result<(i32, i32), Error> {
+    match ty {
+        TypeSignature::IntType => {
+            let mut buffer: [u8; 8] = [0; 8];
+            let i = value_as_i128(&value)?;
+            let high = (i >> 64) as u64;
+            let low = (i & 0xffff_ffff_ffff_ffff) as u64;
+            buffer.copy_from_slice(&low.to_le_bytes());
+            memory
+                .write(&mut store, offset as usize, &buffer)
+                .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
+            buffer.copy_from_slice(&high.to_le_bytes());
+            memory
+                .write(&mut store, (offset + 8) as usize, &buffer)
+                .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
+            Ok((16, 0))
+        }
+        TypeSignature::UIntType => {
+            let mut buffer: [u8; 8] = [0; 8];
+            let i = value_as_u128(&value)?;
+            let high = (i >> 64) as u64;
+            let low = (i & 0xffff_ffff_ffff_ffff) as u64;
+            buffer.copy_from_slice(&low.to_le_bytes());
+            memory
+                .write(&mut store, offset as usize, &buffer)
+                .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
+            buffer.copy_from_slice(&high.to_le_bytes());
+            memory
+                .write(&mut store, (offset + 8) as usize, &buffer)
+                .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
+            Ok((16, 0))
+        }
+        TypeSignature::SequenceType(SequenceSubtype::BufferType(_length)) => {
+            let buffdata = value_as_buffer(value.clone())?;
+            let mut written = 0;
+            let mut in_mem_written = 0;
+
+            // Write the value to `in_mem_offset`
+            memory
+                .write(
+                    &mut store,
+                    (in_mem_offset + in_mem_written) as usize,
+                    &buffdata.data,
+                )
+                .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
+            in_mem_written += buffdata.data.len() as i32;
+
+            if include_repr {
+                // Write the representation (offset and length) of the value to
+                // `offset`.
+                let offset_buffer = (in_mem_offset as i32).to_le_bytes();
+                memory
+                    .write(&mut store, (offset) as usize, &offset_buffer)
+                    .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
+                written += 4;
+                let len_buffer = (in_mem_written as i32).to_le_bytes();
+                memory
+                    .write(&mut store, (offset + written) as usize, &len_buffer)
+                    .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
+                written += 4;
+            }
+
+            Ok((written, in_mem_written))
+        }
+        TypeSignature::SequenceType(SequenceSubtype::StringType(string_subtype)) => {
+            let string = match string_subtype {
+                StringSubtype::ASCII(_length) => value_as_string_ascii(value.clone())?.data,
+                StringSubtype::UTF8(_length) => {
+                    let Value::Sequence(SequenceData::String(CharType::UTF8(utf8_data))) = value
+                    else {
+                        unreachable!("A string-utf8 type should contain a string-utf8 value")
+                    };
+                    String::from_utf8(utf8_data.items().iter().flatten().copied().collect())
+                        .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?
+                        .chars()
+                        .flat_map(|c| (c as u32).to_be_bytes())
+                        .collect()
+                }
+            };
+            let mut written = 0;
+            let mut in_mem_written = 0;
+
+            // Write the value to `in_mem_offset`
+            memory
+                .write(
+                    &mut store,
+                    (in_mem_offset + in_mem_written) as usize,
+                    &string,
+                )
+                .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
+            in_mem_written += string.len() as i32;
+
+            if include_repr {
+                // Write the representation (offset and length) of the value to
+                // `offset`.
+                let offset_buffer = (in_mem_offset as i32).to_le_bytes();
+                memory
+                    .write(&mut store, (offset) as usize, &offset_buffer)
+                    .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
+                written += 4;
+                let len_buffer = (in_mem_written as i32).to_le_bytes();
+                memory
+                    .write(&mut store, (offset + written) as usize, &len_buffer)
+                    .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
+                written += 4;
+            }
+
+            Ok((written, in_mem_written))
+        }
+        TypeSignature::SequenceType(SequenceSubtype::ListType(list)) => {
+            let mut written = 0;
+            let list_data = value_as_list(value)?;
+            let elem_ty = list.get_list_item_type();
+            // For a list, the values are written to the memory at
+            // `in_mem_offset`, and the representation (offset and length) is
+            // written to the memory at `offset`. The `in_mem_offset` for the
+            // list elements should be after their representations.
+            let val_offset = in_mem_offset;
+            let val_in_mem_offset = in_mem_offset
+                + list_data.data.len() as i32
+                    * get_type_size(list_data.type_signature.get_list_item_type());
+            let mut val_written = 0;
+            let mut val_in_mem_written = 0;
+            for elem in &list_data.data {
+                let (new_written, new_in_mem_written) = write_to_wasm(
+                    store.as_context_mut(),
+                    memory,
+                    elem_ty,
+                    val_offset + val_written,
+                    val_in_mem_offset + val_in_mem_written,
+                    &elem,
+                    true,
+                )?;
+                val_written += new_written;
+                val_in_mem_written += new_in_mem_written;
+            }
+
+            if include_repr {
+                // Write the representation (offset and length) of the value to
+                // `offset`.
+                let offset_buffer = (in_mem_offset as i32).to_le_bytes();
+                memory
+                    .write(&mut store, (offset) as usize, &offset_buffer)
+                    .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
+                written += 4;
+                let len_buffer = (val_written as i32).to_le_bytes();
+                memory
+                    .write(&mut store, (offset + 4) as usize, &len_buffer)
+                    .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
+                written += 4;
+            }
+
+            Ok((written, val_written + val_in_mem_written))
+        }
+        TypeSignature::ResponseType(inner_types) => {
+            let mut written = 0;
+            let mut in_mem_written = 0;
+            let res = value_as_response(value)?;
+            let indicator = if res.committed { 1i32 } else { 0i32 };
+            let indicator_bytes = indicator.to_le_bytes();
+            memory
+                .write(&mut store, (offset) as usize, &indicator_bytes)
+                .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
+            written += 4;
+            if res.committed {
+                let (new_written, new_in_mem_written) = write_to_wasm(
+                    store,
+                    memory,
+                    &inner_types.0,
+                    offset + written,
+                    in_mem_offset,
+                    &res.data,
+                    true,
+                )?;
+                written += new_written;
+                in_mem_written += new_in_mem_written;
+
+                // Skip space for the err value
+                written += get_type_size(&inner_types.1);
+            } else {
+                // Skip space for the ok value
+                written += get_type_size(&inner_types.0);
+
+                let (new_written, new_in_mem_written) = write_to_wasm(
+                    store,
+                    memory,
+                    &inner_types.1,
+                    offset + written,
+                    in_mem_offset,
+                    &res.data,
+                    true,
+                )?;
+                written += new_written;
+                in_mem_written += new_in_mem_written;
+            }
+            Ok((written, in_mem_written))
+        }
+        TypeSignature::BoolType => {
+            let bool_val = value_as_bool(&value)?;
+            let val = if bool_val { 1u32 } else { 0u32 };
+            let val_bytes = val.to_le_bytes();
+            memory
+                .write(&mut store, (offset) as usize, &val_bytes)
+                .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
+            Ok((4, 0))
+        }
+        TypeSignature::NoType => {
+            let val_bytes = [0u8; 4];
+            memory
+                .write(&mut store, (offset) as usize, &val_bytes)
+                .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
+            Ok((4, 0))
+        }
+        TypeSignature::OptionalType(inner_ty) => {
+            let mut written = 0;
+            let mut in_mem_written = 0;
+            let opt_data = value_as_optional(value)?;
+            let indicator = if opt_data.data.is_some() { 1i32 } else { 0i32 };
+            let indicator_bytes = indicator.to_le_bytes();
+            memory
+                .write(&mut store, (offset) as usize, &indicator_bytes)
+                .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
+            written += 4;
+            if let Some(inner) = opt_data.data.as_ref() {
+                let (new_written, new_in_mem_written) = write_to_wasm(
+                    store,
+                    memory,
+                    inner_ty,
+                    offset + written,
+                    in_mem_offset,
+                    inner,
+                    true,
+                )?;
+                written += new_written;
+                in_mem_written += new_in_mem_written;
+            } else {
+                written += get_type_size(&inner_ty);
+            }
+            Ok((written, in_mem_written))
+        }
+        TypeSignature::PrincipalType
+        | TypeSignature::CallableType(_)
+        | TypeSignature::TraitReferenceType(_) => {
+            let principal = value_as_principal(&value)?;
+            let (standard, contract_name) = match principal {
+                PrincipalData::Standard(s) => (s, ""),
+                PrincipalData::Contract(contract_identifier) => (
+                    &contract_identifier.issuer,
+                    contract_identifier.name.as_str(),
+                ),
+            };
+            let mut written = 0;
+            let mut in_mem_written = 0;
+
+            // Write the value to in_mem_offset
+            memory
+                .write(
+                    &mut store,
+                    (in_mem_offset + in_mem_written) as usize,
+                    &[standard.0],
+                )
+                .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
+            in_mem_written += 1;
+            memory
+                .write(
+                    &mut store,
+                    (in_mem_offset + in_mem_written) as usize,
+                    &standard.1,
+                )
+                .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
+            in_mem_written += standard.1.len() as i32;
+            if !contract_name.is_empty() {
+                let len_buffer = [contract_name.len() as u8];
+                memory
+                    .write(
+                        &mut store,
+                        (in_mem_offset + in_mem_written) as usize,
+                        &len_buffer,
+                    )
+                    .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
+                in_mem_written += 1;
+                let bytes = contract_name.as_bytes();
+                memory
+                    .write(&mut store, (in_mem_offset + in_mem_written) as usize, bytes)
+                    .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
+                in_mem_written += bytes.len() as i32;
+            } else {
+                let len_buffer = [0u8];
+                memory
+                    .write(
+                        &mut store,
+                        (in_mem_offset + in_mem_written) as usize,
+                        &len_buffer,
+                    )
+                    .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
+                in_mem_written += 1;
+            }
+
+            if include_repr {
+                // Write the representation (offset and length of the value) to the
+                // offset
+                let offset_buffer = (in_mem_offset as i32).to_le_bytes();
+                memory
+                    .write(&mut store, (offset) as usize, &offset_buffer)
+                    .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
+                written += 4;
+                let len_buffer = (in_mem_written as i32).to_le_bytes();
+                memory
+                    .write(&mut store, (offset + written) as usize, &len_buffer)
+                    .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
+                written += 4;
+            }
+
+            Ok((written, in_mem_written))
+        }
+        TypeSignature::TupleType(type_sig) => {
+            let tuple_data = value_as_tuple(value)?;
+            let mut written = 0;
+            let mut in_mem_written = 0;
+
+            for (key, val) in &tuple_data.data_map {
+                let val_type = type_sig
+                    .field_type(&key)
+                    .ok_or(Error::Wasm(WasmError::ValueTypeMismatch))?;
+                let (new_written, new_in_mem_written) = write_to_wasm(
+                    store.as_context_mut(),
+                    memory,
+                    val_type,
+                    offset + written,
+                    in_mem_offset + in_mem_written,
+                    val,
+                    true,
+                )?;
+                written += new_written;
+                in_mem_written += new_in_mem_written;
+            }
+
+            Ok((written, in_mem_written))
+        }
+        TypeSignature::ListUnionType(_) => {
+            unreachable!("not a value type")
+        }
+    }
+}
+
+pub fn value_as_bool(value: &Value) -> Result<bool, Error> {
+    match value {
+        Value::Bool(b) => Ok(*b),
+        _ => Err(Error::Wasm(WasmError::ValueTypeMismatch)),
+    }
+}
+
+pub fn value_as_i128(value: &Value) -> Result<i128, Error> {
+    match value {
+        Value::Int(n) => Ok(*n),
+        _ => Err(Error::Wasm(WasmError::ValueTypeMismatch)),
+    }
+}
+
+pub fn value_as_u128(value: &Value) -> Result<u128, Error> {
+    match value {
+        Value::UInt(n) => Ok(*n),
+        _ => Err(Error::Wasm(WasmError::ValueTypeMismatch)),
+    }
+}
+
+pub fn value_as_principal(value: &Value) -> Result<&PrincipalData, Error> {
+    match value {
+        Value::Principal(p) => Ok(p),
+        _ => Err(Error::Wasm(WasmError::ValueTypeMismatch)),
+    }
+}
+
+pub fn value_as_buffer(value: Value) -> Result<BuffData, Error> {
+    match value {
+        Value::Sequence(SequenceData::Buffer(buffdata)) => Ok(buffdata),
+        _ => Err(Error::Wasm(WasmError::ValueTypeMismatch)),
+    }
+}
+
+pub fn value_as_optional(value: &Value) -> Result<&OptionalData, Error> {
+    match value {
+        Value::Optional(opt_data) => Ok(opt_data),
+        _ => Err(Error::Wasm(WasmError::ValueTypeMismatch)),
+    }
+}
+
+pub fn value_as_response(value: &Value) -> Result<&ResponseData, Error> {
+    match value {
+        Value::Response(res_data) => Ok(res_data),
+        _ => Err(Error::Wasm(WasmError::ValueTypeMismatch)),
+    }
+}
+
+pub fn value_as_string_ascii(value: Value) -> Result<ASCIIData, Error> {
+    match value {
+        Value::Sequence(SequenceData::String(CharType::ASCII(string_data))) => Ok(string_data),
+        _ => Err(Error::Wasm(WasmError::ValueTypeMismatch)),
+    }
+}
+
+pub fn value_as_tuple(value: &Value) -> Result<&TupleData, Error> {
+    match value {
+        Value::Tuple(d) => Ok(d),
+        _ => Err(Error::Wasm(WasmError::ValueTypeMismatch)),
+    }
+}
+
+pub fn value_as_list(value: &Value) -> Result<&ListData, Error> {
+    match value {
+        Value::Sequence(SequenceData::List(list_data)) => Ok(list_data),
+        _ => Err(Error::Wasm(WasmError::ValueTypeMismatch)),
+    }
+}
+
+/// Read bytes from the WASM memory at `offset` with `length`
+pub fn read_bytes_from_wasm(
+    memory: Memory,
+    store: &mut impl AsContextMut,
+    offset: i32,
+    length: i32,
+) -> Result<Vec<u8>, Error> {
+    let mut buffer: Vec<u8> = vec![0; length as usize];
+    memory
+        .read(store, offset as usize, &mut buffer)
+        .map_err(|e| Error::Wasm(WasmError::Runtime(e.into())))?;
+    Ok(buffer)
+}
+
+/// Read an identifier (string) from the WASM memory at `offset` with `length`.
+pub fn read_identifier_from_wasm(
+    memory: Memory,
+    store: &mut impl AsContextMut,
+    offset: i32,
+    length: i32,
+) -> Result<String, Error> {
+    let buffer = read_bytes_from_wasm(memory, store, offset, length)?;
+    String::from_utf8(buffer).map_err(|e| Error::Wasm(WasmError::UnableToReadIdentifier(e)))
+}
+
+/// Return true if the value of the given type stays in memory, and false if
+/// it is stored on the data stack.
+pub fn is_in_memory_type(ty: &TypeSignature) -> bool {
+    match ty {
+        TypeSignature::NoType
+        | TypeSignature::IntType
+        | TypeSignature::UIntType
+        | TypeSignature::BoolType
+        | TypeSignature::TupleType(_)
+        | TypeSignature::OptionalType(_)
+        | TypeSignature::ResponseType(_) => false,
+        TypeSignature::SequenceType(_)
+        | TypeSignature::PrincipalType
+        | TypeSignature::CallableType(_)
+        | TypeSignature::TraitReferenceType(_) => true,
+        TypeSignature::ListUnionType(_) => unreachable!("not a value type"),
+    }
+}
+
+fn clar2wasm_ty(ty: &TypeSignature) -> Vec<ValType> {
+    match ty {
+        TypeSignature::NoType => vec![ValType::I32], // TODO: can this just be empty?
+        TypeSignature::IntType => vec![ValType::I64, ValType::I64],
+        TypeSignature::UIntType => vec![ValType::I64, ValType::I64],
+        TypeSignature::ResponseType(inner_types) => {
+            let mut types = vec![ValType::I32];
+            types.extend(clar2wasm_ty(&inner_types.0));
+            types.extend(clar2wasm_ty(&inner_types.1));
+            types
+        }
+        TypeSignature::SequenceType(_) => vec![
+            ValType::I32, // offset
+            ValType::I32, // length
+        ],
+        TypeSignature::BoolType => vec![ValType::I32],
+        TypeSignature::PrincipalType | TypeSignature::CallableType(_) => vec![
+            ValType::I32, // offset
+            ValType::I32, // length
+        ],
+        TypeSignature::OptionalType(inner_ty) => {
+            let mut types = vec![ValType::I32];
+            types.extend(clar2wasm_ty(inner_ty));
+            types
+        }
+        TypeSignature::TupleType(inner_types) => {
+            let mut types = vec![];
+            for inner_type in inner_types.get_type_map().values() {
+                types.extend(clar2wasm_ty(inner_type));
+            }
+            types
+        }
+        _ => unimplemented!("{:?}", ty),
+    }
+}

--- a/clar2wasm/tests/wasm-generation/sequences.rs
+++ b/clar2wasm/tests/wasm-generation/sequences.rs
@@ -43,6 +43,7 @@ proptest! {
     #![proptest_config(super::runtime_config())]
 
     #[test]
+    #[ignore]
     fn concat_crosscheck((seq1, seq2) in (0usize..=16).prop_flat_map(PropValue::any_sequence).prop_ind_flat_map2(|seq1| PropValue::from_type(TypeSignature::type_of(&seq1.into()).expect("Could not get type signature")))) {
         let snippet = format!("(concat {seq1} {seq2})");
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 path = "./src/lib.rs"
 
 [dependencies]
-clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-next" }
+clarity = { path = "../../stacks-core/clarity" }
 clar2wasm = { path = "../clar2wasm", features = ["developer-mode"] }
 wasmtime = "15.0.0"
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 path = "./src/lib.rs"
 
 [dependencies]
-clarity = { path = "../../stacks-core/clarity" }
+clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-next" }
 clar2wasm = { path = "../clar2wasm", features = ["developer-mode"] }
 wasmtime = "15.0.0"
 

--- a/tests/src/lib_tests.rs
+++ b/tests/src/lib_tests.rs
@@ -2,11 +2,12 @@ use std::collections::HashMap;
 
 use clar2wasm::compile;
 use clar2wasm::datastore::{BurnDatastore, StacksConstants};
+use clar2wasm::initialize::initialize_contract;
 use clar2wasm::tools::execute;
+use clar2wasm::wasm_utils::call_function;
 use clarity::consts::CHAIN_ID_TESTNET;
 use clarity::types::StacksEpochId;
 use clarity::vm::callables::DefineType;
-use clarity::vm::clarity_wasm::{call_function, initialize_contract};
 use clarity::vm::contexts::{CallStack, EventBatch, GlobalContext};
 use clarity::vm::contracts::Contract;
 use clarity::vm::costs::LimitedCostTracker;


### PR DESCRIPTION
This PR moves most code related to wasm to the clar2wasm repo.

It seems like where the code should be in the first place, and will make developing changes and tests much less painful.

Draft for now since i need to update the paths to use branches instead of hard-coded paths. This was done to make sure the stacks-core side is still working. A pr in that repo removing the code is coming as well soon.