### PR TITLE
chore: update clarity

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -4,4 +4,4 @@ fmt-stacks = "fmt -- --config group_imports=StdExternalCrate,imports_granularity
 
 # Uncomment the patch below to use a local version of the stacks-core modules
 # [patch.'https://github.com/stacks-network/stacks-core.git']
-# clarity = { path = "./stacks-core/clarity" }
+# clarity = { path = "../stacks-core/clarity" }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,7 +501,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#c103d83a8ab5c548b9d033829041a16f344325df"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#abea0d349d43f46d3d73eb9e3bc0cb1663dc58f5"
 dependencies = [
  "hashbrown 0.14.3",
  "integer-sqrt",
@@ -2665,7 +2665,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#c103d83a8ab5c548b9d033829041a16f344325df"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#abea0d349d43f46d3d73eb9e3bc0cb1663dc58f5"
 dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,7 +501,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#3297c3f4b6a78f01b2bd81d61e5dd985b4297e2a"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#cf19e624a1ee687ae0b2646e7626de9327a416b9"
 dependencies = [
  "hashbrown 0.14.3",
  "integer-sqrt",
@@ -2672,7 +2672,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#3297c3f4b6a78f01b2bd81d61e5dd985b4297e2a"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#cf19e624a1ee687ae0b2646e7626de9327a416b9"
 dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,7 +501,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#2617d6e6f797f5215782007b3c9038ea670144cd"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#34c7f2987525ceb36cdf7f9303714a074dc5a909"
 dependencies = [
  "hashbrown 0.14.3",
  "integer-sqrt",
@@ -2665,7 +2665,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#2617d6e6f797f5215782007b3c9038ea670144cd"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#34c7f2987525ceb36cdf7f9303714a074dc5a909"
 dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,12 +501,11 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#a0e0fa8ab6ddeec7c0abc9b81c8e784cc9b4f10a"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#a744f29410009f41b56874cbb9254df78bb68209"
 dependencies = [
  "hashbrown 0.14.3",
  "integer-sqrt",
  "lazy_static",
- "mutants",
  "rand",
  "rand_chacha",
  "regex",
@@ -1669,12 +1668,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mutants"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0287524726960e07b119cebd01678f852f147742ae0d925e6a520dca956126"
-
-[[package]]
 name = "nix"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2672,7 +2665,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#a0e0fa8ab6ddeec7c0abc9b81c8e784cc9b4f10a"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#a744f29410009f41b56874cbb9254df78bb68209"
 dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,7 +501,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#34c7f2987525ceb36cdf7f9303714a074dc5a909"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#c103d83a8ab5c548b9d033829041a16f344325df"
 dependencies = [
  "hashbrown 0.14.3",
  "integer-sqrt",
@@ -2665,7 +2665,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#34c7f2987525ceb36cdf7f9303714a074dc5a909"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#c103d83a8ab5c548b9d033829041a16f344325df"
 dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,7 +501,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#03728f1f2e55e91ad5bf8cd3708994b6a1d73113"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#a0e0fa8ab6ddeec7c0abc9b81c8e784cc9b4f10a"
 dependencies = [
  "hashbrown 0.14.3",
  "integer-sqrt",
@@ -2672,7 +2672,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#03728f1f2e55e91ad5bf8cd3708994b6a1d73113"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#a0e0fa8ab6ddeec7c0abc9b81c8e784cc9b4f10a"
 dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,7 +501,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#a744f29410009f41b56874cbb9254df78bb68209"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#2617d6e6f797f5215782007b3c9038ea670144cd"
 dependencies = [
  "hashbrown 0.14.3",
  "integer-sqrt",
@@ -2665,7 +2665,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#a744f29410009f41b56874cbb9254df78bb68209"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#2617d6e6f797f5215782007b3c9038ea670144cd"
 dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,7 +501,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#b141dd00fc753e14ad93e43d9681a3d65e4805f0"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#3297c3f4b6a78f01b2bd81d61e5dd985b4297e2a"
 dependencies = [
  "hashbrown 0.14.3",
  "integer-sqrt",
@@ -2672,7 +2672,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#b141dd00fc753e14ad93e43d9681a3d65e4805f0"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#3297c3f4b6a78f01b2bd81d61e5dd985b4297e2a"
 dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,7 +501,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#cf19e624a1ee687ae0b2646e7626de9327a416b9"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#03728f1f2e55e91ad5bf8cd3708994b6a1d73113"
 dependencies = [
  "hashbrown 0.14.3",
  "integer-sqrt",
@@ -2672,7 +2672,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#cf19e624a1ee687ae0b2646e7626de9327a416b9"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#03728f1f2e55e91ad5bf8cd3708994b6a1d73113"
 dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",

--- a/clar2wasm/src/bin/main.rs
+++ b/clar2wasm/src/bin/main.rs
@@ -39,8 +39,8 @@ fn main() {
 
     // Define some settings
     let contract_id = QualifiedContractIdentifier::transient();
-    let clarity_version = ClarityVersion::latest();
-    let epoch = StacksEpochId::latest();
+    let clarity_version = ClarityVersion::Clarity2;
+    let epoch = StacksEpochId::Epoch25;
 
     // Setup a datastore and cost tracker
     let mut datastore = MemoryBackingStore::new();

--- a/clar2wasm/src/bin/main.rs
+++ b/clar2wasm/src/bin/main.rs
@@ -39,7 +39,7 @@ fn main() {
 
     // Define some settings
     let contract_id = QualifiedContractIdentifier::transient();
-    let clarity_version = ClarityVersion::Clarity2;
+    let clarity_version = ClarityVersion::latest();
     let epoch = StacksEpochId::latest();
 
     // Setup a datastore and cost tracker

--- a/clar2wasm/src/datastore.rs
+++ b/clar2wasm/src/datastore.rs
@@ -408,6 +408,7 @@ impl HeadersDB for BurnDatastore {
     fn get_stacks_block_header_hash_for_block(
         &self,
         id_bhh: &StacksBlockId,
+        _epoch_id: &StacksEpochId,
     ) -> Option<BlockHeaderHash> {
         self.store.get(id_bhh).map(|id| id.block_header_hash)
     }
@@ -419,32 +420,63 @@ impl HeadersDB for BurnDatastore {
         self.store.get(id_bhh).map(|id| id.burn_block_header_hash)
     }
 
-    fn get_consensus_hash_for_block(&self, id_bhh: &StacksBlockId) -> Option<ConsensusHash> {
+    fn get_consensus_hash_for_block(
+        &self,
+        id_bhh: &StacksBlockId,
+        _epoch_id: &StacksEpochId,
+    ) -> Option<ConsensusHash> {
         self.store.get(id_bhh).map(|id| id.consensus_hash)
     }
-    fn get_vrf_seed_for_block(&self, id_bhh: &StacksBlockId) -> Option<VRFSeed> {
+    fn get_vrf_seed_for_block(
+        &self,
+        id_bhh: &StacksBlockId,
+        _epoch_id: &StacksEpochId,
+    ) -> Option<VRFSeed> {
         self.store.get(id_bhh).map(|id| id.vrf_seed)
     }
-    fn get_burn_block_time_for_block(&self, id_bhh: &StacksBlockId) -> Option<u64> {
+    fn get_stacks_block_time_for_block(&self, _id_bhh: &StacksBlockId) -> Option<u64> {
+        None
+    }
+    fn get_burn_block_time_for_block(
+        &self,
+        id_bhh: &StacksBlockId,
+        _epoch_id: Option<&StacksEpochId>,
+    ) -> Option<u64> {
         self.store.get(id_bhh).map(|id| id.burn_block_time)
     }
     fn get_burn_block_height_for_block(&self, id_bhh: &StacksBlockId) -> Option<u32> {
         self.store.get(id_bhh).map(|id| id.burn_block_height)
     }
-    fn get_miner_address(&self, id_bhh: &StacksBlockId) -> Option<StacksAddress> {
+    fn get_miner_address(
+        &self,
+        id_bhh: &StacksBlockId,
+        _epoch_id: &StacksEpochId,
+    ) -> Option<StacksAddress> {
         self.store.get(id_bhh).map(|id| id.miner)
     }
-    fn get_burnchain_tokens_spent_for_block(&self, id_bhh: &StacksBlockId) -> Option<u128> {
+    fn get_burnchain_tokens_spent_for_block(
+        &self,
+        id_bhh: &StacksBlockId,
+        _epoch_id: &StacksEpochId,
+    ) -> Option<u128> {
         self.store
             .get(id_bhh)
             .map(|id| id.burnchain_tokens_spent_for_block)
     }
-    fn get_burnchain_tokens_spent_for_winning_block(&self, id_bhh: &StacksBlockId) -> Option<u128> {
+    fn get_burnchain_tokens_spent_for_winning_block(
+        &self,
+        id_bhh: &StacksBlockId,
+        _epoch_id: &StacksEpochId,
+    ) -> Option<u128> {
         self.store
             .get(id_bhh)
             .map(|id| id.get_burnchain_tokens_spent_for_winning_block)
     }
-    fn get_tokens_earned_for_block(&self, id_bhh: &StacksBlockId) -> Option<u128> {
+    fn get_tokens_earned_for_block(
+        &self,
+        id_bhh: &StacksBlockId,
+        _epoch_id: &StacksEpochId,
+    ) -> Option<u128> {
         self.store.get(id_bhh).map(|id| id.tokens_earned_for_block)
     }
 }

--- a/clar2wasm/src/datastore.rs
+++ b/clar2wasm/src/datastore.rs
@@ -463,11 +463,13 @@ impl BurnStateDB for BurnDatastore {
     }
 
     fn get_tip_burn_block_height(&self) -> Option<u32> {
-        Some(0)
+        Some(self.chain_height)
     }
 
     fn get_tip_sortition_id(&self) -> Option<SortitionId> {
-        Some(SortitionId([0; 32]))
+        let bytes = height_to_hashed_bytes(self.chain_height);
+        let sortition_id = SortitionId(bytes);
+        Some(sortition_id)
     }
 
     /// Returns the *burnchain block height* for the `sortition_id` is associated with.

--- a/clar2wasm/src/datastore.rs
+++ b/clar2wasm/src/datastore.rs
@@ -462,6 +462,14 @@ impl BurnStateDB for BurnDatastore {
         0
     }
 
+    fn get_tip_burn_block_height(&self) -> Option<u32> {
+        Some(0)
+    }
+
+    fn get_tip_sortition_id(&self) -> Option<SortitionId> {
+        Some(SortitionId([0; 32]))
+    }
+
     /// Returns the *burnchain block height* for the `sortition_id` is associated with.
     fn get_burn_block_height(&self, sortition_id: &SortitionId) -> Option<u32> {
         self.sortition_lookup

--- a/clar2wasm/src/initialize.rs
+++ b/clar2wasm/src/initialize.rs
@@ -11,8 +11,8 @@ use crate::linker::link_host_functions;
 use crate::wasm_utils::*;
 
 // The context used when making calls into the Wasm module.
-pub struct ClarityWasmContext<'a, 'b> {
-    pub global_context: &'a mut GlobalContext<'b>,
+pub struct ClarityWasmContext<'a, 'b, 'hooks> {
+    pub global_context: &'a mut GlobalContext<'b, 'hooks>,
     contract_context: Option<&'a ContractContext>,
     contract_context_mut: Option<&'a mut ContractContext>,
     pub call_stack: &'a mut CallStack,
@@ -32,9 +32,9 @@ pub struct ClarityWasmContext<'a, 'b> {
     pub contract_analysis: Option<&'a ContractAnalysis>,
 }
 
-impl<'a, 'b> ClarityWasmContext<'a, 'b> {
+impl<'a, 'b, 'hooks> ClarityWasmContext<'a, 'b, 'hooks> {
     pub fn new_init(
-        global_context: &'a mut GlobalContext<'b>,
+        global_context: &'a mut GlobalContext<'b, 'hooks>,
         contract_context: &'a mut ContractContext,
         call_stack: &'a mut CallStack,
         sender: Option<PrincipalData>,
@@ -58,7 +58,7 @@ impl<'a, 'b> ClarityWasmContext<'a, 'b> {
     }
 
     pub fn new_run(
-        global_context: &'a mut GlobalContext<'b>,
+        global_context: &'a mut GlobalContext<'b, 'hooks>,
         contract_context: &'a ContractContext,
         call_stack: &'a mut CallStack,
         sender: Option<PrincipalData>,

--- a/clar2wasm/src/initialize.rs
+++ b/clar2wasm/src/initialize.rs
@@ -11,8 +11,8 @@ use crate::linker::link_host_functions;
 use crate::wasm_utils::*;
 
 // The context used when making calls into the Wasm module.
-pub struct ClarityWasmContext<'a, 'b, 'hooks> {
-    pub global_context: &'a mut GlobalContext<'b, 'hooks>,
+pub struct ClarityWasmContext<'a, 'b> {
+    pub global_context: &'a mut GlobalContext<'b>,
     contract_context: Option<&'a ContractContext>,
     contract_context_mut: Option<&'a mut ContractContext>,
     pub call_stack: &'a mut CallStack,
@@ -32,9 +32,9 @@ pub struct ClarityWasmContext<'a, 'b, 'hooks> {
     pub contract_analysis: Option<&'a ContractAnalysis>,
 }
 
-impl<'a, 'b, 'hooks> ClarityWasmContext<'a, 'b, 'hooks> {
+impl<'a, 'b> ClarityWasmContext<'a, 'b> {
     pub fn new_init(
-        global_context: &'a mut GlobalContext<'b, 'hooks>,
+        global_context: &'a mut GlobalContext<'b>,
         contract_context: &'a mut ContractContext,
         call_stack: &'a mut CallStack,
         sender: Option<PrincipalData>,
@@ -58,7 +58,7 @@ impl<'a, 'b, 'hooks> ClarityWasmContext<'a, 'b, 'hooks> {
     }
 
     pub fn new_run(
-        global_context: &'a mut GlobalContext<'b, 'hooks>,
+        global_context: &'a mut GlobalContext<'b>,
         contract_context: &'a ContractContext,
         call_stack: &'a mut CallStack,
         sender: Option<PrincipalData>,

--- a/clar2wasm/src/linker.rs
+++ b/clar2wasm/src/linker.rs
@@ -35,6 +35,8 @@ pub fn link_host_functions(linker: &mut Linker<ClarityWasmContext>) -> Result<()
     link_contract_caller_fn(linker)?;
     link_tx_sponsor_fn(linker)?;
     link_block_height_fn(linker)?;
+    link_stacks_block_height_fn(linker)?;
+    link_tenure_height_fn(linker)?;
     link_burn_block_height_fn(linker)?;
     link_stx_liquid_supply_fn(linker)?;
     link_is_in_regtest_fn(linker)?;
@@ -883,6 +885,56 @@ fn link_block_height_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), E
         .map_err(|e| {
             Error::Wasm(WasmError::UnableToLinkHostFunction(
                 "block_height".to_string(),
+                e,
+            ))
+        })
+}
+
+/// Link host interface function, `stacks_block_height`, into the Wasm module.
+/// This function is called for use of the builtin variable, `stacks_block-height`.
+fn link_stacks_block_height_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error> {
+    linker
+        .func_wrap(
+            "clarity",
+            "stacks_block_height",
+            |mut caller: Caller<'_, ClarityWasmContext>| {
+                let height = caller
+                    .data_mut()
+                    .global_context
+                    .database
+                    .get_current_block_height();
+                Ok((height as i64, 0i64))
+            },
+        )
+        .map(|_| ())
+        .map_err(|e| {
+            Error::Wasm(WasmError::UnableToLinkHostFunction(
+                "stacks_block_height".to_string(),
+                e,
+            ))
+        })
+}
+
+/// Link host interface function, `tenure_height`, into the Wasm module.
+/// This function is called for use of the builtin variable, `tenure-height`.
+fn link_tenure_height_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error> {
+    linker
+        .func_wrap(
+            "clarity",
+            "tenure_height",
+            |mut caller: Caller<'_, ClarityWasmContext>| {
+                let height = caller
+                    .data_mut()
+                    .global_context
+                    .database
+                    .get_tenure_height()?;
+                Ok((height as i64, 0i64))
+            },
+        )
+        .map(|_| ())
+        .map_err(|e| {
+            Error::Wasm(WasmError::UnableToLinkHostFunction(
+                "tenure_height".to_string(),
                 e,
             ))
         })
@@ -4118,6 +4170,16 @@ pub fn load_stdlib() -> Result<(Instance, Store<()>), wasmtime::Error> {
 
     linker.func_wrap("clarity", "block_height", |_: Caller<'_, ()>| {
         println!("block-height");
+        Ok((0i64, 0i64))
+    })?;
+
+    linker.func_wrap("clarity", "stacks_block_height", |_: Caller<'_, ()>| {
+        println!("stacks-block-height");
+        Ok((0i64, 0i64))
+    })?;
+
+    linker.func_wrap("clarity", "tenure_height", |_: Caller<'_, ()>| {
+        println!("tenure-height");
         Ok((0i64, 0i64))
     })?;
 

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -221,6 +221,8 @@
                                                      (param $return_length i32)
                                                      (result i32 i32 i32)))
     (import "clarity" "block_height" (func $stdlib.block_height (result i64 i64)))
+    (import "clarity" "stacks_block_height" (func $stdlib.stacks_block_height (result i64 i64)))
+    (import "clarity" "tenure_height" (func $stdlib.tenure_height (result i64 i64)))
     (import "clarity" "burn_block_height" (func $stdlib.burn_block_height (result i64 i64)))
     (import "clarity" "stx_liquid_supply" (func $stdlib.stx_liquid_supply (result i64 i64)))
     ;; TODO: these three funcs below could be hard-coded at compile-time.

--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -236,7 +236,7 @@ impl TestEnvironment {
 
 impl Default for TestEnvironment {
     fn default() -> Self {
-        Self::new(StacksEpochId::latest(), ClarityVersion::latest())
+        Self::new(StacksEpochId::Epoch25, ClarityVersion::Clarity2)
     }
 }
 

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -1216,6 +1216,8 @@ impl WasmGenerator {
                     builder.call(self.func_by_name("stdlib.chain_id"));
                     Ok(true)
                 }
+                NativeVariables::StacksBlockHeight => todo!(),
+                NativeVariables::TenureHeight => todo!(),
             }
         } else {
             Ok(false)

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -1176,6 +1176,16 @@ impl WasmGenerator {
                     builder.call(self.func_by_name("stdlib.block_height"));
                     Ok(true)
                 }
+                NativeVariables::StacksBlockHeight => {
+                    // Call the host interface function, `stacks_block_height`
+                    builder.call(self.func_by_name("stdlib.stacks_block_height"));
+                    Ok(true)
+                }
+                NativeVariables::TenureHeight => {
+                    // Call the host interface function, `tenure_height`
+                    builder.call(self.func_by_name("stdlib.tenure_height"));
+                    Ok(true)
+                }
                 NativeVariables::BurnBlockHeight => {
                     // Call the host interface function, `burn_block_height`
                     builder.call(self.func_by_name("stdlib.burn_block_height"));
@@ -1216,8 +1226,6 @@ impl WasmGenerator {
                     builder.call(self.func_by_name("stdlib.chain_id"));
                     Ok(true)
                 }
-                NativeVariables::StacksBlockHeight => todo!(),
-                NativeVariables::TenureHeight => todo!(),
             }
         } else {
             Ok(false)

--- a/clar2wasm/src/wasm_utils.rs
+++ b/clar2wasm/src/wasm_utils.rs
@@ -1236,7 +1236,9 @@ pub fn call_function<'a>(
     // Access the global stack pointer from the instance
     let stack_pointer = instance
         .get_global(&mut store, "stack-pointer")
-        .ok_or(Error::Wasm(WasmError::StackPointerNotFound))?;
+        .ok_or(Error::Wasm(WasmError::GlobalNotFound(
+            "stack-pointer".to_string(),
+        )))?;
     let mut offset = stack_pointer
         .get(&mut store)
         .i32()

--- a/clar2wasm/src/words/blockinfo.rs
+++ b/clar2wasm/src/words/blockinfo.rs
@@ -145,10 +145,11 @@ impl ComplexWord for AtBlock {
 
 #[cfg(test)]
 mod tests {
+    use clarity::types::StacksEpochId;
     use clarity::vm::types::{OptionalData, PrincipalData, TupleData};
     use clarity::vm::Value;
 
-    use crate::tools::{crosscheck, evaluate, TestEnvironment};
+    use crate::tools::{crosscheck, crosscheck_with_epoch, evaluate, TestEnvironment};
 
     //- Block Info
 
@@ -333,8 +334,9 @@ mod tests {
     //- At Block
     #[test]
     fn at_block() {
-        crosscheck("(at-block 0x0000000000000000000000000000000000000000000000000000000000000000 stacks-block-height)",
-            Ok(Some(Value::UInt(0xFFFFFFFF)))
+        crosscheck_with_epoch("(at-block 0x0000000000000000000000000000000000000000000000000000000000000000 stacks-block-height)",
+            Ok(Some(Value::UInt(0xFFFFFFFF))),
+            StacksEpochId::Epoch24,
         )
     }
 
@@ -360,14 +362,22 @@ mod tests {
     fn test_block_height() {
         let snpt = "
 (define-public (block)
-  (ok stacks-block-height))
+  (ok block-height))
 
 (define-public (burn-block)
   (ok burn-block-height))
 ";
 
-        crosscheck(&format!("{snpt} (block)"), evaluate("(ok u0)"));
-        crosscheck(&format!("{snpt} (burn-block)"), evaluate("(ok u0)"));
+        crosscheck_with_epoch(
+            &format!("{snpt} (block)"),
+            evaluate("(ok u0)"),
+            StacksEpochId::Epoch24,
+        );
+        crosscheck_with_epoch(
+            &format!("{snpt} (burn-block)"),
+            evaluate("(ok u0)"),
+            StacksEpochId::Epoch24,
+        );
     }
 
     #[test]

--- a/clar2wasm/src/words/blockinfo.rs
+++ b/clar2wasm/src/words/blockinfo.rs
@@ -333,7 +333,7 @@ mod tests {
     //- At Block
     #[test]
     fn at_block() {
-        crosscheck("(at-block 0x0000000000000000000000000000000000000000000000000000000000000000 block-height)",
+        crosscheck("(at-block 0x0000000000000000000000000000000000000000000000000000000000000000 stacks-block-height)",
             Ok(Some(Value::UInt(0xFFFFFFFF)))
         )
     }
@@ -360,7 +360,7 @@ mod tests {
     fn test_block_height() {
         let snpt = "
 (define-public (block)
-  (ok block-height))
+  (ok stacks-block-height))
 
 (define-public (burn-block)
   (ok burn-block-height))

--- a/clar2wasm/src/words/blockinfo.rs
+++ b/clar2wasm/src/words/blockinfo.rs
@@ -155,7 +155,11 @@ mod tests {
 
     #[test]
     fn get_block_info_non_existent() {
-        crosscheck("(get-block-info? time u9999999)", Ok(Some(Value::none())));
+        crosscheck_with_epoch(
+            "(get-block-info? time u9999999)",
+            Ok(Some(Value::none())),
+            StacksEpochId::Epoch25,
+        );
     }
 
     #[test]

--- a/clar2wasm/src/words/blockinfo.rs
+++ b/clar2wasm/src/words/blockinfo.rs
@@ -291,9 +291,6 @@ mod tests {
 
     #[test]
     fn get_burn_block_info_header_hash() {
-        let mut env = TestEnvironment::default();
-        env.advance_chain_tip(1);
-
         crosscheck(
             "(get-burn-block-info? header-hash u0)",
             Ok(Some(

--- a/clar2wasm/src/words/blockinfo.rs
+++ b/clar2wasm/src/words/blockinfo.rs
@@ -279,7 +279,9 @@ mod tests {
     fn get_burn_block_info_non_existent() {
         crosscheck(
             "(get-burn-block-info? header-hash u9999999)",
-            Ok(Some(Value::none())),
+            Ok(Some(
+                Value::some(Value::buff_from([0; 32].to_vec()).unwrap()).unwrap(),
+            )),
         )
     }
 
@@ -287,13 +289,13 @@ mod tests {
     fn get_burn_block_info_header_hash() {
         let mut env = TestEnvironment::default();
         env.advance_chain_tip(1);
-        let result = env
-            .evaluate("(get-burn-block-info? header-hash u0)")
-            .expect("Failed to init contract.");
-        assert_eq!(
-            result,
-            Some(Value::some(Value::buff_from([0; 32].to_vec()).unwrap()).unwrap())
-        );
+
+        crosscheck(
+            "(get-burn-block-info? header-hash u0)",
+            Ok(Some(
+                Value::some(Value::buff_from([0; 32].to_vec()).unwrap()).unwrap(),
+            )),
+        )
     }
 
     #[test]

--- a/clar2wasm/src/words/blockinfo.rs
+++ b/clar2wasm/src/words/blockinfo.rs
@@ -334,9 +334,18 @@ mod tests {
     //- At Block
     #[test]
     fn at_block() {
-        crosscheck_with_epoch("(at-block 0x0000000000000000000000000000000000000000000000000000000000000000 stacks-block-height)",
+        crosscheck_with_epoch("(at-block 0x0000000000000000000000000000000000000000000000000000000000000000 block-height)",
             Ok(Some(Value::UInt(0xFFFFFFFF))),
             StacksEpochId::Epoch24,
+        )
+    }
+
+    //- At Block
+    #[test]
+    fn at_block_with_stacks_block_height() {
+        crosscheck_with_epoch("(at-block 0x0000000000000000000000000000000000000000000000000000000000000000 stacks-block-height)",
+            Ok(Some(Value::UInt(0xFFFFFFFF))),
+            StacksEpochId::Epoch30,
         )
     }
 

--- a/clar2wasm/tests/bin_tests.rs
+++ b/clar2wasm/tests/bin_tests.rs
@@ -18,6 +18,11 @@ fn test_clar2wasm_with_input() {
         if file.path().extension().unwrap_or(OsStr::new("")) != "clar" {
             continue;
         }
+        if file.path().file_name().unwrap() == "bns.clar" {
+            // bns.clar uses `block-height` which is not supported in clarity 3
+            // the clar2wasm bin should accept a ClarityVersion flag
+            continue;
+        }
         let outfile = temp.join(
             file.file_name()
                 .into_string()

--- a/clar2wasm/tests/contracts/block-heights.clar
+++ b/clar2wasm/tests/contracts/block-heights.clar
@@ -1,5 +1,5 @@
 (define-public (block)
-  (ok block-height)
+  (ok stacks-block-height)
 )
 
 (define-public (burn-block)

--- a/clar2wasm/tests/contracts/block-heights.clar
+++ b/clar2wasm/tests/contracts/block-heights.clar
@@ -1,5 +1,5 @@
 (define-public (block)
-  (ok stacks-block-height)
+  (ok block-height)
 )
 
 (define-public (burn-block)

--- a/clar2wasm/tests/lib.rs
+++ b/clar2wasm/tests/lib.rs
@@ -14,13 +14,17 @@ mod tests {
         .expect("Can't find bns contract");
 
         // check for normal behavior with latest epoch/version
-        clar2wasm::tools::crosscheck(&bns, Ok(None));
+        clar2wasm::tools::crosscheck_with_epoch(
+            &bns,
+            Ok(None),
+            clarity::types::StacksEpochId::Epoch20,
+        );
 
         // check with the issue's problematic epoch
         assert!(clar2wasm::tools::evaluate_at(
             &bns,
             clarity::types::StacksEpochId::Epoch20,
-            clarity::vm::version::ClarityVersion::latest(),
+            clarity::vm::version::ClarityVersion::Clarity2,
         )
         .is_ok());
     }

--- a/clar2wasm/tests/lib.rs
+++ b/clar2wasm/tests/lib.rs
@@ -7,23 +7,22 @@ pub mod lib_tests;
 mod tests {
     #[test]
     /// Specific test for the fix of [issue 340](https://github.com/stacks-network/clarity-wasm/issues/340)
-    fn test_bns_contract_latest() {
+    fn test_bns_contract_in_epoch2_4() {
         let bns = std::fs::read_to_string(
             env!("CARGO_MANIFEST_DIR").to_owned() + "/tests/contracts/bns.clar",
         )
         .expect("Can't find bns contract");
 
-        // check for normal behavior with latest epoch/version
-        clar2wasm::tools::crosscheck_with_epoch(
-            &bns,
-            Ok(None),
-            clarity::types::StacksEpochId::Epoch20,
-        );
-
-        // check with the issue's problematic epoch
         assert!(clar2wasm::tools::evaluate_at(
             &bns,
             clarity::types::StacksEpochId::Epoch20,
+            clarity::vm::version::ClarityVersion::Clarity1,
+        )
+        .is_ok());
+
+        assert!(clar2wasm::tools::evaluate_at(
+            &bns,
+            clarity::types::StacksEpochId::Epoch24,
             clarity::vm::version::ClarityVersion::Clarity2,
         )
         .is_ok());

--- a/clar2wasm/tests/lib_tests.rs
+++ b/clar2wasm/tests/lib_tests.rs
@@ -1148,15 +1148,15 @@ test_contract_call_response!(
 // chain, which is not the case when running the tests. Once the test framework
 // supports this, these tests can be re-enabled.
 
-test_contract_call_response!(
-    test_gbi_non_existent,
-    "get-block-info",
-    "non-existent",
-    |response: ResponseData| {
-        assert!(response.committed);
-        assert_eq!(*response.data, Value::none());
-    }
-);
+// test_contract_call_response!(
+//     test_gbi_non_existent,
+//     "get-block-info",
+//     "non-existent",
+//     |response: ResponseData| {
+//         assert!(response.committed);
+//         assert_eq!(*response.data, Value::none());
+//     }
+// );
 
 // test_contract_call_response!(
 //     test_gbi_bhh,
@@ -1230,25 +1230,25 @@ test_contract_call_response!(
 //     }
 // );
 
-test_contract_call_response!(
-    test_gbi_miner_spend_total,
-    "get-block-info",
-    "get-miner-spend-total",
-    |response: ResponseData| {
-        assert!(response.committed);
-        assert_eq!(*response.data, Value::some(Value::UInt(0)).unwrap());
-    }
-);
+// test_contract_call_response!(
+//     test_gbi_miner_spend_total,
+//     "get-block-info",
+//     "get-miner-spend-total",
+//     |response: ResponseData| {
+//         assert!(response.committed);
+//         assert_eq!(*response.data, Value::some(Value::UInt(0)).unwrap());
+//     }
+// );
 
-test_contract_call_response!(
-    test_gbi_miner_spend_winner,
-    "get-block-info",
-    "get-miner-spend-winner",
-    |response: ResponseData| {
-        assert!(response.committed);
-        assert_eq!(*response.data, Value::some(Value::UInt(0)).unwrap());
-    }
-);
+// test_contract_call_response!(
+//     test_gbi_miner_spend_winner,
+//     "get-block-info",
+//     "get-miner-spend-winner",
+//     |response: ResponseData| {
+//         assert!(response.committed);
+//         assert_eq!(*response.data, Value::some(Value::UInt(0)).unwrap());
+//     }
+// );
 
 test_multi_contract_call_response!(
     test_contract_call_no_args,

--- a/clar2wasm/tests/lib_tests.rs
+++ b/clar2wasm/tests/lib_tests.rs
@@ -70,7 +70,7 @@ macro_rules! test_multi_contract_init {
                             contract_str.as_str(),
                             &contract_id,
                             LimitedCostTracker::new_free(),
-                            ClarityVersion::latest(),
+                            ClarityVersion::Clarity2,
                             StacksEpochId::latest(),
                             analysis_db,
                         )
@@ -86,7 +86,7 @@ macro_rules! test_multi_contract_init {
                     .expect("Failed to insert contract analysis.");
 
                 let mut contract_context =
-                    ContractContext::new(contract_id.clone(), ClarityVersion::latest());
+                    ContractContext::new(contract_id.clone(), ClarityVersion::Clarity2);
                 // compile_result.module.emit_wasm_file("test.wasm").unwrap();
                 contract_context.set_wasm_module(compile_result.module.emit_wasm());
 
@@ -1148,15 +1148,15 @@ test_contract_call_response!(
 // chain, which is not the case when running the tests. Once the test framework
 // supports this, these tests can be re-enabled.
 
-// test_contract_call_response!(
-//     test_gbi_non_existent,
-//     "get-block-info",
-//     "non-existent",
-//     |response: ResponseData| {
-//         assert!(response.committed);
-//         assert_eq!(*response.data, Value::none());
-//     }
-// );
+test_contract_call_response!(
+    test_gbi_non_existent,
+    "get-block-info",
+    "non-existent",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::none());
+    }
+);
 
 // test_contract_call_response!(
 //     test_gbi_bhh,
@@ -1230,25 +1230,25 @@ test_contract_call_response!(
 //     }
 // );
 
-// test_contract_call_response!(
-//     test_gbi_miner_spend_total,
-//     "get-block-info",
-//     "get-miner-spend-total",
-//     |response: ResponseData| {
-//         assert!(response.committed);
-//         assert_eq!(*response.data, Value::some(Value::UInt(0)).unwrap());
-//     }
-// );
+test_contract_call_response!(
+    test_gbi_miner_spend_total,
+    "get-block-info",
+    "get-miner-spend-total",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::some(Value::UInt(0)).unwrap());
+    }
+);
 
-// test_contract_call_response!(
-//     test_gbi_miner_spend_winner,
-//     "get-block-info",
-//     "get-miner-spend-winner",
-//     |response: ResponseData| {
-//         assert!(response.committed);
-//         assert_eq!(*response.data, Value::some(Value::UInt(0)).unwrap());
-//     }
-// );
+test_contract_call_response!(
+    test_gbi_miner_spend_winner,
+    "get-block-info",
+    "get-miner-spend-winner",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::some(Value::UInt(0)).unwrap());
+    }
+);
 
 test_multi_contract_call_response!(
     test_contract_call_no_args,


### PR DESCRIPTION
stacks-core branch [`feat/clarity-wasm-develop`](https://github.com/stacks-network/stacks-core/pull/4756) was updated with the latest changes from develop. Including Clarity 3 changes.

This PR updates the clarity crate.

Further work is need to properly support Clarity 3. See #428 