### PR TITLE
test: don't ignore concat_crosscheck

### DIFF
--- a/clar2wasm/tests/wasm-generation/sequences.rs
+++ b/clar2wasm/tests/wasm-generation/sequences.rs
@@ -54,7 +54,6 @@ proptest! {
     #![proptest_config(super::runtime_config())]
 
     #[test]
-    #[ignore]
     fn concat_crosscheck((seq1, seq2) in (0usize..=16).prop_flat_map(PropValue::any_sequence).prop_ind_flat_map2(|seq1| PropValue::from_type(TypeSignature::type_of(&seq1.into()).expect("Could not get type signature")))) {
         let snippet = format!("(concat {seq1} {seq2})");
 


### PR DESCRIPTION
I noticed this test was ignored with no reason given, and since it passes it makes sense to just re-enable so that we don't forget