### PR TITLE
fix: Make sure eq works correctly on sequences of different max lengths

### DIFF
--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -425,10 +425,16 @@ fn wasm_equal(
         }
         // is-eq-bytes function can be used for types with (offset, length)
         TypeSignature::SequenceType(SequenceSubtype::BufferType(_))
-        | TypeSignature::SequenceType(SequenceSubtype::StringType(_))
-        | TypeSignature::PrincipalType
-        | TypeSignature::CallableType(CallableSubtype::Principal(_)) => {
+        | TypeSignature::SequenceType(SequenceSubtype::StringType(_)) => {
             if ty.compatible(nth_ty) {
+                wasm_equal_bytes(generator, builder, first_op, nth_op)
+            } else {
+                no_type_match()
+            }
+        }
+        TypeSignature::PrincipalType
+        | TypeSignature::CallableType(CallableSubtype::Principal(_)) => {
+            if ty == nth_ty {
                 wasm_equal_bytes(generator, builder, first_op, nth_op)
             } else {
                 no_type_match()

--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -9,22 +9,6 @@ use crate::wasm_generator::{
     clar2wasm_ty, drop_value, ArgumentsExt, GeneratorError, SequenceElementType, WasmGenerator,
 };
 
-fn eq_compatible(a: &TypeSignature, b: &TypeSignature) -> bool {
-    matches!(
-        (a, b),
-        (
-            TypeSignature::SequenceType(SequenceSubtype::BufferType(_)),
-            TypeSignature::SequenceType(SequenceSubtype::BufferType(_)),
-        ) | (
-            TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::ASCII(_))),
-            TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::ASCII(_))),
-        ) | (
-            TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::UTF8(_))),
-            TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::UTF8(_))),
-        )
-    )
-}
-
 #[derive(Debug)]
 pub struct IsEq;
 
@@ -420,7 +404,27 @@ fn wasm_equal(
         // is-eq-bytes function can be used for types with (offset, length)
         TypeSignature::SequenceType(SequenceSubtype::BufferType(_))
         | TypeSignature::SequenceType(SequenceSubtype::StringType(_)) => {
-            if eq_compatible(ty, nth_ty) {
+            if matches!(
+                (ty, nth_ty),
+                (
+                    TypeSignature::SequenceType(SequenceSubtype::BufferType(_)),
+                    TypeSignature::SequenceType(SequenceSubtype::BufferType(_)),
+                ) | (
+                    TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::ASCII(
+                        _
+                    ))),
+                    TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::ASCII(
+                        _
+                    ))),
+                ) | (
+                    TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::UTF8(
+                        _
+                    ))),
+                    TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::UTF8(
+                        _
+                    ))),
+                )
+            ) {
                 wasm_equal_bytes(generator, builder, first_op, nth_op)
             } else {
                 no_type_match()

--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -1,4 +1,3 @@
-use clap::builder::StringValueParser;
 use clarity::vm::types::signatures::CallableSubtype;
 use clarity::vm::types::{SequenceSubtype, StringSubtype, TupleTypeSignature, TypeSignature};
 use clarity::vm::{ClarityName, SymbolicExpression};
@@ -16,21 +15,19 @@ trait EqCompatible {
 
 impl EqCompatible for TypeSignature {
     fn compatible(&self, other: &Self) -> bool {
-        match (self, other) {
+        matches!(
+            (self, other),
             (
                 TypeSignature::SequenceType(SequenceSubtype::BufferType(_)),
                 TypeSignature::SequenceType(SequenceSubtype::BufferType(_)),
-            ) => true,
-            (
+            ) | (
                 TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::ASCII(_))),
                 TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::ASCII(_))),
-            ) => true,
-            (
+            ) | (
                 TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::UTF8(_))),
                 TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::UTF8(_))),
-            ) => true,
-            _ => false,
-        }
+            )
+        )
     }
 }
 


### PR DESCRIPTION
Simple enough fix replacing == on types with a custom comparison

fixes #375 