### PR TITLE
chore: update stacks-core dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core?branch=feat/clarity-wasm-develop#03314b175558f07dabf385eaf2aff5c15a98a4a5"
+source = "git+https://github.com/stacks-network/stacks-core?branch=feat/clarity-wasm-develop#68f687fa2628a8482f54e432a0edd672a9247306"
 dependencies = [
  "hashbrown 0.14.5",
  "integer-sqrt",
@@ -2660,7 +2660,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core?branch=feat/clarity-wasm-develop#03314b175558f07dabf385eaf2aff5c15a98a4a5"
+source = "git+https://github.com/stacks-network/stacks-core?branch=feat/clarity-wasm-develop#68f687fa2628a8482f54e432a0edd672a9247306"
 dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#6eb4a2377cb8d18275280530abb6044dee9081ee"
+source = "git+https://github.com/stacks-network/stacks-core?branch=feat/clarity-wasm-develop#03314b175558f07dabf385eaf2aff5c15a98a4a5"
 dependencies = [
  "hashbrown 0.14.5",
  "integer-sqrt",
@@ -2660,7 +2660,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#6eb4a2377cb8d18275280530abb6044dee9081ee"
+source = "git+https://github.com/stacks-network/stacks-core?branch=feat/clarity-wasm-develop#03314b175558f07dabf385eaf2aff5c15a98a4a5"
 dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",

--- a/clar2wasm/Cargo.toml
+++ b/clar2wasm/Cargo.toml
@@ -5,19 +5,17 @@ edition = "2021"
 build = "build.rs"
 
 [dependencies]
-clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop", features = [
-  "testing",
-] }
 clap = { version = "4.3.17", features = ["derive"] }
 regex = "1.9.1"
 walrus = "0.20.1"
 lazy_static = "1.4.0"
 wasmtime = "15.0.0"
-stacks-common = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
-
 sha2 = { version = "0.10.7" }
 chrono = { version = "0.4.20" }
 rusqlite = { version = "0.31.0" }
+
+clarity = { git="https://github.com/stacks-network/stacks-core", branch="feat/clarity-wasm-develop", features = ["testing"] }
+stacks-common = { git="https://github.com/stacks-network/stacks-core", branch="feat/clarity-wasm-develop" }
 
 [build-dependencies]
 wat = "1.0.74"


### PR DESCRIPTION
Update clarity and stacks-common following this PR https://github.com/stacks-network/stacks-core/pull/5010 (to be merged first)

WIP

- temporarily targeting `refactor/use-relative-path-for-workspace-dependencies` until it's merged