### PR TITLE
Fix clarity dependency features

### DIFF
--- a/clar2wasm/Cargo.toml
+++ b/clar2wasm/Cargo.toml
@@ -5,7 +5,9 @@ edition = "2021"
 build = "build.rs"
 
 [dependencies]
-clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
+clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop", features = [
+  "testing",
+] }
 clap = { version = "4.3.17", features = ["derive"] }
 regex = "1.9.1"
 walrus = "0.20.1"
@@ -25,7 +27,6 @@ flamegraph = []
 pb = []
 
 [dev-dependencies]
-clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop", features = ["testing"] }
 criterion = "0.5.1"
 proptest = "1.2.0"
 num-integer = { version = "0.1.45", default-features = false }


### PR DESCRIPTION
It seems that the _clarity_ dependency needed the _testing_ feature only as a dev-dependency before. This PR fixes the recent build problem by moving it to the regular dependencies.