### PR TITLE
Chore: fix clippy after 1.80 update

### DIFF
--- a/clar2wasm/benches/benchmark.rs
+++ b/clar2wasm/benches/benchmark.rs
@@ -33,7 +33,7 @@ fn add(c: &mut Criterion) {
         b.iter(|| {
             let mut results = [Val::I64(0), Val::I64(0)];
             add.call(
-                &mut store.borrow_mut(),
+                store.as_context_mut(),
                 &[Val::I64(0), Val::I64(42), Val::I64(0), Val::I64(12345)],
                 &mut results,
             )
@@ -179,7 +179,7 @@ fn sha512(c: &mut Criterion) {
             let mut results = [Val::I64(0), Val::I64(0)];
             sha512
                 .call(
-                    &mut store.borrow_mut(),
+                    store.as_context_mut(),
                     &[
                         Val::I32(END_OF_STANDARD_DATA as i32),
                         Val::I32(text.len() as i32),
@@ -332,7 +332,7 @@ fn sha256(c: &mut Criterion) {
             let mut results = [Val::I32(0), Val::I32(0)];
             sha512
                 .call(
-                    &mut store.borrow_mut(),
+                    store.as_context_mut(),
                     &[
                         Val::I32(END_OF_STANDARD_DATA as i32),
                         Val::I32(text.len() as i32),

--- a/clar2wasm/src/datastore.rs
+++ b/clar2wasm/src/datastore.rs
@@ -309,7 +309,6 @@ impl ClarityBackingStore for Datastore {
         panic!("Datastore cannot get_metadata_manual")
     }
 
-    #[cfg(not(feature = "wasm"))]
     fn get_side_store(&mut self) -> &Connection {
         panic!("Datastore cannot get_side_store")
     }

--- a/clar2wasm/tests/lib_tests.rs
+++ b/clar2wasm/tests/lib_tests.rs
@@ -28,7 +28,7 @@ use hex::FromHex;
 /// - the names of the contracts to initialize (optionally including a
 ///   subdirectory, e.g. `multi-contract/contract-caller`),
 /// - a closure with type
-///  `|global_context: &mut GlobalContext, contract_context: &HashMap<&str, ContractContext>, return_val: Option<Value>|`
+///   `|global_context: &mut GlobalContext, contract_context: &HashMap<&str, ContractContext>, return_val: Option<Value>|`
 ///   and that contains all the assertions we want to test.
 macro_rules! test_multi_contract_init {
     ($func: ident, $contract_names: expr, $context_test: expr) => {
@@ -166,7 +166,7 @@ macro_rules! test_multi_contract_init {
 /// - the name of the test to create,
 /// - the name of the contracts to initialize,
 /// - a closure with type
-///  `|global_context: &mut GlobalContext, contract_context: &ContractContext, return_val: Option<Value>|`
+///   `|global_context: &mut GlobalContext, contract_context: &ContractContext, return_val: Option<Value>|`
 ///   and that contains all the assertions we want to test.
 macro_rules! test_contract_init {
     ($func: ident, $contract_name: literal, $context_test: expr) => {


### PR DESCRIPTION
Title says everything.

Two annoying fixes to add:
- docstrings need better indentation
- a new lint that seems to creates false positive: https://rust-lang.github.io/rust-clippy/master/index.html#/needless_borrows_for_generic_args