### PR TITLE
Fix constants definition

### DIFF
--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -1239,25 +1239,8 @@ impl WasmGenerator {
                 .ok_or_else(|| GeneratorError::TypeError("constant must be typed".to_owned()))?
                 .clone();
 
-            // If `ty` is a value that stays in memory, we can just push the
-            // offset and length to the stack.
-            // CAUTION: list type needs to be dereferenced, contrarily to other
-            //          in-memory types
-            if is_in_memory_type(&ty)
-                && !matches!(
-                    &ty,
-                    TypeSignature::SequenceType(seq) if seq.is_list_type()
-                )
-            {
-                builder
-                    .local_get(offset_local)
-                    .i32_const(get_type_in_memory_size(&ty, false));
-                Ok(true)
-            } else {
-                // Otherwise, we need to load the value from memory.
-                self.read_from_memory(builder, offset_local, 0, &ty)?;
-                Ok(true)
-            }
+            self.read_from_memory(builder, offset_local, 0, &ty)?;
+            Ok(true)
         } else {
             Ok(false)
         }

--- a/clar2wasm/src/words/constants.rs
+++ b/clar2wasm/src/words/constants.rs
@@ -72,7 +72,7 @@ impl ComplexWord for DefineConstant {
 #[cfg(test)]
 mod tests {
     use clarity::types::StacksEpochId;
-    use clarity::vm::types::{ListData, ListTypeData, SequenceData};
+    use clarity::vm::types::{ASCIIData, CharType, ListData, ListTypeData, SequenceData};
     use clarity::vm::Value;
 
     use crate::tools::{crosscheck, crosscheck_with_epoch, evaluate};
@@ -200,5 +200,17 @@ mod tests {
         // Latest Epoch and Clarity Version
         crosscheck("(define-constant index-of (+ 2 2))", Err(()));
         crosscheck("(define-constant index-of? (+ 2 2))", Err(()));
+    }
+
+    #[test]
+    fn test_non_litteral_string() {
+        crosscheck(
+            r#"(define-constant cst (concat "Hello," " World!")) cst"#,
+            Ok(Some(Value::Sequence(SequenceData::String(
+                CharType::ASCII(ASCIIData {
+                    data: "Hello, World!".bytes().collect(),
+                }),
+            )))),
+        )
     }
 }

--- a/clar2wasm/src/words/constants.rs
+++ b/clar2wasm/src/words/constants.rs
@@ -1,14 +1,10 @@
 use clarity::vm::{ClarityName, SymbolicExpression, SymbolicExpressionType};
-use walrus::{
-    ir::{MemArg, StoreKind},
-    ValType,
-};
+use walrus::ir::{MemArg, StoreKind};
+use walrus::ValType;
 
 use super::ComplexWord;
-use crate::{
-    wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator},
-    wasm_utils::{get_type_size, is_in_memory_type},
-};
+use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
+use crate::wasm_utils::{get_type_size, is_in_memory_type};
 
 #[derive(Debug)]
 pub struct DefineConstant;
@@ -46,8 +42,8 @@ impl ComplexWord for DefineConstant {
         let offset = if let SymbolicExpressionType::LiteralValue(value) = &value.expr {
             let (mut offset, len) = generator.add_literal(value)?;
 
-            // in-memory litterals should write (offset, len) to memory, so that their
-            // representation is consistent with in-memory non-litterals.
+            // in-memory literals should write (offset, len) to memory, so that their
+            // representation is consistent with in-memory non-literals.
             if is_in_memory_type(&ty) {
                 let ref_offset = generator.literal_memory_end;
                 generator.literal_memory_end += 8; // offset + len bytes
@@ -241,7 +237,7 @@ mod tests {
     }
 
     #[test]
-    fn test_non_litteral_string() {
+    fn test_non_literal_string() {
         crosscheck(
             r#"(define-constant cst (concat "Hello," " World!")) cst"#,
             Ok(Some(Value::Sequence(SequenceData::String(

--- a/clar2wasm/tests/wasm-generation/constants.rs
+++ b/clar2wasm/tests/wasm-generation/constants.rs
@@ -1,0 +1,41 @@
+use clar2wasm::tools::crosscheck;
+use proptest::prelude::*;
+
+use crate::{
+    int, qualified_principal, standard_principal, string_ascii, string_utf8, uint, PropValue,
+};
+
+fn literal() -> impl Strategy<Value = PropValue> {
+    prop_oneof![
+        int(),
+        uint(),
+        standard_principal(),
+        qualified_principal(),
+        (0..32u32).prop_flat_map(string_ascii),
+        (0..32u32).prop_flat_map(string_utf8)
+    ]
+    .prop_map_into()
+}
+
+proptest! {
+    #![proptest_config(super::runtime_config())]
+
+    #[test]
+    fn define_constant_from_literal(lit in literal()) {
+        crosscheck(&format!("(define-constant cst {lit}) cst"), Ok(Some(lit.into())));
+    }
+
+    #[test]
+    fn define_constant_from_anything(val in PropValue::any()) {
+        crosscheck(&format!("(define-constant cst {val}) cst"), Ok(Some(val.into())));
+    }
+
+    #[test]
+    fn define_constant_from_non_literal(val in PropValue::any()) {
+        let snippet = format!(r#"
+            (define-private (foo) {val})
+            (define-constant cst (foo)) cst
+        "#);
+        crosscheck(&snippet, Ok(Some(val.into())));
+    }
+}

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -5,6 +5,7 @@ pub mod bitwise;
 pub mod blockinfo;
 pub mod comparison;
 pub mod conditionals;
+pub mod constants;
 pub mod control_flow;
 pub mod default_to;
 pub mod equal;


### PR DESCRIPTION
While working on #370, I noticed an incoherence in the definition of constants. An in-memory type could have different representations depending on if its definition is from a literal or not.

This PR fixes the problem.

It also adds property tests for constants definition and retrieval.