### PR TITLE
chore: update clarity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,11 +513,12 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#96aba4746c9db60200b26147a0b1368fae4664b2"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#a929365bc084da93d75e9e6c15a6361b2e306aa1"
 dependencies = [
  "hashbrown 0.14.3",
  "integer-sqrt",
  "lazy_static",
+ "mutants",
  "rand",
  "rand_chacha",
  "regex",
@@ -528,7 +529,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_stacker",
- "sha2-asm",
+ "sha2-asm 0.5.5",
  "slog",
  "stacks-common",
  "wasmtime",
@@ -1689,6 +1690,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mutants"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0287524726960e07b119cebd01678f852f147742ae0d925e6a520dca956126"
+
+[[package]]
 name = "nix"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1811,9 +1818,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256k1"
-version = "7.0.0"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a64d160b891178fb9d43d1a58ddcafb6502daeb54d810e5e92a7c3c9bfacc07"
+checksum = "a40a031a559eb38c35a14096f21c366254501a06d41c4b327d2a7515d713a5b7"
 dependencies = [
  "bitvec",
  "bs58 0.4.0",
@@ -2548,6 +2555,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
+ "sha2-asm 0.6.3",
 ]
 
 [[package]]
@@ -2555,6 +2563,15 @@ name = "sha2-asm"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7c2f225be6502f2134e6bbb35bb5e2957e41ffa0495ed08bce2e2b4ca885da4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27ba7066011e3fb30d808b51affff34f0a66d3a03a58edd787c6e420e40e44e"
 dependencies = [
  "cc",
 ]
@@ -2677,7 +2694,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#96aba4746c9db60200b26147a0b1368fae4664b2"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#a929365bc084da93d75e9e6c15a6361b2e306aa1"
 dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",
@@ -3800,9 +3817,9 @@ dependencies = [
 
 [[package]]
 name = "wsts"
-version = "8.1.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467aa8e40ed0277d19922fd0e7357c16552cb900e5138f61a48ac23c4b7878e0"
+checksum = "9c80d57a61294350ed91e91eb20a6c34da084ec8f15d039bab79ce3efabbd1a4"
 dependencies = [
  "aes-gcm",
  "bs58 0.5.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#a929365bc084da93d75e9e6c15a6361b2e306aa1"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#b141dd00fc753e14ad93e43d9681a3d65e4805f0"
 dependencies = [
  "hashbrown 0.14.3",
  "integer-sqrt",
@@ -2694,7 +2694,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#a929365bc084da93d75e9e6c15a6361b2e306aa1"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#b141dd00fc753e14ad93e43d9681a3d65e4805f0"
 dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",

--- a/clar2wasm/Cargo.toml
+++ b/clar2wasm/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2021"
 build = "build.rs"
 
 [dependencies]
-clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-next" }
+clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
 clap = { version = "4.3.17", features = ["derive"] }
 regex = "1.9.1"
 walrus = "0.20.1"
 lazy_static = "1.4.0"
 wasmtime = "15.0.0"
-stacks-common = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-next" }
+stacks-common = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
 
 # For developer mode
 sha2 = { version = "0.10.7", optional = true }

--- a/clar2wasm/benches/benchmark.rs
+++ b/clar2wasm/benches/benchmark.rs
@@ -712,6 +712,7 @@ fn clarity_add(c: &mut Criterion) {
         cost_tracker,
         StacksEpochId::latest(),
         ClarityVersion::latest(),
+        true,
     )
     .expect("Failed to run analysis");
 
@@ -851,6 +852,7 @@ fn clarity_sha512(c: &mut Criterion) {
         cost_tracker,
         StacksEpochId::latest(),
         ClarityVersion::latest(),
+        true,
     )
     .expect("Failed to run analysis");
 
@@ -1003,6 +1005,7 @@ fn clarity_sha256(c: &mut Criterion) {
         cost_tracker,
         StacksEpochId::latest(),
         ClarityVersion::latest(),
+        true,
     )
     .expect("Failed to run analysis");
 

--- a/clar2wasm/src/datastore.rs
+++ b/clar2wasm/src/datastore.rs
@@ -194,7 +194,7 @@ impl Default for Datastore {
 }
 
 impl ClarityBackingStore for Datastore {
-    fn put_all(&mut self, items: Vec<(String, String)>) -> Result<()> {
+    fn put_all_data(&mut self, items: Vec<(String, String)>) -> Result<()> {
         for (key, value) in items {
             self.put(&key, &value);
         }
@@ -202,7 +202,7 @@ impl ClarityBackingStore for Datastore {
     }
 
     /// fetch K-V out of the committed datastore
-    fn get(&mut self, key: &str) -> Result<Option<String>> {
+    fn get_data(&mut self, key: &str) -> Result<Option<String>> {
         let lookup_id = self
             .block_id_lookup
             .get(&self.current_chain_tip)
@@ -223,7 +223,7 @@ impl ClarityBackingStore for Datastore {
     }
 
     fn has_entry(&mut self, key: &str) -> Result<bool> {
-        Ok(self.get(key)?.is_some())
+        Ok(self.get_data(key)?.is_some())
     }
 
     /// change the current MARF context to service reads from a different chain_tip
@@ -287,7 +287,7 @@ impl ClarityBackingStore for Datastore {
         }
     }
 
-    fn get_with_proof(&mut self, _key: &str) -> Result<Option<(String, Vec<u8>)>> {
+    fn get_data_with_proof(&mut self, _key: &str) -> Result<Option<(String, Vec<u8>)>> {
         Ok(None)
     }
 

--- a/clar2wasm/src/deserialize.rs
+++ b/clar2wasm/src/deserialize.rs
@@ -11,6 +11,7 @@ use walrus::{InstrSeqBuilder, LocalId, MemoryId, ValType};
 use crate::wasm_generator::{
     add_placeholder_for_clarity_type, clar2wasm_ty, GeneratorError, WasmGenerator,
 };
+use crate::wasm_utils::ordered_tuple_signature;
 
 impl WasmGenerator {
     /// Deserialize an integer (`int` or `uint`) from memory using consensus
@@ -1048,7 +1049,7 @@ impl WasmGenerator {
 
         // For each key in the type, verify that the key matches the type,
         // and deserialize the value.
-        for (key, value_ty) in tuple_ty.get_type_map() {
+        for (key, value_ty) in ordered_tuple_signature(tuple_ty) {
             // The key is a 1-byte length followed by the string bytes.
             // First, verify that the key is within the buffer.
             block

--- a/clar2wasm/src/initialize.rs
+++ b/clar2wasm/src/initialize.rs
@@ -383,7 +383,7 @@ pub fn initialize_contract(
         contract_analysis
             .type_map
             .as_ref()
-            .and_then(|type_map| type_map.get_type(expr))
+            .and_then(|type_map| type_map.get_type_expected(expr))
     });
 
     if let Some(return_type) = return_type {

--- a/clar2wasm/src/lib.rs
+++ b/clar2wasm/src/lib.rs
@@ -84,7 +84,7 @@ pub fn compile(
         cost_tracker,
         epoch,
         clarity_version,
-        false,
+        true,
     ) {
         Ok(contract_analysis) => contract_analysis,
         Err((e, cost_track)) => {

--- a/clar2wasm/src/lib.rs
+++ b/clar2wasm/src/lib.rs
@@ -84,6 +84,7 @@ pub fn compile(
         cost_tracker,
         epoch,
         clarity_version,
+        false,
     ) {
         Ok(contract_analysis) => contract_analysis,
         Err((e, cost_track)) => {

--- a/clar2wasm/src/serialize.rs
+++ b/clar2wasm/src/serialize.rs
@@ -7,6 +7,7 @@ use walrus::ir::{BinaryOp, IfElse, InstrSeqType, Loop, MemArg, StoreKind};
 use walrus::{InstrSeqBuilder, LocalId, MemoryId, ValType};
 
 use crate::wasm_generator::{clar2wasm_ty, GeneratorError, WasmGenerator};
+use crate::wasm_utils::ordered_tuple_signature;
 
 impl WasmGenerator {
     /// Serialize an integer (`int` or `uint`) to memory using consensus
@@ -827,7 +828,7 @@ impl WasmGenerator {
             .local_tee(write_ptr);
 
         // Now serialize the keys/values to memory
-        for (key, value_ty) in tuple_ty.get_type_map() {
+        for (key, value_ty) in ordered_tuple_signature(tuple_ty) {
             // Serialize the key length
             builder.i32_const(key.len() as i32).store(
                 memory,

--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -196,7 +196,7 @@ impl TestEnvironment {
                 cost_tracker,
                 self.epoch,
                 self.version,
-                false,
+                true,
             )
             .map_err(|(e, _)| Error::Wasm(WasmError::WasmGeneratorError(format!("{:?}", e))))
         })?;

--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -196,6 +196,7 @@ impl TestEnvironment {
                 cost_tracker,
                 self.epoch,
                 self.version,
+                false,
             )
             .map_err(|(e, _)| Error::Wasm(WasmError::WasmGeneratorError(format!("{:?}", e))))
         })?;

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -539,7 +539,7 @@ impl WasmGenerator {
         self.contract_analysis
             .type_map
             .as_ref()
-            .and_then(|ty| ty.get_type(expr))
+            .and_then(|ty| ty.get_type_expected(expr))
     }
 
     /// Sets the result type of the given `SymbolicExpression`. This is

--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -331,17 +331,17 @@ fn assign_to_locals(
         }
         (TypeSignature::TupleType(t), TypeSignature::TupleType(s)) => {
             let mut remaining_locals = locals;
-            for (tt, ss) in t
-                .get_type_map()
-                .values()
-                .rev()
-                .zip(s.get_type_map().values().rev())
-            {
-                let tt_size = clar2wasm_ty(tt).len();
+            let mut reversed_t = t.get_type_map().iter().collect::<Vec<_>>();
+            reversed_t.sort_by(|x, y| y.0.cmp(x.0));
+            let mut reversed_s = s.get_type_map().iter().collect::<Vec<_>>();
+            reversed_s.sort_by(|x, y| y.0.cmp(x.0));
+
+            for (tt, ss) in reversed_t.iter().zip(reversed_s) {
+                let tt_size = clar2wasm_ty(tt.1).len();
                 let (rest, cur_locals) =
                     remaining_locals.split_at(remaining_locals.len() - tt_size);
                 remaining_locals = rest;
-                assign_to_locals(builder, tt, ss, cur_locals)?;
+                assign_to_locals(builder, tt.1, ss.1, cur_locals)?;
             }
         }
         // All the other types aren't influenced by inner NoType and can just be assigned automatically
@@ -715,7 +715,10 @@ fn wasm_equal_tuple(
     // this is an iterator in reverse order (for bottom-up sequence) of
     // `(ty, range)`, where `ty` is the type of the current tuple element and `range` is
     // the range index of this element in the list of locals
-    let mut wasm_ranges = field_types.values().rev().scan(
+    let mut reversed_field_types = field_types.iter().collect::<Vec<_>>();
+    reversed_field_types.sort_by(|x, y| y.0.cmp(x.0));
+
+    let mut wasm_ranges = reversed_field_types.into_iter().map(|x| x.1).scan(
         field_types.values().map(|ty| clar2wasm_ty(ty).len()).sum(),
         |i, ty| {
             (*i != 0).then(|| {
@@ -728,7 +731,9 @@ fn wasm_equal_tuple(
     );
 
     // types for nth argument
-    let mut nth_types = nth_tuple_ty.get_type_map().values().rev();
+    let mut nth_types = nth_tuple_ty.get_type_map().iter().collect::<Vec<_>>();
+    nth_types.sort_by(|x, y| y.0.cmp(x.0));
+    let mut nth_types = nth_types.into_iter().map(|x| x.1);
 
     // if this is a 1-tuple, we can just check for equality of element
     if depth == 1 {

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -491,9 +491,14 @@ pub fn type_string(ty: &TypeSignature) -> String {
             )
         }
         TypeSignature::TupleType(tuple_ty) => {
+            let tuple_ty = {
+                let mut v: Vec<_> = tuple_ty.get_type_map().iter().collect();
+                v.sort_unstable_by_key(|&(k, _)| k);
+                v
+            };
             let mut s = String::new();
             s.push('{');
-            for (key, value) in tuple_ty.get_type_map() {
+            for (key, value) in tuple_ty {
                 s.push_str(key);
                 s.push(':');
                 s.push_str(&type_string(value));

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 path = "./src/lib.rs"
 
 [dependencies]
-clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-next" }
+clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
 clar2wasm = { path = "../clar2wasm", features = ["developer-mode"] }
 wasmtime = "15.0.0"
 

--- a/tests/benches/benchmark.rs
+++ b/tests/benches/benchmark.rs
@@ -154,6 +154,7 @@ fn interp_fold_add_square(c: &mut Criterion) {
         cost_tracker,
         StacksEpochId::latest(),
         ClarityVersion::latest(),
+        true,
     )
     .expect("Failed to run analysis");
 


### PR DESCRIPTION
## Description

Use `feat/clarity-wasm-develop` instead of `feat/clarity-wasm-next`.
See this here: https://github.com/stacks-network/stacks-core/pull/4756

A few breaking changes had to be addressed:

- some functions were renamed
- tuple type signature has been replaced by an `hashmap` instead of `btreemap` (https://github.com/stacks-network/stacks-core/pull/4614), breaking the usage of `.rev()` on this repo
- `run_analysis` takes a new arguments build type map (same PR as above), I set to `true` but maybe it can be optimized
