### PR TITLE
Fix `append` to `append` issue

### DIFF
--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -280,9 +280,9 @@ impl ComplexWord for Append {
             TypeSignature::SequenceType(SequenceSubtype::ListType(ltd)) => {
                 generator.set_expr_type(
                     list,
-                    #[allow(clippy::unwrap_used)]
+                    #[allow(clippy::expect_used)]
                     ListTypeData::new_list(ltd.get_list_item_type().clone(), ltd.get_max_len() - 1)
-                        .unwrap() // this type is same as expr but smaller -> valid
+                        .expect("Argument type should be correct as it is the same as the expression type with a smaller max_len")
                         .into(),
                 )?;
                 generator.set_expr_type(elem, ltd.get_list_item_type().clone())?;

--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -1979,4 +1979,22 @@ mod tests {
     fn slice_full() {
         crosscheck("(slice? \"abc\" u0 u3)", evaluate("(some \"abc\")"));
     }
+
+    #[test]
+    fn double_append() {
+        let snippet = "(append (append (list 1) 2) 3)";
+
+        let expected = Value::Sequence(clarity::vm::types::SequenceData::List(
+            clarity::vm::types::ListData {
+                data: vec![Value::Int(1), Value::Int(2), Value::Int(3)],
+                type_signature: clarity::vm::types::ListTypeData::new_list(
+                    clarity::vm::types::TypeSignature::IntType,
+                    3,
+                )
+                .unwrap(),
+            },
+        ));
+
+        crosscheck(snippet, Ok(Some(expected)))
+    }
 }

--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -1993,16 +1993,9 @@ mod tests {
     fn double_append() {
         let snippet = "(append (append (list 1) 2) 3)";
 
-        let expected = Value::Sequence(clarity::vm::types::SequenceData::List(
-            clarity::vm::types::ListData {
-                data: vec![Value::Int(1), Value::Int(2), Value::Int(3)],
-                type_signature: clarity::vm::types::ListTypeData::new_list(
-                    clarity::vm::types::TypeSignature::IntType,
-                    3,
-                )
-                .unwrap(),
-            },
-        ));
+        let expected =
+            Value::cons_list_unsanitized(vec![Value::Int(1), Value::Int(2), Value::Int(3)])
+                .unwrap();
 
         crosscheck(snippet, Ok(Some(expected)))
     }

--- a/clar2wasm/tests/wasm-generation/sequences.rs
+++ b/clar2wasm/tests/wasm-generation/sequences.rs
@@ -17,6 +17,17 @@ proptest! {
 
         crosscheck(&format!("(append {values} {elem})"), Ok(Some(expected)))
     }
+
+    #[test]
+    fn double_append_value_to_list(mut values in (prop_signature(), 2usize..16).prop_flat_map(|(ty, size)| PropValue::many_from_type(ty, size))) {
+        let expected = Value::cons_list_unsanitized(values.iter().cloned().map(Value::from).collect()).unwrap();
+
+        let elem_last = values.pop().unwrap();
+        let elem_before_last = values.pop().unwrap();
+        let values = PropValue::try_from(values).unwrap();
+
+        crosscheck(&format!("(append (append {values} {elem_before_last}) {elem_last})"), Ok(Some(expected)))
+    }
 }
 
 proptest! {


### PR DESCRIPTION
Fixes #412 

The type workaround now sets correctly the type of the list argument.

I added a simple test for it and a property test.