### PR TITLE
Property tests for nft functions

### DIFF
--- a/clar2wasm/src/linker.rs
+++ b/clar2wasm/src/linker.rs
@@ -2076,8 +2076,8 @@ fn link_nft_burn_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error
             |mut caller: Caller<'_, ClarityWasmContext>,
              name_offset: i32,
              name_length: i32,
-             asset_offset: i32,
-             asset_length: i32,
+             mut asset_offset: i32,
+             mut asset_length: i32,
              sender_offset: i32,
              sender_length: i32| {
                 // Get the memory from the caller
@@ -2107,6 +2107,10 @@ fn link_nft_burn_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error
                 let expected_asset_type = &nft_metadata.key_type;
 
                 // Read in the NFT identifier from the Wasm memory
+                if is_in_memory_type(expected_asset_type) {
+                    (asset_offset, asset_length) =
+                        read_indirect_offset_and_length(memory, &mut caller, asset_offset)?;
+                }
                 let asset = read_from_wasm(
                     memory,
                     &mut caller,

--- a/clar2wasm/src/linker.rs
+++ b/clar2wasm/src/linker.rs
@@ -2339,8 +2339,8 @@ fn link_nft_transfer_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), E
             |mut caller: Caller<'_, ClarityWasmContext>,
              name_offset: i32,
              name_length: i32,
-             asset_offset: i32,
-             asset_length: i32,
+             mut asset_offset: i32,
+             mut asset_length: i32,
              sender_offset: i32,
              sender_length: i32,
              recipient_offset: i32,
@@ -2372,6 +2372,10 @@ fn link_nft_transfer_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), E
                 let expected_asset_type = &nft_metadata.key_type;
 
                 // Read in the NFT identifier from the Wasm memory
+                if is_in_memory_type(expected_asset_type) {
+                    (asset_offset, asset_length) =
+                        read_indirect_offset_and_length(memory, &mut caller, asset_offset)?;
+                }
                 let asset = read_from_wasm(
                     memory,
                     &mut caller,

--- a/clar2wasm/src/linker.rs
+++ b/clar2wasm/src/linker.rs
@@ -1976,8 +1976,8 @@ fn link_nft_get_owner_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), 
             |mut caller: Caller<'_, ClarityWasmContext>,
              name_offset: i32,
              name_length: i32,
-             asset_offset: i32,
-             asset_length: i32,
+             mut asset_offset: i32,
+             mut asset_length: i32,
              return_offset: i32,
              _return_length: i32| {
                 // Get the memory from the caller
@@ -2006,6 +2006,10 @@ fn link_nft_get_owner_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), 
                 let expected_asset_type = &nft_metadata.key_type;
 
                 // Read in the NFT identifier from the Wasm memory
+                if is_in_memory_type(expected_asset_type) {
+                    (asset_offset, asset_length) =
+                        read_indirect_offset_and_length(memory, &mut caller, asset_offset)?;
+                }
                 let asset = read_from_wasm(
                     memory,
                     &mut caller,
@@ -2207,8 +2211,8 @@ fn link_nft_mint_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error
             |mut caller: Caller<'_, ClarityWasmContext>,
              name_offset: i32,
              name_length: i32,
-             asset_offset: i32,
-             asset_length: i32,
+             mut asset_offset: i32,
+             mut asset_length: i32,
              recipient_offset: i32,
              recipient_length: i32| {
                 // Get the memory from the caller
@@ -2238,6 +2242,10 @@ fn link_nft_mint_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error
                 let expected_asset_type = &nft_metadata.key_type;
 
                 // Read in the NFT identifier from the Wasm memory
+                if is_in_memory_type(expected_asset_type) {
+                    (asset_offset, asset_length) =
+                        read_indirect_offset_and_length(memory, &mut caller, asset_offset)?;
+                }
                 let asset = read_from_wasm(
                     memory,
                     &mut caller,

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -14,6 +14,7 @@ pub mod optional;
 pub mod regression;
 pub mod response;
 pub mod sequences;
+pub mod tokens;
 pub mod tuple;
 pub mod values;
 

--- a/clar2wasm/tests/wasm-generation/tokens.rs
+++ b/clar2wasm/tests/wasm-generation/tokens.rs
@@ -1,10 +1,8 @@
 use clar2wasm::tools::crosscheck;
+use clarity::vm::types::signatures::TypeSignature::PrincipalType;
+use clarity::vm::types::TupleData;
+use clarity::vm::{ClarityName, Value};
 use proptest::prelude::*;
-
-use clarity::vm::{
-    types::{signatures::TypeSignature::PrincipalType, TupleData},
-    ClarityName, Value,
-};
 
 use crate::{PropValue, TypePrinter};
 
@@ -111,5 +109,4 @@ proptest! {
 
         crosscheck(&snippet, Ok(Some(expected)));
     }
-
 }

--- a/clar2wasm/tests/wasm-generation/tokens.rs
+++ b/clar2wasm/tests/wasm-generation/tokens.rs
@@ -14,13 +14,13 @@ proptest! {
     #[test]
     fn nft_mint_get_owner(
         nft in PropValue::any(),
-        owner in PropValue::from_type(PrincipalType)
+        owner in PropValue::from_type(PrincipalType),
     ) {
         let snippet = format!(r#"
             (define-non-fungible-token stackaroo {})
             {{
                 mint: (nft-mint? stackaroo {nft} {owner}),
-                owner: (nft-get-owner? stackaroo {nft})
+                owner: (nft-get-owner? stackaroo {nft}),
             }}
         "#, nft.type_string());
 
@@ -34,6 +34,42 @@ proptest! {
                     ClarityName::from("owner"),
                     Value::some(owner.into()).unwrap(),
                 ),
+            ])
+            .unwrap(),
+        );
+
+        crosscheck(&snippet, Ok(Some(expected)));
+    }
+
+    #[test]
+    fn nft_mint_transfer_owner(
+        nft in PropValue::any(),
+        owner1 in PropValue::from_type(PrincipalType),
+        owner2 in PropValue::from_type(PrincipalType),
+    ) {
+        let snippet = format!(r#"
+            (define-non-fungible-token stackaroo {})
+            {{
+                a-mint: (nft-mint? stackaroo {nft} {owner1}),
+                b-transfer: (nft-transfer? stackaroo {nft} {owner1} {owner2}),
+                c-owner: (nft-get-owner? stackaroo {nft}),
+            }}
+        "#, nft.type_string());
+
+        let expected = Value::from(
+            TupleData::from_data(vec![
+                (
+                    ClarityName::from("a-mint"),
+                    Value::okay_true(),
+                ),
+                (
+                    ClarityName::from("b-transfer"),
+                    Value::okay_true(),
+                ),
+                (
+                    ClarityName::from("c-owner"),
+                    Value::some(owner2.into()).unwrap(),
+                )
             ])
             .unwrap(),
         );

--- a/clar2wasm/tests/wasm-generation/tokens.rs
+++ b/clar2wasm/tests/wasm-generation/tokens.rs
@@ -69,11 +69,47 @@ proptest! {
                 (
                     ClarityName::from("c-owner"),
                     Value::some(owner2.into()).unwrap(),
-                )
+                ),
             ])
             .unwrap(),
         );
 
         crosscheck(&snippet, Ok(Some(expected)));
     }
+
+    #[test]
+    fn nft_mint_burn_get_owner(
+        nft in PropValue::any(),
+        owner in PropValue::from_type(PrincipalType),
+    ) {
+        let snippet = format!(r#"
+            (define-non-fungible-token stackaroo {})
+            {{
+                a-mint: (nft-mint? stackaroo {nft} {owner}),
+                b-burn: (nft-burn? stackaroo {nft} {owner}),
+                c-owner: (nft-get-owner? stackaroo {nft}),
+            }}
+        "#, nft.type_string());
+
+        let expected = Value::from(
+            TupleData::from_data(vec![
+                (
+                    ClarityName::from("a-mint"),
+                    Value::okay_true(),
+                ),
+                (
+                    ClarityName::from("b-burn"),
+                    Value::okay_true(),
+                ),
+                (
+                    ClarityName::from("c-owner"),
+                    Value::none(),
+                ),
+            ])
+            .unwrap(),
+        );
+
+        crosscheck(&snippet, Ok(Some(expected)));
+    }
+
 }

--- a/clar2wasm/tests/wasm-generation/tokens.rs
+++ b/clar2wasm/tests/wasm-generation/tokens.rs
@@ -1,0 +1,43 @@
+use clar2wasm::tools::crosscheck;
+use proptest::prelude::*;
+
+use clarity::vm::{
+    types::{signatures::TypeSignature::PrincipalType, TupleData},
+    ClarityName, Value,
+};
+
+use crate::{PropValue, TypePrinter};
+
+proptest! {
+    #![proptest_config(super::runtime_config())]
+
+    #[test]
+    fn nft_mint_get_owner(
+        nft in PropValue::any(),
+        owner in PropValue::from_type(PrincipalType)
+    ) {
+        let snippet = format!(r#"
+            (define-non-fungible-token stackaroo {})
+            {{
+                mint: (nft-mint? stackaroo {nft} {owner}),
+                owner: (nft-get-owner? stackaroo {nft})
+            }}
+        "#, nft.type_string());
+
+        let expected = Value::from(
+            TupleData::from_data(vec![
+                (
+                    ClarityName::from("mint"),
+                    Value::okay_true(),
+                ),
+                (
+                    ClarityName::from("owner"),
+                    Value::some(owner.into()).unwrap(),
+                ),
+            ])
+            .unwrap(),
+        );
+
+        crosscheck(&snippet, Ok(Some(expected)));
+    }
+}


### PR DESCRIPTION
Here are the property tests for the nft functions `define-non-fungible-token`, `nft-burn?`, `nft-mint?` and `nft-get-owner?`.

All of them suffered from a known bug in linked host functions: an "any-type" argument should check if it is an in-memory type and dereference it if it is the case.