### PR TITLE
Proptests for stx functions

### DIFF
--- a/clar2wasm/src/linker.rs
+++ b/clar2wasm/src/linker.rs
@@ -1306,7 +1306,7 @@ fn link_stx_transfer_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), E
              recipient_length: i32,
              memo_offset: i32,
              memo_length: i32| {
-                let amount = (amount_hi as u128) << 64 | (amount_lo as u128);
+                let amount = (amount_hi as u128) << 64 | ((amount_lo as u64) as u128);
 
                 // Get the memory from the caller
                 let memory = caller

--- a/clar2wasm/src/linker.rs
+++ b/clar2wasm/src/linker.rs
@@ -1208,7 +1208,7 @@ fn link_stx_burn_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error
              amount_hi: i64,
              principal_offset: i32,
              principal_length: i32| {
-                let amount = (amount_hi as u128) << 64 | (amount_lo as u128);
+                let amount = (amount_hi as u128) << 64 | ((amount_lo as u64) as u128);
 
                 // Get the memory from the caller
                 let memory = caller

--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -33,7 +33,7 @@ pub struct TestEnvironment {
 }
 
 impl TestEnvironment {
-    pub fn new(epoch: StacksEpochId, version: ClarityVersion) -> Self {
+    pub fn new_with_amount(amount: u128, epoch: StacksEpochId, version: ClarityVersion) -> Self {
         let constants = StacksConstants::default();
         let burn_datastore = BurnDatastore::new(constants.clone());
         let mut datastore = Datastore::new();
@@ -47,7 +47,6 @@ impl TestEnvironment {
 
         // Give one account a starting balance, to be used for testing.
         let recipient = PrincipalData::Standard(StandardPrincipalData::transient());
-        let amount = 1_000_000_000;
         let mut conn = ClarityDatabase::new(&mut datastore, &burn_datastore, &burn_datastore);
         execute(&mut conn, |database| {
             let mut snapshot = database.get_stx_balance_snapshot(&recipient)?;
@@ -65,6 +64,10 @@ impl TestEnvironment {
             burn_datastore,
             cost_tracker,
         }
+    }
+
+    pub fn new(epoch: StacksEpochId, version: ClarityVersion) -> Self {
+        Self::new_with_amount(1_000_000_000, epoch, version)
     }
 
     pub fn init_contract_with_snippet(
@@ -272,6 +275,19 @@ pub fn evaluate_at(
     env.evaluate(snippet)
 }
 
+/// Evaluate a Clarity snippet at a specific epoch and version, with a default
+/// amount of money for the transient principal account.
+/// Returns an optional value -- the result of the evaluation.
+pub fn evaluate_at_with_amount(
+    snippet: &str,
+    amount: u128,
+    epoch: StacksEpochId,
+    version: ClarityVersion,
+) -> Result<Option<Value>, Error> {
+    let mut env = TestEnvironment::new_with_amount(amount, epoch, version);
+    env.evaluate(snippet)
+}
+
 /// Evaluate a Clarity snippet at the latest epoch and clarity version.
 /// Returns an optional value -- the result of the evaluation.
 #[allow(clippy::result_unit_err)]
@@ -290,6 +306,19 @@ pub fn interpret_at(
     env.interpret(snippet)
 }
 
+/// Interpret a Clarity snippet at a specific epoch and version, with a default
+/// amount of money for the transient principal account.
+/// Returns an optional value -- the result of the evaluation.
+pub fn interpret_at_with_amount(
+    snippet: &str,
+    amount: u128,
+    epoch: StacksEpochId,
+    version: ClarityVersion,
+) -> Result<Option<Value>, Error> {
+    let mut env = TestEnvironment::new_with_amount(amount, epoch, version);
+    env.interpret(snippet)
+}
+
 /// Interprets a Clarity snippet at the latest epoch and clarity version.
 /// Returns an optional value -- the result of the evaluation.
 #[allow(clippy::result_unit_err)]
@@ -300,6 +329,36 @@ pub fn interpret(snippet: &str) -> Result<Option<Value>, ()> {
 pub fn crosscheck(snippet: &str, expected: Result<Option<Value>, ()>) {
     let compiled = evaluate_at(snippet, StacksEpochId::latest(), ClarityVersion::latest());
     let interpreted = interpret(snippet);
+
+    assert_eq!(
+        compiled.as_ref().map_err(|_| &()),
+        interpreted.as_ref().map_err(|_| &()),
+        "Compiled and interpreted results diverge!\ncompiled: {:?}\ninterpreted: {:?}",
+        &compiled,
+        &interpreted
+    );
+
+    assert_eq!(
+        compiled.as_ref().map_err(|_| &()),
+        expected.as_ref(),
+        "value is not the expected {:?}",
+        compiled
+    );
+}
+
+pub fn crosscheck_with_amount(snippet: &str, amount: u128, expected: Result<Option<Value>, ()>) {
+    let compiled = evaluate_at_with_amount(
+        snippet,
+        amount,
+        StacksEpochId::latest(),
+        ClarityVersion::latest(),
+    );
+    let interpreted = interpret_at_with_amount(
+        snippet,
+        amount,
+        StacksEpochId::latest(),
+        ClarityVersion::latest(),
+    );
 
     assert_eq!(
         compiled.as_ref().map_err(|_| &()),

--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -202,22 +202,11 @@ impl TestEnvironment {
 
         let mut contract_context = ContractContext::new(contract_id.clone(), self.version);
 
-        let mut conn = ClarityDatabase::new(
+        let conn = ClarityDatabase::new(
             &mut self.datastore,
             &self.burn_datastore,
             &self.burn_datastore,
         );
-
-        // Give one account a starting balance, to be used for testing.
-        let recipient = PrincipalData::Standard(StandardPrincipalData::transient());
-        let amount = 1_000_000_000;
-        execute(&mut conn, |database| {
-            let mut snapshot = database.get_stx_balance_snapshot(&recipient)?;
-            snapshot.credit(amount)?;
-            snapshot.save()?;
-            database.increment_ustx_liquid_supply(amount)
-        })
-        .expect("Failed to increment liquid supply.");
 
         let mut global_context = GlobalContext::new(
             false,

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -14,6 +14,7 @@ pub mod optional;
 pub mod regression;
 pub mod response;
 pub mod sequences;
+pub mod stx;
 pub mod tokens;
 pub mod tuple;
 pub mod values;

--- a/clar2wasm/tests/wasm-generation/stx.rs
+++ b/clar2wasm/tests/wasm-generation/stx.rs
@@ -1,0 +1,41 @@
+use clar2wasm::tools::crosscheck_with_amount;
+use clarity::vm::types::TupleData;
+use clarity::vm::{ClarityName, Value};
+use proptest::prelude::*;
+
+proptest! {
+    #![proptest_config(super::runtime_config())]
+
+    #[test]
+    fn stx_balance_burn_balance(amount in any::<u128>()) {
+
+
+        let snippet = format!(r#"
+            {{
+                a-balance1: (stx-get-balance 'S1G2081040G2081040G2081040G208105NK8PE5),
+                b-burn: (stx-burn? u{amount} 'S1G2081040G2081040G2081040G208105NK8PE5),
+                c-balance2: (stx-get-balance 'S1G2081040G2081040G2081040G208105NK8PE5),
+            }}
+        "#);
+
+        let expected = Value::from(
+            TupleData::from_data(vec![
+                (
+                    ClarityName::from("a-balance1"),
+                    Value::UInt(amount),
+                ),
+                (
+                    ClarityName::from("b-burn"),
+                    Value::okay_true(),
+                ),
+                (
+                    ClarityName::from("c-balance2"),
+                    Value::UInt(0),
+                ),
+            ])
+            .unwrap(),
+        );
+
+        crosscheck_with_amount(&snippet, amount, Ok(Some(expected)));
+    }
+}

--- a/clar2wasm/tests/wasm-generation/stx.rs
+++ b/clar2wasm/tests/wasm-generation/stx.rs
@@ -1,7 +1,9 @@
 use clar2wasm::tools::crosscheck_with_amount;
-use clarity::vm::types::TupleData;
+use clarity::vm::types::{TupleData, TypeSignature};
 use clarity::vm::{ClarityName, Value};
 use proptest::prelude::*;
+
+use crate::PropValue;
 
 proptest! {
     #![proptest_config(super::runtime_config())]
@@ -31,6 +33,48 @@ proptest! {
                 (
                     ClarityName::from("c-balance2"),
                     Value::UInt(0),
+                ),
+            ])
+            .unwrap(),
+        );
+
+        crosscheck_with_amount(&snippet, amount, Ok(Some(expected)));
+    }
+
+    #[test]
+    fn stx_balance_transfer_balance(
+        amount in any::<u128>(),
+        new_owner in PropValue::from_type(TypeSignature::PrincipalType)
+
+    ) {
+
+
+        let snippet = format!(r#"
+            {{
+                a-balance-before: (stx-get-balance 'S1G2081040G2081040G2081040G208105NK8PE5),
+                b-transfer: (stx-transfer? u{amount} 'S1G2081040G2081040G2081040G208105NK8PE5 {new_owner}),
+                c-balance-former: (stx-get-balance 'S1G2081040G2081040G2081040G208105NK8PE5),
+                d-balance-new: (stx-get-balance {new_owner}),
+            }}
+        "#);
+
+        let expected = Value::from(
+            TupleData::from_data(vec![
+                (
+                    ClarityName::from("a-balance-before"),
+                    Value::UInt(amount),
+                ),
+                (
+                    ClarityName::from("b-transfer"),
+                    Value::okay_true(),
+                ),
+                (
+                    ClarityName::from("c-balance-former"),
+                    Value::UInt(0),
+                ),
+                (
+                    ClarityName::from("d-balance-new"),
+                    Value::UInt(amount),
                 ),
             ])
             .unwrap(),

--- a/clar2wasm/tests/wasm-generation/stx.rs
+++ b/clar2wasm/tests/wasm-generation/stx.rs
@@ -3,15 +3,13 @@ use clarity::vm::types::{TupleData, TypeSignature};
 use clarity::vm::{ClarityName, Value};
 use proptest::prelude::*;
 
-use crate::PropValue;
+use crate::{buffer, PropValue};
 
 proptest! {
     #![proptest_config(super::runtime_config())]
 
     #[test]
     fn stx_balance_burn_balance(amount in any::<u128>()) {
-
-
         let snippet = format!(r#"
             {{
                 a-balance1: (stx-get-balance 'S1G2081040G2081040G2081040G208105NK8PE5),
@@ -44,15 +42,52 @@ proptest! {
     #[test]
     fn stx_balance_transfer_balance(
         amount in any::<u128>(),
-        new_owner in PropValue::from_type(TypeSignature::PrincipalType)
-
+        new_owner in PropValue::from_type(TypeSignature::PrincipalType),
     ) {
-
-
         let snippet = format!(r#"
             {{
                 a-balance-before: (stx-get-balance 'S1G2081040G2081040G2081040G208105NK8PE5),
                 b-transfer: (stx-transfer? u{amount} 'S1G2081040G2081040G2081040G208105NK8PE5 {new_owner}),
+                c-balance-former: (stx-get-balance 'S1G2081040G2081040G2081040G208105NK8PE5),
+                d-balance-new: (stx-get-balance {new_owner}),
+            }}
+        "#);
+
+        let expected = Value::from(
+            TupleData::from_data(vec![
+                (
+                    ClarityName::from("a-balance-before"),
+                    Value::UInt(amount),
+                ),
+                (
+                    ClarityName::from("b-transfer"),
+                    Value::okay_true(),
+                ),
+                (
+                    ClarityName::from("c-balance-former"),
+                    Value::UInt(0),
+                ),
+                (
+                    ClarityName::from("d-balance-new"),
+                    Value::UInt(amount),
+                ),
+            ])
+            .unwrap(),
+        );
+
+        crosscheck_with_amount(&snippet, amount, Ok(Some(expected)));
+    }
+
+    #[test]
+    fn stx_balance_transfermemo_balance(
+        amount in any::<u128>(),
+        new_owner in PropValue::from_type(TypeSignature::PrincipalType),
+        memo in (0u32..=34).prop_flat_map(buffer).prop_map_into::<PropValue>()
+    ) {
+        let snippet = format!(r#"
+            {{
+                a-balance-before: (stx-get-balance 'S1G2081040G2081040G2081040G208105NK8PE5),
+                b-transfer: (stx-transfer-memo? u{amount} 'S1G2081040G2081040G2081040G208105NK8PE5 {new_owner} {memo}),
                 c-balance-former: (stx-get-balance 'S1G2081040G2081040G2081040G208105NK8PE5),
                 d-balance-new: (stx-get-balance {new_owner}),
             }}

--- a/clar2wasm/tests/wasm-generation/stx.rs
+++ b/clar2wasm/tests/wasm-generation/stx.rs
@@ -115,6 +115,8 @@ proptest! {
             .unwrap(),
         );
 
+        // TODO: check for the correct memo in the events (issue #398)
+
         crosscheck_with_amount(&snippet, amount, Ok(Some(expected)));
     }
 }


### PR DESCRIPTION
This PR adds property tests for the functions `stx-burn?`, `stx-get-balance`, `stx-transfer?`, `stx-transfer-memo?`.

To use random amounts in the tests, some adaptations were made to the `TestEnvironment`.

All those functions suffered from a wrong conversion of the amount `(i64, i64) -> u128`.

This PR is part of #261 .

~~__It will currently fail the CI until we merge #396 .__~~ _done_