### PR TITLE
Fixes for the changes due to Rust 1.78

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,6 +98,9 @@ jobs:
       - name: Checkout PR
         uses: actions/checkout@v4
 
+      - name: Use Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
@@ -127,6 +130,9 @@ jobs:
     steps:
       - name: Checkout PR
         uses: actions/checkout@v4
+
+      - name: Use Rust stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/clar2wasm/src/words/conditionals.rs
+++ b/clar2wasm/src/words/conditionals.rs
@@ -145,7 +145,7 @@ impl ComplexWord for Match {
                 let ok_block = generator.block_from_expr(builder, success_body)?;
 
                 // restore named locals
-                generator.bindings = saved_bindings.clone();
+                generator.bindings.clone_from(&saved_bindings);
 
                 // bind err branch local
                 generator

--- a/clar2wasm/src/words/functions.rs
+++ b/clar2wasm/src/words/functions.rs
@@ -1,15 +1,7 @@
-use clarity::vm::representations::Span;
 use clarity::vm::{ClarityName, SymbolicExpression};
 
 use super::ComplexWord;
 use crate::wasm_generator::{ArgumentsExt, FunctionKind, GeneratorError, WasmGenerator};
-
-#[derive(Clone)]
-pub struct TypedVar<'a> {
-    pub name: &'a ClarityName,
-    pub type_expr: &'a SymbolicExpression,
-    pub decl_span: Span,
-}
 
 #[derive(Debug)]
 pub struct DefinePrivateFunction;

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -4140,18 +4140,53 @@ fn utf8_to_string_utf8_invalid() {
     check_invalid_conversion(&[0b1111_0111, 0b1000_0000, 0b1110_1010, 0b1011_0101], 1);
     check_invalid_conversion(&[0b1111_0111, 0b1000_0000, 0b1010_1010, 0b1111_0101], 1);
 
+    // SAFETY: WRONG ON PURPOSE!
+    // converts a random u32 to a char without validating utf-8 correctness
+    let u32_to_utf8_raw = unsafe {
+        // adapted from core::char::encode_utf8_raw
+        |code: u32| {
+            let mut buff = [0; 4];
+
+            #[allow(clippy::transmute_int_to_char)]
+            let c: char = std::mem::transmute(code);
+            let len_utf8 = c.len_utf8();
+
+            match (len_utf8, &mut buff[..]) {
+                (1, [a, ..]) => {
+                    *a = code as u8;
+                }
+                (2, [a, b, ..]) => {
+                    *a = (code >> 6 & 0x1F) as u8 | 0b1100_0000;
+                    *b = (code & 0x3F) as u8 | 0b1000_0000;
+                }
+                (3, [a, b, c, ..]) => {
+                    *a = (code >> 12 & 0x0F) as u8 | 0b1110_0000;
+                    *b = (code >> 6 & 0x3F) as u8 | 0b1000_0000;
+                    *c = (code & 0x3F) as u8 | 0b1000_0000;
+                }
+                (_, [a, b, c, d]) => {
+                    *a = (code >> 18 & 0x07) as u8 | 0b1111_0000;
+                    *b = (code >> 12 & 0x3F) as u8 | 0b1000_0000;
+                    *c = (code >> 6 & 0x3F) as u8 | 0b1000_0000;
+                    *d = (code & 0x3F) as u8 | 0b1000_0000;
+                }
+                _ => std::hint::unreachable_unchecked(),
+            }
+
+            buff[..len_utf8].to_vec()
+        }
+    };
+
     // invalid utf-16 surrogate characters
     for n in 0xd800..=0xdfff {
-        // SAFETY: this is wrong! The purpose *is* to create an invalid char.
-        let surrogate_str: String = unsafe { char::from_u32_unchecked(n).into() };
-        check_invalid_conversion(surrogate_str.as_bytes(), 1);
+        let surrogate_bytes = u32_to_utf8_raw(n);
+        check_invalid_conversion(&surrogate_bytes, 1);
     }
 
     // invalid too large chars > U+10FFFF (max 21 bits in a 4 bytes utf-8 char)
     for n in ((char::MAX as u32) + 1..=0b1_1111_1111_1111_1111_1111).step_by(10000) {
-        // SAFETY: this is wrong! The purpose *is* to create an invalid char.
-        let surrogate_str: String = unsafe { char::from_u32_unchecked(n).into() };
-        check_invalid_conversion(surrogate_str.as_bytes(), 1);
+        let large_chars_bytes = u32_to_utf8_raw(n);
+        check_invalid_conversion(&large_chars_bytes, 1);
     }
 
     // tests with too short max-size

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -4140,7 +4140,7 @@ fn utf8_to_string_utf8_invalid() {
     check_invalid_conversion(&[0b1111_0111, 0b1000_0000, 0b1110_1010, 0b1011_0101], 1);
     check_invalid_conversion(&[0b1111_0111, 0b1000_0000, 0b1010_1010, 0b1111_0101], 1);
 
-    // converts a random u32 to a char without validating utf-8 correctness
+    // converts a random u32 to its utf8 representation without checking for validity.
     let u32_to_utf8_raw = |code: u32| {
         // adapted from core::char::encode_utf8_raw
         let mut buff = [0; 4];

--- a/clar2wasm/tests/wasm-generation/sequences.rs
+++ b/clar2wasm/tests/wasm-generation/sequences.rs
@@ -240,6 +240,7 @@ proptest! {
     #![proptest_config(super::runtime_config())]
 
     #[test]
+    #[ignore = "issue #395"]
     fn crosscheck_replace_at(
         (seq, source, dest) in (1usize..=20).prop_flat_map(|seq_size| {
             (PropValue::any_sequence(seq_size),


### PR DESCRIPTION
Rust 1.78 added new features that make our CI fail:

1. The new debug assertions in the standard lib made a test about invalid utf8 conversion fail.
2. Apparently we had an unused struct `TypedVar` (@krl could you confirm this?)
3. Clippy added a new lint to use `clone_from` in some condition.

I also added an unrelated `ignore` to a test that fails too often, and opened issue #395 .