### PR TITLE
Fixes `replace-at?` with empty replacement

### DIFF
--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -1999,4 +1999,19 @@ mod tests {
 
         crosscheck(snippet, Ok(Some(expected)))
     }
+
+    #[test]
+    fn replace_element_cannot_be_empty_string_ascii() {
+        crosscheck(r#"(replace-at? "abcd" u0 "")"#, Err(()))
+    }
+
+    #[test]
+    fn replace_element_cannot_be_empty_string_utf8() {
+        crosscheck(r#"(replace-at? u"abcd" u0 u"")"#, Err(()))
+    }
+
+    #[test]
+    fn replace_element_cannot_be_empty_buff() {
+        crosscheck(r#"(replace-at? 0x12345678 u0 0x)"#, Err(()))
+    }
 }


### PR DESCRIPTION
Simple fix where we check for strings types and the buffer type if the replacement is empty, and throw a runtime error in this case.

Fixes #418

Since I touched this function whose crosscheck test was ignored, I fixed its problem too. It seems it was due to [a typechecker error](https://github.com/stacks-network/stacks-core/issues/4622) which could be _workarounded_ by setting the types of the arguments.

Fixes #395 

(Seems like that issue was poorly assessed: I didn't have any `ValueTooLarge` after the fix, and I ran thousands of examples)