### PR TITLE
Rewrite of tuple consensus-buff deserialization

### DIFF
--- a/clar2wasm/src/deserialize.rs
+++ b/clar2wasm/src/deserialize.rs
@@ -1168,7 +1168,7 @@ impl WasmGenerator {
                             .i32_const(keys_len as i32)
                             .local_get(offset_local)
                             .local_get(name_size)
-                            .call(self.func_by_name("stdlib.bsearch_clarity_name"));
+                            .call(self.func_by_name("stdlib.bsearch-clarity-name"));
 
                         // update the offset local to point after the field name
                         switch_block

--- a/clar2wasm/src/deserialize.rs
+++ b/clar2wasm/src/deserialize.rs
@@ -4,7 +4,8 @@ use clarity::vm::types::{
     ListTypeData, SequenceSubtype, StringSubtype, TupleTypeSignature, TypeSignature,
 };
 use walrus::ir::{
-    BinaryOp, Const, ExtendedLoad, IfElse, InstrSeqType, LoadKind, Loop, MemArg, StoreKind, UnaryOp,
+    BinaryOp, Block, Const, ExtendedLoad, IfElse, InstrSeqType, LoadKind, Loop, MemArg, StoreKind,
+    UnaryOp,
 };
 use walrus::{InstrSeqBuilder, LocalId, MemoryId, ValType};
 
@@ -962,220 +963,343 @@ impl WasmGenerator {
         end_local: LocalId,
         tuple_ty: &TupleTypeSignature,
     ) -> Result<(), GeneratorError> {
+        // We need to be able to parse the keys coming in a random order, only one occurence of each key.
+        // We should ignore a valid key and value that is not specified in the result type.
+        // Here is what is generated in pseudo-code:
+        /*
+            let bitset = Bitset::new();
+            for key in serialized_bytes {
+                let n = find_index(key)
+                switch n {
+                    case 1:
+                        if bitset.contains(key) { return None; }
+                        handle_parsing_of_value_1;
+                        bitset.insert(key);
+                        break;
+                    case 2:
+                        if bitset.contains(key) { return None; }
+                        handle_parsing_of_value_2;
+                        bitset.insert(key);
+                        break;
+                    ...
+                    default:
+                        check_valid_skippable_key();
+                        check_valid_skippable_value();
+                        break;
+                }
+            }
+            if bitset.full() { return Some(result) } else { return None };
+        */
+
+        // We will need to add all the keys to the data to be able to check if
+        // they are part of the tuple and find their index. They will be stored as
+        // [number of keys as u32 | key 1 offset as u32 | key 2 offset as u32 | key 1 len as u8 | key 2 len as u8 | ... | key 1 | key 2 | ...]
+        let tm = ordered_tuple_signature(tuple_ty);
+        let (keys_offset, keys_len) = {
+            let mut keys = (tm.len() as u32).to_le_bytes().to_vec();
+            // add relative offsets
+            keys.extend(
+                tm.keys()
+                    .scan(
+                        self.literal_memory_end + 4 + tm.len() as u32 * 5,
+                        |state, name| {
+                            let res = state.to_le_bytes();
+                            *state += name.len() as u32;
+                            Some(res)
+                        },
+                    )
+                    .flatten(),
+            );
+            // add lens
+            keys.extend(tm.keys().map(|name| name.len()));
+            // add keys names
+            keys.extend(tm.keys().flat_map(|name| name.as_bytes()));
+            self.add_bytes_literal(&keys)?
+        };
+
         let ty = TypeSignature::TupleType(tuple_ty.clone());
 
-        // Create a block for the body of this operation, so that we can
+        // bitset which will indicate if a field was defined or not
+        let result_len = tm.len();
+        let bitset: Vec<LocalId> = (0..(result_len + 31) / 32)
+            .map(|_| self.module.locals.add(ValType::I32))
+            .collect();
+
+        // locals that will hold the tuple values, in the same order as the tuple type map
+        let values_locals: Vec<Vec<LocalId>> = tm
+            .values()
+            .map(|ty_| {
+                clar2wasm_ty(ty_)
+                    .into_iter()
+                    .map(|local_ty| self.module.locals.add(local_ty))
+                    .collect()
+            })
+            .collect();
+
+        // This locale will contain the remaining number of fields to deserialize
+        let remaining_fields = self.module.locals.add(ValType::I32);
+
+        // Create a main block for the body of this operation, so that we can
         // early exit as needed.
         let mut wasm_val_ty = vec![ValType::I32];
         wasm_val_ty.extend(clar2wasm_ty(&ty));
-        let block_ty = InstrSeqType::new(&mut self.module.types, &[], &wasm_val_ty);
-        let mut block = builder.dangling_instr_seq(block_ty);
-        let block_id = block.id();
+        let return_ty = InstrSeqType::new(&mut self.module.types, &[], &wasm_val_ty);
 
-        // Verify that reading 5 bytes (prefix + number of keys) from the
-        // offset is within the buffer.
-        block
-            .local_get(offset_local)
-            .i32_const(5)
-            .binop(BinaryOp::I32Add)
-            .local_get(end_local)
-            .binop(BinaryOp::I32GtU)
-            .if_else(
-                None,
-                |then| {
-                    // Return none
-                    then.i32_const(0);
-                    add_placeholder_for_clarity_type(then, &ty);
-                    then.br(block_id);
-                },
-                |_| {},
-            );
+        // Main block creation
+        let main_block_id = {
+            let mut main_block = builder.dangling_instr_seq(return_ty);
 
-        // Read the prefix byte
-        block.local_get(offset_local).load(
-            memory,
-            LoadKind::I32_8 {
-                kind: ExtendedLoad::ZeroExtend,
-            },
-            MemArg {
-                align: 1,
-                offset: 0,
-            },
-        );
+            // we initialize the empty bitset
+            for &b in bitset.iter() {
+                main_block.i32_const(0).local_set(b);
+            }
 
-        // Verify the prefix byte
-        block
-            .i32_const(TypePrefix::Tuple as i32)
-            .binop(BinaryOp::I32Ne)
-            .if_else(
-                None,
-                |then| {
-                    // Return none
-                    then.i32_const(0);
-                    add_placeholder_for_clarity_type(then, &ty);
-                    then.br(block_id);
-                },
-                |_| {},
-            );
+            // Create the done_block which will contain the loop and all the blocks for the
+            // switch-case-like construction.
+            let done_block_id = {
+                let mut done_block = main_block.dangling_instr_seq(None);
+                let done_block_id = done_block.id();
 
-        // Read the number of keys
-        block
-            .local_get(offset_local)
-            .i32_const(1)
-            .binop(BinaryOp::I32Add)
-            .call(self.func_by_name("stdlib.load-i32-be"));
-
-        // Verify that the number of keys matches the specified type
-        block
-            .i32_const(tuple_ty.get_type_map().len() as i32)
-            .binop(BinaryOp::I32Ne)
-            .if_else(
-                None,
-                |then| {
-                    // Return none
-                    then.i32_const(0);
-                    add_placeholder_for_clarity_type(then, &ty);
-                    then.br(block_id);
-                },
-                |_| {},
-            );
-
-        // Update the offset to point to the key
-        block
-            .local_get(offset_local)
-            .i32_const(5)
-            .binop(BinaryOp::I32Add)
-            .local_set(offset_local);
-
-        // For each key in the type, verify that the key matches the type,
-        // and deserialize the value.
-        for (key, value_ty) in ordered_tuple_signature(tuple_ty) {
-            // The key is a 1-byte length followed by the string bytes.
-            // First, verify that the key is within the buffer.
-            block
-                .local_get(offset_local)
-                .i32_const(key.len() as i32 + 1)
-                .binop(BinaryOp::I32Add)
-                .local_get(end_local)
-                .binop(BinaryOp::I32GtU)
-                .if_else(
-                    None,
-                    |then| {
-                        // Return none
-                        then.i32_const(0);
-                        add_placeholder_for_clarity_type(then, &ty);
-                        then.br(block_id);
-                    },
-                    |_| {},
-                );
-
-            // Then, grab the length of the key.
-            block.local_get(offset_local).load(
-                memory,
-                LoadKind::I32_8 {
-                    kind: ExtendedLoad::ZeroExtend,
-                },
-                MemArg {
-                    align: 1,
-                    offset: 0,
-                },
-            );
-
-            // Compare the key length to the expected length
-            block
-                .i32_const(key.len() as i32)
-                .binop(BinaryOp::I32Ne)
-                .if_else(
-                    None,
-                    |then| {
-                        // Return none
-                        then.i32_const(0);
-                        add_placeholder_for_clarity_type(then, &ty);
-                        then.br(block_id);
-                    },
-                    |_| {},
-                );
-
-            // Compare the key to the expected key
-            let key_bytes = key.as_bytes();
-            for (i, byte) in key_bytes.iter().enumerate() {
-                block
+                // Verify that reading 5 bytes (prefix + number of keys) from the
+                // offset is within the buffer.
+                done_block
                     .local_get(offset_local)
-                    .load(
-                        memory,
-                        LoadKind::I32_8 {
-                            kind: ExtendedLoad::ZeroExtend,
-                        },
-                        MemArg {
-                            align: 1,
-                            offset: i as u32 + 1,
-                        },
-                    )
-                    .i32_const(*byte as i32)
+                    .i32_const(5)
+                    .binop(BinaryOp::I32Add)
+                    .local_get(end_local)
+                    .binop(BinaryOp::I32GtU)
+                    .br_if(done_block_id);
+
+                // Read the prefix byte
+                done_block.local_get(offset_local).load(
+                    memory,
+                    LoadKind::I32_8 {
+                        kind: ExtendedLoad::ZeroExtend,
+                    },
+                    MemArg {
+                        align: 1,
+                        offset: 0,
+                    },
+                );
+
+                // Verify the prefix byte
+                done_block
+                    .i32_const(TypePrefix::Tuple as i32)
                     .binop(BinaryOp::I32Ne)
-                    .if_else(
-                        None,
-                        |then| {
-                            // Return none
-                            then.i32_const(0);
-                            add_placeholder_for_clarity_type(then, &ty);
-                            then.br(block_id);
-                        },
-                        |_| {},
-                    );
+                    .br_if(done_block_id);
+
+                // Read the number of keys and check that it's >= to the
+                // result tuple number of fields
+                done_block
+                    .local_get(offset_local)
+                    .i32_const(1)
+                    .binop(BinaryOp::I32Add)
+                    .call(self.func_by_name("stdlib.load-i32-be"))
+                    .local_tee(remaining_fields)
+                    .i32_const(tuple_ty.get_type_map().len() as i32)
+                    .binop(BinaryOp::I32LtU)
+                    .br_if(done_block_id);
+
+                // Update the offset to point to the first key
+                done_block
+                    .local_get(offset_local)
+                    .i32_const(5)
+                    .binop(BinaryOp::I32Add)
+                    .local_set(offset_local);
+
+                // This is the loop body, which will contain the switch/case
+                let loop_id = {
+                    let mut loop_ = done_block.dangling_instr_seq(None);
+                    let loop_id = loop_.id();
+
+                    // Here are all the blocks needed for the switch-case
+                    let switch_case_blocks: Vec<_> = (0..=tuple_ty.get_type_map().len())
+                        .map(|_| loop_.dangling_instr_seq(None).id())
+                        .collect();
+
+                    // Here is the switch
+                    {
+                        let mut switch_block = loop_.instr_seq(switch_case_blocks[0]);
+
+                        // Check that we have one byte for the field name and fail if not.
+                        switch_block
+                            .local_get(offset_local)
+                            .local_get(end_local)
+                            .binop(BinaryOp::I32GeU)
+                            .br_if(done_block_id);
+
+                        // Load the number of bytes for the field name
+                        let name_size = self.module.locals.add(ValType::I32);
+                        switch_block
+                            .local_get(offset_local)
+                            .load(
+                                memory,
+                                LoadKind::I32_8 {
+                                    kind: ExtendedLoad::ZeroExtend,
+                                },
+                                MemArg {
+                                    align: 1,
+                                    offset: 0,
+                                },
+                            )
+                            .local_tee(name_size);
+
+                        // Check that we have enough bytes left for the parsing the name and fail if not.
+                        switch_block
+                            .local_get(offset_local)
+                            .i32_const(1)
+                            .binop(BinaryOp::I32Add)
+                            .local_tee(offset_local)
+                            .binop(BinaryOp::I32Add)
+                            .local_get(end_local)
+                            .binop(BinaryOp::I32GtU)
+                            .br_if(done_block_id);
+
+                        // Compute the index of the field name to know which branch to take in
+                        // the switch case.
+                        switch_block
+                            .i32_const(keys_offset as i32)
+                            .i32_const(keys_len as i32)
+                            .local_get(offset_local)
+                            .local_get(name_size)
+                            .call(self.func_by_name("stdlib.bsearch_clarity_name"));
+
+                        // update the offset local to point after the field name
+                        switch_block
+                            .local_get(offset_local)
+                            .local_get(name_size)
+                            .binop(BinaryOp::I32Add)
+                            .local_set(offset_local);
+
+                        // branch to the correct case
+                        #[allow(clippy::expect_used)]
+                        let (default, blocks) = switch_case_blocks
+                            .split_last()
+                            .expect("blocks should have at least the default block");
+                        switch_block.br_table(blocks.into(), *default);
+                    }
+
+                    // switch case for valid fields
+                    for (((&case, &field_ty), field_locals), case_idx) in switch_case_blocks[1..]
+                        .iter()
+                        .zip(tm.values())
+                        .zip(values_locals.iter())
+                        .zip(0usize..)
+                    {
+                        let mut case_block = loop_.instr_seq(case);
+
+                        // link the previous block to this one
+                        case_block.instr(Block {
+                            seq: switch_case_blocks[case_idx],
+                        });
+
+                        // check in the bitset if we haven't already dealt with this type
+                        let bitset_idx = case_idx / 32;
+                        let bitset_pos = 1u32 << (case_idx % 32);
+                        case_block
+                            .local_get(bitset[bitset_idx])
+                            .i32_const(bitset_pos as i32)
+                            .binop(BinaryOp::I32And)
+                            .br_if(done_block_id);
+
+                        // try to deserialize the value and add the result to locals
+                        self.deserialize_from_memory(
+                            &mut case_block,
+                            offset_local,
+                            end_local,
+                            field_ty,
+                        )?;
+                        for &l in field_locals.iter().rev() {
+                            case_block.local_set(l);
+                        }
+
+                        // last value after deserialization is for success/failure
+                        case_block.unop(UnaryOp::I32Eqz).br_if(done_block_id);
+
+                        // we set the bit in the bitset
+                        case_block
+                            .local_get(bitset[bitset_idx])
+                            .i32_const(bitset_pos as i32)
+                            .binop(BinaryOp::I32Or)
+                            .local_set(bitset[bitset_idx]);
+
+                        // we loop if we still have fields to deserialize
+                        case_block
+                            .local_get(remaining_fields)
+                            .i32_const(1)
+                            .binop(BinaryOp::I32Sub)
+                            .local_tee(remaining_fields)
+                            .br_if(loop_id);
+
+                        // otherwise it means we are done with the deserialization
+                        case_block.br(done_block_id);
+                    }
+
+                    // default code, which is in the loop after all the cases. It's for an unknown
+                    // field name.
+                    #[allow(clippy::expect_used)]
+                    loop_.instr(Block {
+                        seq: *switch_case_blocks
+                            .last()
+                            .expect("blocks should always have the default block"),
+                    });
+                    // TODO: remove (unreachable) and check for the validity of the field name and the value,
+                    //       then either skip bytes or fail.
+                    loop_.unreachable();
+
+                    loop_id
+                };
+
+                done_block.instr(Loop { seq: loop_id });
+                done_block_id
+            };
+
+            main_block.instr(Block { seq: done_block_id });
+
+            // check if there are no more keys to parse
+            main_block.local_get(remaining_fields).unop(UnaryOp::I32Eqz);
+
+            // check if the bitset is full
+            #[allow(clippy::expect_used)]
+            let (last, inits) = bitset
+                .split_last()
+                .expect("bitset cannot be empty since tuple cannot be 0-tuple");
+            for &b in inits {
+                main_block
+                    .local_get(b)
+                    .i32_const(u32::MAX as i32)
+                    .binop(BinaryOp::I32Eq)
+                    .binop(BinaryOp::I32And);
             }
+            let bits_in_last = if result_len % 32 == 0 {
+                u32::MAX as i32
+            } else {
+                (1u32 << (result_len % 32)).wrapping_sub(1) as i32
+            };
+            main_block
+                .local_get(*last)
+                .i32_const(bits_in_last)
+                .binop(BinaryOp::I32Eq)
+                .binop(BinaryOp::I32And);
 
-            // Increment the offset by the key length and its size
-            block
-                .local_get(offset_local)
-                .i32_const(key.len() as i32 + 1)
-                .binop(BinaryOp::I32Add)
-                .local_set(offset_local);
-
-            // Deserialize the value. Note, this will update the offset to
-            // point to the next key.
-            self.deserialize_from_memory(&mut block, offset_local, end_local, value_ty)?;
-
-            // Check if the deserialization failed:
-            // - Store the value in locals
-            // - Check the inidicator now on top of the stack
-            let inner_locals = self.save_to_locals(&mut block, value_ty, true);
-
-            block.unop(UnaryOp::I32Eqz).if_else(
-                None,
+            main_block.if_else(
+                return_ty,
                 |then| {
-                    // Return none
-                    then.i32_const(0);
-                    add_placeholder_for_clarity_type(then, &ty);
-                    then.br(block_id);
+                    then.i32_const(1);
+                    for l in values_locals.into_iter().flatten() {
+                        then.local_get(l);
+                    }
                 },
-                |_| {},
+                |else_| {
+                    else_.i32_const(0);
+                    add_placeholder_for_clarity_type(else_, &ty);
+                },
             );
 
-            // Deserializing the element was successful, so push the value back
-            // onto the stack.
-            for local in inner_locals {
-                block.local_get(local);
-            }
-        }
+            main_block.id()
+        };
 
-        // If we've reached here, then the tuple is valid, so return it.
-        // But first we need to push the `some` indicator onto the stack.
-
-        // Save the tuple (on the stack) to locals
-        let tuple_locals = self.save_to_locals(&mut block, &ty, true);
-
-        // Push the `some` indicator onto the stack
-        block.i32_const(1);
-
-        // Push the tuple back onto the stack
-        for local in tuple_locals {
-            block.local_get(local);
-        }
-
-        // Add our main block to the builder.
-        builder.instr(walrus::ir::Block { seq: block_id });
-
+        builder.instr(Block { seq: main_block_id });
         Ok(())
     }
 

--- a/clar2wasm/src/deserialize.rs
+++ b/clar2wasm/src/deserialize.rs
@@ -966,31 +966,30 @@ impl WasmGenerator {
         // We need to be able to parse the keys coming in a random order, only one occurence of each key.
         // We should ignore a valid key and value that is not specified in the result type.
         // Here is what is generated in pseudo-code:
-        /*
-            let bitset = Bitset::new();
-            for key in serialized_bytes {
-                let n = find_index(key)
-                switch n {
-                    case 1:
-                        if bitset.contains(key) { return None; }
-                        handle_parsing_of_value_1;
-                        bitset.insert(key);
-                        break;
-                    case 2:
-                        if bitset.contains(key) { return None; }
-                        handle_parsing_of_value_2;
-                        bitset.insert(key);
-                        break;
-                    ...
-                    default:
-                        check_valid_skippable_key();
-                        check_valid_skippable_value();
-                        break;
-                }
-            }
-            if bitset.full() { return Some(result) } else { return None };
-        */
-
+        //
+        //     let bitset = Bitset::new();
+        //     for key in serialized_bytes {
+        //         let n = find_index(key)
+        //         switch n {
+        //             case 1:
+        //                 if bitset.contains(key) { return None; }
+        //                     handle_parsing_of_value_1;
+        //                     bitset.insert(key);
+        //                     break;
+        //             case 2:
+        //                 if bitset.contains(key) { return None; }
+        //                     handle_parsing_of_value_2;
+        //                     bitset.insert(key);
+        //                     break;
+        //             ...
+        //             default:
+        //                 check_valid_skippable_key();
+        //                 check_valid_skippable_value();
+        //                 break;
+        //         }
+        //     }
+        //     if bitset.full() { return Some(result) } else { return None };
+        //
         // We will need to add all the keys to the data to be able to check if
         // they are part of the tuple and find their index. They will be stored as
         // [number of keys as u32 | key 1 offset as u32 | key 2 offset as u32 | key 1 len as u8 | key 2 len as u8 | ... | key 1 | key 2 | ...]

--- a/clar2wasm/src/deserialize.rs
+++ b/clar2wasm/src/deserialize.rs
@@ -1116,6 +1116,13 @@ impl WasmGenerator {
                         .map(|_| loop_.dangling_instr_seq(None).id())
                         .collect();
 
+                    // `switch_case_blocks` should be at least of length 2 since empty Tuple cannot exist.
+                    if switch_case_blocks.len() < 2 {
+                        return Err(GeneratorError::InternalError(
+                            "Tuple should have a least one field".to_owned(),
+                        ));
+                    }
+
                     // Here is the switch
                     {
                         let mut switch_block = loop_.instr_seq(switch_case_blocks[0]);

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -3417,7 +3417,7 @@
         (i32.const 1) (local.get $output-offset) (i32.sub (local.get $writeptr) (local.get $output-offset))
     )
 
-    (func $compare_clarity_names (param $offset_a i32) (param $len_a i32) (param $offset_b i32) (param $len_b i32) (result i32)
+    (func $compare-clarity-names (param $offset_a i32) (param $len_a i32) (param $offset_b i32) (param $len_b i32) (result i32)
         ;; compare two clarity names and return -1 if a < b, 0 if a == b or 1 if a > b
         (local $min_len i32) (local $a i32) (local $b i32)
 
@@ -3444,7 +3444,7 @@
         )
     )
 
-    (func $stdlib.bsearch_clarity_name (param $offset_list i32) (param $len_list i32) (param $offset_elem i32) (param $len_elem i32) (result i32)
+    (func $stdlib.bsearch-clarity-name (param $offset_list i32) (param $len_list i32) (param $offset_elem i32) (param $len_elem i32) (result i32)
         ;; find the index of a clarity name in a list with this format: [number of elem as u32, offset 1 u32, offset 2 u32,... , len 1 u8, len 2 u8, ..., item 1 [u8...], item 2 [u8...], ...]
         (local $size i32) (local $i i32) (local $j i32) (local $mid i32) (local $cmp i32) (local $offset_len i32)
 
@@ -3456,7 +3456,7 @@
             (local.set $mid (i32.add (local.get $i) (i32.shr_u (local.get $size) (i32.const 1))))
 
             (local.set $cmp
-                (call $compare_clarity_names
+                (call $compare-clarity-names
                     (local.get $offset_elem)
                     (local.get $len_elem)
                     (i32.load (i32.add (local.get $offset_list) (i32.shl (local.get $mid) (i32.const 2))))
@@ -3573,5 +3573,5 @@
     (export "stdlib.convert-scalars-to-utf8" (func $stdlib.convert-scalars-to-utf8))
     (export "stdlib.is-valid-string-ascii" (func $stdlib.is-valid-string-ascii))
     (export "stdlib.utf8-to-string-utf8" (func $stdlib.utf8-to-string-utf8))
-    (export "stdlib.bsearch_clarity_name" (func $stdlib.bsearch_clarity_name))
+    (export "stdlib.bsearch-clarity-name" (func $stdlib.bsearch-clarity-name))
 )

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -3423,7 +3423,7 @@
 
         (local.set $min_len (select (local.get $len_a) (local.get $len_b) (i32.lt_u (local.get $len_a) (local.get $len_b))))
 
-        (loop
+        (loop $loop
             (if
                 (i32.eq
                     (local.tee $a (i32.load8_u (local.get $offset_a)))
@@ -3432,7 +3432,7 @@
                 (then
                     (local.set $offset_a (i32.add (local.get $offset_a) (i32.const 1)))
                     (local.set $offset_b (i32.add (local.get $offset_b) (i32.const 1)))
-                    (br_if 1 (local.tee $min_len (i32.sub (local.get $min_len) (i32.const 1))))
+                    (br_if $loop (local.tee $min_len (i32.sub (local.get $min_len) (i32.const 1))))
                 )
             )
         )

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -3417,6 +3417,33 @@
         (i32.const 1) (local.get $output-offset) (i32.sub (local.get $writeptr) (local.get $output-offset))
     )
 
+    (func $compare_clarity_names (param $offset_a i32) (param $len_a i32) (param $offset_b i32) (param $len_b i32) (result i32)
+        ;; compare two clarity names and return -1 if a < b, 0 if a == b or 1 if a > b
+        (local $min_len i32) (local $a i32) (local $b i32)
+
+        (local.set $min_len (select (local.get $len_a) (local.get $len_b) (i32.lt_u (local.get $len_a) (local.get $len_b))))
+
+        (loop
+            (if
+                (i32.eq
+                    (local.tee $a (i32.load8_u (local.get $offset_a)))
+                    (local.tee $b (i32.load8_u (local.get $offset_b)))
+                )
+                (then
+                    (local.set $offset_a (i32.add (local.get $offset_a) (i32.const 1)))
+                    (local.set $offset_b (i32.add (local.get $offset_b) (i32.const 1)))
+                    (br_if 1 (local.tee $min_len (i32.sub (local.get $min_len) (i32.const 1))))
+                )
+            )
+        )
+
+        (select
+            (select (i32.const -1) (i32.ne (local.get $len_a) (local.get $len_b)) (i32.lt_u (local.get $len_a) (local.get $len_b)))
+            (select (i32.const -1) (i32.ne (local.get $a) (local.get $b)) (i32.lt_u (local.get $a) (local.get $b)))
+            (i32.eq (local.get $a) (local.get $b))
+        )
+    )
+
     ;;
     ;; Export section
 

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -63,6 +63,7 @@ pub struct WasmGenerator {
 pub enum LiteralMemoryEntry {
     Ascii(String),
     Utf8(String),
+    Bytes(Box<[u8]>),
 }
 
 #[derive(Debug)]
@@ -641,6 +642,29 @@ impl WasmGenerator {
         self.literal_memory_end += name.len() as u32;
 
         // Save the offset in the literal memory for this identifier
+        self.literal_memory_offset.insert(entry, offset);
+
+        Ok((offset, len))
+    }
+
+    pub(crate) fn add_bytes_literal(&mut self, bytes: &[u8]) -> Result<(u32, u32), GeneratorError> {
+        let entry = LiteralMemoryEntry::Bytes(bytes.into());
+        if let Some(offset) = self.literal_memory_offset.get(&entry) {
+            return Ok((*offset, bytes.len() as u32));
+        }
+
+        let memory = self.get_memory()?;
+        let offset = self.literal_memory_end;
+        let len = bytes.len() as u32;
+        self.module.data.add(
+            DataKind::Active(ActiveData {
+                memory,
+                location: walrus::ActiveDataLocation::Absolute(offset),
+            }),
+            bytes.to_vec(),
+        );
+        self.literal_memory_end += len;
+
         self.literal_memory_offset.insert(entry, offset);
 
         Ok((offset, len))

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -4201,3 +4201,75 @@ fn utf8_to_string_utf8_invalid() {
         check_invalid_conversion(s.as_bytes(), s.chars().count() as i32 - 1);
     }
 }
+
+#[test]
+fn bsearch_clarity_name() {
+    let (instance, mut store) = load_stdlib().unwrap();
+    let memory = instance
+        .get_memory(&mut store, "memory")
+        .expect("Could not find memory");
+
+    let cmp = instance
+        .get_func(&mut store, "stdlib.bsearch_clarity_name")
+        .unwrap();
+    let mut result = [Val::I32(0)];
+
+    let mut check = |a: &[&str], b: &str| {
+        let mut list = (a.len() as u32).to_le_bytes().to_vec();
+        list.extend(
+            a.iter()
+                .scan(4 + a.len() as u32 * 5, |state, &name| {
+                    let res = state.to_le_bytes();
+                    *state += name.len() as u32;
+                    Some(res)
+                })
+                .flatten(),
+        );
+        list.extend(a.iter().map(|&a| a.len() as u8));
+        list.extend(a.iter().flat_map(|&name| name.as_bytes()));
+
+        memory.write(&mut store, 0, &list).unwrap();
+        memory.write(&mut store, list.len(), b.as_bytes()).unwrap();
+
+        cmp.call(
+            &mut store,
+            &[
+                Val::I32(0),
+                Val::I32(a.len() as i32),
+                Val::I32(list.len() as i32),
+                Val::I32(b.len() as i32),
+            ],
+            &mut result,
+        )
+        .unwrap();
+
+        assert_eq!(
+            result[0].unwrap_i32(),
+            a.binary_search(&b).map(|i| i as i32).unwrap_or(-1)
+        );
+    };
+
+    let list_odd = ["Lorem", "amet", "dolor", "ipsum", "sit"];
+    //check(&list_odd, "sit");
+    for w in list_odd {
+        check(&list_odd, w);
+    }
+    check(&list_odd, "zzzzzzzzzz");
+    check(&list_odd, "AAAAAA");
+    check(&list_odd, "color");
+    check(&list_odd, "concrete");
+    check(&list_odd, "elephant");
+    check(&list_odd, "leopard");
+
+    let list_even = ["Lorem", "amet", "consectetur", "dolor", "ipsum", "sit"];
+    for w in list_even {
+        check(&list_even, w);
+    }
+
+    check(&list_even, "zzzzzzzzzz");
+    check(&list_even, "AAAAAA");
+    check(&list_even, "color");
+    check(&list_even, "concrete");
+    check(&list_even, "elephant");
+    check(&list_even, "leopard");
+}

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -4250,7 +4250,6 @@ fn bsearch_clarity_name() {
     };
 
     let list_odd = ["Lorem", "amet", "dolor", "ipsum", "sit"];
-    //check(&list_odd, "sit");
     for w in list_odd {
         check(&list_odd, w);
     }

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -4210,7 +4210,7 @@ fn bsearch_clarity_name() {
         .expect("Could not find memory");
 
     let cmp = instance
-        .get_func(&mut store, "stdlib.bsearch_clarity_name")
+        .get_func(&mut store, "stdlib.bsearch-clarity-name")
         .unwrap();
     let mut result = [Val::I32(0)];
 


### PR DESCRIPTION
This is the first part of completing #307 .

This PR rewrites completely the tuple deserialization function to allow for the missing functionalities.
For now, the missing functionalities implemented are

- fields can arrive in any order (not just lexicographic order)
- fields cannot be duplicated

To satisfy those conditions, the new algorithm in pseudo-code became
```
let bitset = Bitset::new();
for key in serialized_bytes {
    let n = find_index(key)
    switch n {
        case 1:
            if bitset.contains(key) { return None; }
            handle_parsing_of_value_1;
            bitset.insert(key);
            break;
        case 2:
            if bitset.contains(key) { return None; }
            handle_parsing_of_value_2;
            bitset.insert(key);
            break;
        ...
        default:
            check_valid_skippable_key();
            check_valid_skippable_value();
            break;
    }
}
if bitset.full() { return Some(result) } else { return None };
```

These contains new functionalities that had to be created:

1. The _bitset_ is a list of `i32` locals, the logic to handle it is directly inside the deserialization algo.
2. The *find_index* function is a binary search in a list of string. It is implemented in the standard, with another function to compare clarity names (there are also unit tests for this function).
3. The switch-case construct is a bit awkward in Wat, since it doesn't have _label_s and _goto_s instructions. So it's a succession of labelled blocks, with the inner one being the switch and using a `br_table` instruction to jump **after** the block labelled like the currently parsed field (I suggest compiling a few examples to see what it looks like).
4. The default case where we switch extra fields is a `TODO` for now but is nearly complete already. I decided to cut it from this PR and add it in a future one because it will require quite a lot of code to handle the testing.