### PR TITLE
Proptests for ft functions

### DIFF
--- a/clar2wasm/src/linker.rs
+++ b/clar2wasm/src/linker.rs
@@ -1698,7 +1698,7 @@ fn link_ft_mint_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error>
                 let token_name = ClarityName::try_from(name.clone())?;
 
                 // Compute the amount
-                let amount = (amount_hi as u128) << 64 | (amount_lo as u128);
+                let amount = (amount_hi as u128) << 64 | ((amount_lo as u64) as u128);
 
                 // Read the sender principal from the Wasm memory
                 let value = read_from_wasm(

--- a/clar2wasm/src/linker.rs
+++ b/clar2wasm/src/linker.rs
@@ -1570,7 +1570,7 @@ fn link_ft_burn_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error>
                 let token_name = ClarityName::try_from(name.clone())?;
 
                 // Compute the amount
-                let amount = (amount_hi as u128) << 64 | (amount_lo as u128);
+                let amount = (amount_hi as u128) << 64 | ((amount_lo as u64) as u128);
 
                 // Read the sender principal from the Wasm memory
                 let value = read_from_wasm(

--- a/clar2wasm/src/linker.rs
+++ b/clar2wasm/src/linker.rs
@@ -1824,7 +1824,7 @@ fn link_ft_transfer_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Er
                 let token_name = ClarityName::try_from(name.clone())?;
 
                 // Compute the amount
-                let amount = (amount_hi as u128) << 64 | (amount_lo as u128);
+                let amount = (amount_hi as u128) << 64 | ((amount_lo as u64) as u128);
 
                 // Read the sender principal from the Wasm memory
                 let value = read_from_wasm(

--- a/clar2wasm/tests/wasm-generation/tokens.rs
+++ b/clar2wasm/tests/wasm-generation/tokens.rs
@@ -185,7 +185,7 @@ proptest! {
         sender in PropValue::from_type(PrincipalType),
         recipient in PropValue::from_type(PrincipalType),
     ) {
-        let mint_supply = total_supply >> 1;
+        let mint_supply = total_supply / 2;
 
         let snippet = format!(r#"
             (define-fungible-token stackaroo u{total_supply})
@@ -211,7 +211,7 @@ proptest! {
                 ),
                 (
                     ClarityName::from("c-supply"),
-                    Value::UInt(total_supply & !1),
+                    Value::UInt(mint_supply * 2),
                 ),
                 (
                     ClarityName::from("d-transfer"),

--- a/clar2wasm/tests/wasm-generation/tokens.rs
+++ b/clar2wasm/tests/wasm-generation/tokens.rs
@@ -110,3 +110,37 @@ proptest! {
         crosscheck(&snippet, Ok(Some(expected)));
     }
 }
+
+proptest! {
+    #![proptest_config(super::runtime_config())]
+
+    #[test]
+    fn ft_mint_balance(
+        total_supply in any::<u128>(),
+        recipient in PropValue::from_type(PrincipalType),
+    ) {
+        let snippet = format!(r#"
+            (define-fungible-token stackaroo u{total_supply})
+            {{
+                a-mint: (ft-mint? stackaroo u{total_supply} {recipient}),
+                b-balance: (ft-get-balance stackaroo {recipient}),
+            }}
+        "#);
+
+        let expected = Value::from(
+            TupleData::from_data(vec![
+                (
+                    ClarityName::from("a-mint"),
+                    Value::okay_true(),
+                ),
+                (
+                    ClarityName::from("b-balance"),
+                    Value::UInt(total_supply),
+                ),
+            ])
+            .unwrap(),
+        );
+
+        crosscheck(&snippet, Ok(Some(expected)));
+    }
+}

--- a/clar2wasm/tests/wasm-generation/tokens.rs
+++ b/clar2wasm/tests/wasm-generation/tokens.rs
@@ -145,6 +145,41 @@ proptest! {
     }
 
     #[test]
+    fn ft_mint_burn(
+        total_supply in any::<u128>(),
+        recipient in PropValue::from_type(PrincipalType),
+    ) {
+        let snippet = format!(r#"
+            (define-fungible-token stackaroo u{total_supply})
+            {{
+                a-mint: (ft-mint? stackaroo u{total_supply} {recipient}),
+                b-burn: (ft-burn? stackaroo u{total_supply} {recipient}),
+                c-balance: (ft-get-balance stackaroo {recipient}),
+            }}
+        "#);
+
+        let expected = Value::from(
+            TupleData::from_data(vec![
+                (
+                    ClarityName::from("a-mint"),
+                    Value::okay_true(),
+                ),
+                (
+                    ClarityName::from("b-burn"),
+                    Value::okay_true(),
+                ),
+                (
+                    ClarityName::from("c-balance"),
+                    Value::UInt(0),
+                ),
+            ])
+            .unwrap(),
+        );
+
+        crosscheck(&snippet, Ok(Some(expected)));
+    }
+
+    #[test]
     fn ft_mint_mint_supply_transfer_balance(
         total_supply in any::<u128>(),
         sender in PropValue::from_type(PrincipalType),


### PR DESCRIPTION
This add proptests for the ft functions `ft-burn?`, `ft-get-balance`, `ft-get-supply`, `ft-mint?`, `ft-transfer?`.

They suffered the same bug as the functions in #397, with the amount erroneously parsed in the linked functions.

As with #397, I didn't test for the unhappy path [for the same reasons](https://github.com/stacks-network/clarity-wasm/pull/397#issuecomment-2098057481).

This PR is part of #261.