### PR TITLE
Property tests for `contract-call?`

### DIFF
--- a/clar2wasm/src/linker.rs
+++ b/clar2wasm/src/linker.rs
@@ -3451,7 +3451,7 @@ fn link_contract_call_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), 
                     return_offset,
                     return_offset + get_type_size(return_ty),
                     &result,
-                    true,
+                    false,
                 )?;
 
                 Ok(())

--- a/clar2wasm/src/wasm_utils.rs
+++ b/clar2wasm/src/wasm_utils.rs
@@ -826,9 +826,8 @@ pub fn write_to_wasm(
             // written to the memory at `offset`. The `in_mem_offset` for the
             // list elements should be after their representations.
             let val_offset = in_mem_offset;
-            let val_in_mem_offset = in_mem_offset
-                + list_data.data.len() as i32
-                    * get_type_size(list_data.type_signature.get_list_item_type());
+            let val_in_mem_offset =
+                in_mem_offset + list_data.data.len() as i32 * get_type_size(elem_ty);
             let mut val_written = 0;
             let mut val_in_mem_written = 0;
             for elem in &list_data.data {
@@ -872,6 +871,7 @@ pub fn write_to_wasm(
                 .write(&mut store, (offset) as usize, &indicator_bytes)
                 .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
             written += 4;
+
             if res.committed {
                 let (new_written, new_in_mem_written) = write_to_wasm(
                     store,

--- a/clar2wasm/src/wasm_utils.rs
+++ b/clar2wasm/src/wasm_utils.rs
@@ -6,9 +6,10 @@ use clarity::vm::analysis::CheckErrors;
 use clarity::vm::contexts::GlobalContext;
 use clarity::vm::errors::{Error, WasmError};
 use clarity::vm::types::{
-    ASCIIData, BuffData, BufferLength, CharType, ListData, OptionalData, PrincipalData,
-    QualifiedContractIdentifier, ResponseData, SequenceData, SequenceSubtype, SequencedValue,
-    StandardPrincipalData, StringSubtype, TupleData, TupleTypeSignature, TypeSignature,
+    ASCIIData, BuffData, BufferLength, CallableData, CharType, ListData, OptionalData,
+    PrincipalData, QualifiedContractIdentifier, ResponseData, SequenceData, SequenceSubtype,
+    SequencedValue, StandardPrincipalData, StringSubtype, TupleData, TupleTypeSignature,
+    TypeSignature,
 };
 use clarity::vm::{CallStack, ClarityName, ContractContext, ContractName, Value};
 use stacks_common::types::StacksEpochId;
@@ -1271,27 +1272,22 @@ pub fn call_function<'a>(
     // Determine how much space is needed for arguments
     let mut arg_size = 0;
     for arg in func_types.get_arg_types() {
-        arg_size += get_type_size(arg);
+        arg_size += get_type_in_memory_size(arg, false);
     }
     let mut in_mem_offset = offset + arg_size;
 
     // Convert the args into wasmtime values
     let mut wasm_args = vec![];
-    for arg in args {
+    for (arg, ty) in args.iter().zip(func_types.get_arg_types()) {
         let (arg_vec, new_offset, new_in_mem_offset) =
-            pass_argument_to_wasm(memory, &mut store, arg, offset, in_mem_offset)?;
+            pass_argument_to_wasm(memory, &mut store, ty, arg, offset, in_mem_offset)?;
         wasm_args.extend(arg_vec);
         offset = new_offset;
         in_mem_offset = new_in_mem_offset;
     }
 
     // Reserve stack space for the return value, if necessary.
-    let return_type = store
-        .data()
-        .contract_context()
-        .functions
-        .get(function_name)
-        .ok_or(CheckErrors::UndefinedFunction(function_name.to_string()))?
+    let return_type = func_types
         .get_return_type()
         .as_ref()
         .ok_or(Error::Wasm(WasmError::ExpectedReturnValue))?
@@ -1323,6 +1319,7 @@ pub fn call_function<'a>(
 fn pass_argument_to_wasm(
     memory: Memory,
     mut store: impl AsContextMut,
+    ty: &TypeSignature,
     value: &Value,
     offset: i32,
     in_mem_offset: i32,
@@ -1346,24 +1343,71 @@ fn pass_argument_to_wasm(
             in_mem_offset,
         )),
         Value::Optional(o) => {
-            let mut buffer = vec![Val::I32(if o.data.is_some() { 1 } else { 0 })];
-            let (inner, new_offset, new_in_mem_offset) = pass_argument_to_wasm(
+            let TypeSignature::OptionalType(inner_ty) = ty else {
+                return Err(Error::Wasm(WasmError::ValueTypeMismatch));
+            };
+
+            if let Some(inner_value) = o.data.as_ref() {
+                let mut buffer = vec![Val::I32(1)];
+                let (inner_buffer, new_offset, new_in_mem_offset) = pass_argument_to_wasm(
+                    memory,
+                    store,
+                    inner_ty,
+                    inner_value,
+                    offset,
+                    in_mem_offset,
+                )?;
+                buffer.extend(inner_buffer);
+                Ok((buffer, new_offset, new_in_mem_offset))
+            } else {
+                let buffer = clar2wasm_ty(ty)
+                    .into_iter()
+                    .map(|vt| match vt {
+                        ValType::I32 => Val::I32(0),
+                        ValType::I64 => Val::I64(0),
+                        _ => unreachable!("No other types used in Clarity-Wasm"),
+                    })
+                    .collect();
+                Ok((buffer, offset, in_mem_offset))
+            }
+        }
+        Value::Response(r) => {
+            let TypeSignature::ResponseType(inner_tys) = ty else {
+                return Err(Error::Wasm(WasmError::ValueTypeMismatch));
+            };
+            let mut buffer = vec![Val::I32(r.committed as i32)];
+            let (value_buffer, new_offset, new_in_mem_offset) = pass_argument_to_wasm(
                 memory,
                 store,
-                o.data
-                    .as_ref()
-                    .map_or(&Value::none(), |boxed_value| boxed_value),
+                if r.committed {
+                    &inner_tys.0
+                } else {
+                    &inner_tys.1
+                },
+                &r.data,
                 offset,
                 in_mem_offset,
             )?;
-            buffer.extend(inner);
-            Ok((buffer, new_offset, new_in_mem_offset))
-        }
-        Value::Response(r) => {
-            let mut buffer = vec![Val::I32(if r.committed { 1 } else { 0 })];
-            let (inner, new_offset, new_in_mem_offset) =
-                pass_argument_to_wasm(memory, store, &r.data, offset, in_mem_offset)?;
-            buffer.extend(inner);
+            let empty_buffer = clar2wasm_ty(if r.committed {
+                &inner_tys.1
+            } else {
+                &inner_tys.0
+            })
+            .into_iter()
+            .map(|vt| match vt {
+                ValType::I32 => Val::I32(0),
+                ValType::I64 => Val::I64(0),
+                _ => unreachable!("No other types used in Clarity-Wasm"),
+            });
+
+            if r.committed {
+                buffer.extend(value_buffer);
+                buffer.extend(empty_buffer);
+            } else {
+                buffer.extend(empty_buffer);
+                buffer.extend(value_buffer);
+            }
+
             Ok((buffer, new_offset, new_in_mem_offset))
         }
         Value::Sequence(SequenceData::String(CharType::ASCII(s))) => {
@@ -1371,25 +1415,49 @@ fn pass_argument_to_wasm(
             // offset and length to the Wasm function.
             let buffer = vec![Val::I32(in_mem_offset), Val::I32(s.data.len() as i32)];
             memory
-                .write(&mut store, in_mem_offset as usize, s.data.as_slice())
+                .write(
+                    store.as_context_mut(),
+                    in_mem_offset as usize,
+                    s.data.as_slice(),
+                )
                 .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
             let adjusted_in_mem_offset = in_mem_offset + s.data.len() as i32;
             Ok((buffer, offset, adjusted_in_mem_offset))
         }
-        Value::Sequence(SequenceData::String(CharType::UTF8(_s))) => {
-            todo!("Value type not yet implemented: {:?}", value)
+        Value::Sequence(SequenceData::String(CharType::UTF8(s))) => {
+            // For a utf8 string, convert the chars to big-endian i32, convert this into a list of
+            // bytes, then pass the offset and length to the wasm function
+            let bytes: Vec<u8> = String::from_utf8(s.items().iter().flatten().copied().collect())
+                .map_err(|e| Error::Wasm(WasmError::WasmGeneratorError(e.to_string())))?
+                .chars()
+                .flat_map(|c| (c as u32).to_be_bytes())
+                .collect();
+            let buffer = vec![Val::I32(in_mem_offset), Val::I32(bytes.len() as i32)];
+            memory
+                .write(&mut store, in_mem_offset as usize, &bytes)
+                .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
+            let adjusted_in_mem_offset = in_mem_offset + bytes.len() as i32;
+            Ok((buffer, offset, adjusted_in_mem_offset))
         }
         Value::Sequence(SequenceData::Buffer(b)) => {
             // For a buffer, write the bytes into the memory, then pass the
             // offset and length to the Wasm function.
             let buffer = vec![Val::I32(in_mem_offset), Val::I32(b.data.len() as i32)];
             memory
-                .write(&mut store, in_mem_offset as usize, b.data.as_slice())
+                .write(
+                    store.as_context_mut(),
+                    in_mem_offset as usize,
+                    b.data.as_slice(),
+                )
                 .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
             let adjusted_in_mem_offset = in_mem_offset + b.data.len() as i32;
             Ok((buffer, offset, adjusted_in_mem_offset))
         }
         Value::Sequence(SequenceData::List(l)) => {
+            let TypeSignature::SequenceType(SequenceSubtype::ListType(ltd)) = ty else {
+                return Err(Error::Wasm(WasmError::ValueTypeMismatch));
+            };
+
             let mut buffer = vec![Val::I32(offset)];
             let mut written = 0;
             let mut in_mem_written = 0;
@@ -1397,7 +1465,7 @@ fn pass_argument_to_wasm(
                 let (len, in_mem_len) = write_to_wasm(
                     &mut store,
                     memory,
-                    l.type_signature.get_list_item_type(),
+                    ltd.get_list_item_type(),
                     offset + written,
                     in_mem_offset + in_mem_written,
                     item,
@@ -1409,9 +1477,64 @@ fn pass_argument_to_wasm(
             buffer.push(Val::I32(written));
             Ok((buffer, offset + written, in_mem_offset + in_mem_written))
         }
-        Value::Principal(_p) => todo!("Value type not yet implemented: {:?}", value),
-        Value::CallableContract(_c) => todo!("Value type not yet implemented: {:?}", value),
-        Value::Tuple(_t) => todo!("Value type not yet implemented: {:?}", value),
+        Value::Principal(PrincipalData::Standard(StandardPrincipalData(v, h))) => {
+            let mut bytes: Vec<u8> = Vec::with_capacity(22);
+            bytes.push(*v);
+            bytes.extend(h);
+            bytes.push(0);
+            let buffer = vec![Val::I32(in_mem_offset), Val::I32(bytes.len() as i32)];
+            memory
+                .write(&mut store, in_mem_offset as usize, &bytes)
+                .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
+            let adjusted_in_mem_offset = in_mem_offset + bytes.len() as i32;
+            Ok((buffer, offset, adjusted_in_mem_offset))
+        }
+        Value::Principal(PrincipalData::Contract(p))
+        | Value::CallableContract(CallableData {
+            contract_identifier: p,
+            ..
+        }) => {
+            // Callable types can just ignore the optional trait identifier, and
+            // is handled like a qualified contract
+            let QualifiedContractIdentifier {
+                issuer: StandardPrincipalData(v, h),
+                name,
+            } = p;
+            let bytes: Vec<u8> = std::iter::once(v)
+                .chain(h.iter())
+                .chain(std::iter::once(&name.len()))
+                .chain(name.as_bytes())
+                .copied()
+                .collect();
+            let buffer = vec![Val::I32(in_mem_offset), Val::I32(bytes.len() as i32)];
+            memory
+                .write(&mut store, in_mem_offset as usize, &bytes)
+                .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
+            let adjusted_in_mem_offset = in_mem_offset + bytes.len() as i32;
+            Ok((buffer, offset, adjusted_in_mem_offset))
+        }
+        Value::Tuple(TupleData { data_map, .. }) => {
+            let TypeSignature::TupleType(tuple_ty) = ty else {
+                return Err(Error::Wasm(WasmError::ValueTypeMismatch));
+            };
+
+            let mut buffer = vec![];
+            let mut offset = offset;
+            let mut in_mem_offset = in_mem_offset;
+            for (name, ty) in tuple_ty.get_type_map() {
+                let b;
+                (b, offset, in_mem_offset) = pass_argument_to_wasm(
+                    memory,
+                    store.as_context_mut(),
+                    ty,
+                    &data_map[name],
+                    offset,
+                    in_mem_offset,
+                )?;
+                buffer.extend(b);
+            }
+            Ok((buffer, offset, in_mem_offset))
+        }
     }
 }
 

--- a/clar2wasm/tests/wasm-generation/contracts.rs
+++ b/clar2wasm/tests/wasm-generation/contracts.rs
@@ -1,0 +1,58 @@
+use clar2wasm::tools::crosscheck_multi_contract;
+use clarity::vm::{types::ResponseData, Value};
+use proptest::prelude::*;
+
+use crate::{prop_signature, type_string, PropValue};
+
+use std::fmt::Write;
+
+proptest! {
+    #![proptest_config(super::runtime_config())]
+
+    #[test]
+    fn contract_call_accepts_any_args(
+        (tys, values)
+            in prop::collection::vec(
+                prop_signature().prop_ind_flat_map2(|ty| PropValue::from_type(ty.clone())),
+                1..=20
+            )
+            .prop_map(|arg_ty| arg_ty.into_iter().unzip::<_, _, Vec<_>, Vec<_>>())
+            .no_shrink(),
+        result in PropValue::any().no_shrink()
+    ) {
+        // first contract
+        let first_contract_name = "foo".into();
+        let mut function_arguments = String::new();
+        for (name, ty) in ('a'..).zip(tys.iter()) {
+            write!(function_arguments, "({name} {}) ", type_string(ty)).unwrap();
+        }
+        let first_snippet = format!(
+            r#"
+                (define-public (foofun {function_arguments})
+                    (ok {result})
+                )
+            "#
+        );
+
+        // second contract
+        let second_contract_name = "bar".into();
+        let mut call_arguments = String::new();
+        for value in values {
+            write!(call_arguments, "{value} ").unwrap();
+        }
+        let second_snippet =
+            format!(r#"(contract-call? .{first_contract_name} foofun {call_arguments})"#);
+
+
+        crosscheck_multi_contract(
+            &[
+                (first_contract_name, &first_snippet),
+                (second_contract_name, &second_snippet),
+            ],
+            Ok(Some(Value::Response(ResponseData {
+                committed: true,
+                data: Box::new(result.into()),
+            }))),
+        );
+    }
+}

--- a/clar2wasm/tests/wasm-generation/contracts.rs
+++ b/clar2wasm/tests/wasm-generation/contracts.rs
@@ -1,13 +1,11 @@
+use std::fmt::Write;
+
 use clar2wasm::tools::crosscheck_multi_contract;
-use clarity::vm::{
-    types::{ResponseData, TupleData},
-    ClarityName, Value,
-};
+use clarity::vm::types::{ResponseData, TupleData};
+use clarity::vm::{ClarityName, Value};
 use proptest::prelude::*;
 
 use crate::{prop_signature, type_string, PropValue};
-
-use std::fmt::Write;
 
 proptest! {
     #![proptest_config(super::runtime_config())]

--- a/clar2wasm/tests/wasm-generation/contracts.rs
+++ b/clar2wasm/tests/wasm-generation/contracts.rs
@@ -1,5 +1,8 @@
 use clar2wasm::tools::crosscheck_multi_contract;
-use clarity::vm::{types::ResponseData, Value};
+use clarity::vm::{
+    types::{ResponseData, TupleData},
+    ClarityName, Value,
+};
 use proptest::prelude::*;
 
 use crate::{prop_signature, type_string, PropValue};
@@ -83,6 +86,66 @@ proptest! {
             Ok(Some(Value::Response(ResponseData {
                 committed: true,
                 data: Box::new(value.into()),
+            }))),
+        );
+    }
+
+    #[test]
+    fn contract_call_can_use_all_arguments(
+        (tys, values)
+            in prop::collection::vec(
+                prop_signature()
+                    .prop_ind_flat_map2(|ty| PropValue::from_type(ty.clone())),
+                1..=20
+            )
+            .prop_map(|arg_ty| arg_ty.into_iter().unzip::<_, _, Vec<_>, Vec<_>>())
+            .no_shrink(),
+    ) {
+        let first_contract_name = "foo".into();
+        let mut function_arguments = String::new();
+        for (name, ty) in ('a'..).zip(tys.iter()) {
+            write!(function_arguments, "({name} {}) ", type_string(ty)).unwrap();
+        }
+        let expected_res = ('a'..)
+            .take(tys.len())
+            .fold(String::new(), |mut output, arg| {
+                write!(output, "{arg}: {arg}, ").unwrap();
+                output
+            });
+        let first_snippet = format!(
+            r#"
+                (define-public (foofun {function_arguments})
+                    (ok {{ {expected_res} }})
+                )
+            "#
+        );
+
+        // second contract
+        let second_contract_name = "bar".into();
+        let mut call_arguments = String::new();
+        for value in values.iter() {
+            write!(call_arguments, "{value} ").unwrap();
+        }
+        let second_snippet =
+            format!(r#"(contract-call? .{first_contract_name} foofun {call_arguments})"#);
+
+        let expected = TupleData::from_data(
+            ('a'..)
+                .map(|c| ClarityName::try_from(c.to_string()).unwrap())
+                .zip(values.into_iter().map(Value::from))
+                .collect(),
+        )
+        .unwrap()
+        .into();
+
+        crosscheck_multi_contract(
+            &[
+                (first_contract_name, &first_snippet),
+                (second_contract_name, &second_snippet),
+            ],
+            Ok(Some(Value::Response(ResponseData {
+                committed: true,
+                data: Box::new(expected),
             }))),
         );
     }

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -6,6 +6,7 @@ pub mod blockinfo;
 pub mod comparison;
 pub mod conditionals;
 pub mod constants;
+pub mod contracts;
 pub mod control_flow;
 pub mod default_to;
 pub mod equal;

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -502,7 +502,7 @@ pub fn type_string(ty: &TypeSignature) -> String {
             s.push('{');
             for (key, value) in tuple_ty {
                 s.push_str(key);
-                s.push(':');
+                s.push_str(": ");
                 s.push_str(&type_string(value));
                 s.push(',');
             }
@@ -620,7 +620,7 @@ mod tests {
                 .unwrap()
             )
             .type_string(),
-            "{a:int,b:uint,c:bool,}"
+            "{a: int,b: uint,c: bool,}"
         );
         assert_eq!(
             Value::from(


### PR DESCRIPTION
This PR adds three property tests for the `contract-call?` function:

1. the first one checks that it can take as many random arguments as it wants and returns a random value
2. the second one checks that it can take a random argument and return it
3. the third one checks that it can take as many random arguments as it wants and use them all

I needed to create a new type of "crosscheck" for those tests. We now have a `crosscheck-multi-contract`, which takes multiple `(contract_name, snippet)` as arguments and executes them in order.
For now, the comparison with the interpreter is disabled because the function that executes it doesn't save interpreted contracts.

There are a few fixes for the issues that the new proptests found.