### PR TITLE
CI Notify on failure

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -22,14 +22,47 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Run
-        run: cargo test --test wasm-generation --test standard
+        run: |
+          set +e
+          cargo test --test wasm-generation --test standard | tee output.log
+          test_exit=${PIPESTATUS[0]}
+          grep -A 50 'Test failed: assertion' output.log >> failure_section.log
+          echo "failure_section<<EOF" >> $GITHUB_ENV
+          cat failure_section.log >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+          if [ $test_exit -ne 0 ]; then
+            exit 101
+          fi
 
-      - name: Add link to the failure issue
+      - name: Create GitHub Issue on Failure
         uses: jayqi/failed-build-issue-action@v1
         if: ${{ failure() }}
         with:
           github-token: ${{ secrets.GH_TOKEN }}
           label-name: "property-testing-failure"
-          title-template: "Property testing coverage has failed"
+          title-template: "Property testing failure"
           body-template: |
             GitHub Actions workflow [{{workflow}} #{{runNumber}}](https://github.com/{{repo.owner}}/{{repo.repo}}/actions/runs/{{runId}}) failed.
+            ```log
+            ${{ env.failure_section }}
+            ```
+
+      - name: Send message to Slack
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        if: ${{ failure() }}
+        with:
+          channel-id: ${{ secrets.CHANNEL_ID }}
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "GitHub Actions workflow <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Property Testing #${{ github.run_number }}> failed."
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -1,8 +1,9 @@
 name: Property Testings
 
 on:
+  schedule:
+    - cron: '0 */4 * * *'
   workflow_dispatch:
-  pull_request:
 
 env:
   CARGO_TERM_COLOR: always
@@ -33,4 +34,5 @@ jobs:
       uses: maxkomarychev/oction-create-issue@v0.7.1
       with:
         token: ${{ secrets.GH_TOKEN }}
-        title: "[Test] Property testing coverage has failed"
+        title: "Property testing coverage has failed"
+        body: "FYI & A: @stacks-network/clarity-wasm"

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -22,3 +22,15 @@ jobs:
 
       - name: Run
         run: cargo test --test wasm-generation --test standard
+
+  notification:
+    name: Notification
+    runs-on: ubuntu-latest
+    needs: property-testing
+    if: ${{ failure() }}
+    steps:
+    - name: Notify on Failure
+      uses: maxkomarychev/oction-create-issue@v0.7.1
+      with:
+        token: ${{ secrets.GH_TOKEN }}
+        title: "[Test] Property testing coverage has failed"

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -1,9 +1,8 @@
 name: Property Testings
 
 on:
-  schedule:
-    - cron: '0 */4 * * *'
   workflow_dispatch:
+  pull_request:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -32,5 +32,4 @@ jobs:
           label-name: "property-testing-failure"
           title-template: "Property testing coverage has failed"
           body-template: |
-            FYI & A: @stacks-network/clarity-wasm
             GitHub Actions workflow [{{workflow}} #{{runNumber}}](https://github.com/{{repo.owner}}/{{repo.repo}}/actions/runs/{{runId}}) failed.

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -24,18 +24,13 @@ jobs:
       - name: Run
         run: cargo test --test wasm-generation --test standard
 
-  notification:
-    name: Notification
-    runs-on: ubuntu-latest
-    needs: property-testing
-    if: ${{ failure() }}
-    steps:
-    - name: Notify on Failure
-      uses: maxkomarychev/oction-create-issue@v0.7.1
-      with:
-        token: ${{ secrets.GH_TOKEN }}
-        title: "Property testing coverage has failed"
-        body: "FYI & A: @stacks-network/clarity-wasm"
-        labels:
-          - testing
-          - property-testing
+      - name: Add link to the failure issue
+        uses: jayqi/failed-build-issue-action@v1
+        if: ${{ failure() }}
+        with:
+          github-token: ${{ secrets.GH_TOKEN }}
+          label-name: "property-testing-failure"
+          title-template: "Property testing coverage has failed"
+          body-template: |
+            FYI & A: @stacks-network/clarity-wasm
+            GitHub Actions workflow [{{workflow}} #{{runNumber}}](https://github.com/{{repo.owner}}/{{repo.repo}}/actions/runs/{{runId}}) failed.

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -3,6 +3,7 @@ name: Property Testings
 on:
   schedule:
     - cron: '0 */4 * * *'
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -36,3 +36,6 @@ jobs:
         token: ${{ secrets.GH_TOKEN }}
         title: "Property testing coverage has failed"
         body: "FYI & A: @stacks-network/clarity-wasm"
+        labels:
+          - testing
+          - property-testing

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -10,8 +10,12 @@ env:
 
 jobs:
   property-testing:
-    name: Property Testing
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        clarity_version: [1, 2, 3]
+    name: Clarity::V${{ matrix.clarity_version }} Property Tests
     env:
       PROPTEST_CASES: 100
     steps:
@@ -21,12 +25,19 @@ jobs:
       - name: Use Rust stable
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Run
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Run Tests
         run: |
           set +e
-          cargo test --test wasm-generation --test standard | tee output.log
+          cargo nextest run \
+          --features test-clarity-v${{ matrix.clarity_version }} \
+          --test wasm-generation \
+          --test standard 2>&1| tee output.log
           test_exit=${PIPESTATUS[0]}
-          grep -A 50 'Test failed: assertion' output.log >> failure_section.log
+          cat output.log | sed 's/\x1b\[[0-9;]*[a-zA-Z]//g' | sed 's/\x0//g' > cleaned_output.log
+          sed -n '/Test failed: assertion/,/FAIL/p' cleaned_output.log >> failure_section.log
           echo "failure_section<<EOF" >> $GITHUB_ENV
           cat failure_section.log >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
@@ -42,7 +53,7 @@ jobs:
           label-name: "property-testing-failure"
           title-template: "Property testing failure"
           body-template: |
-            GitHub Actions workflow [{{workflow}} #{{runNumber}}](https://github.com/{{repo.owner}}/{{repo.repo}}/actions/runs/{{runId}}) failed.
+            GitHub Actions workflow [{{workflow}} #{{runNumber}}](https://github.com/{{repo.owner}}/{{repo.repo}}/actions/runs/{{runId}}) Clarity::V${{ matrix.clarity_version }} failed.
             ```log
             ${{ env.failure_section }}
             ```
@@ -59,7 +70,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "GitHub Actions workflow <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Property Testing #${{ github.run_number }}> failed."
+                    "text": "GitHub Actions workflow <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Property Testing #${{ github.run_number }}> Clarity::V${{ matrix.clarity_version }} failed."
                   }
                 }
               ]

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -46,17 +46,17 @@ jobs:
           fi
 
       - name: Create GitHub Issue on Failure
-        uses: jayqi/failed-build-issue-action@v1
         if: ${{ failure() }}
-        with:
-          github-token: ${{ secrets.GH_TOKEN }}
-          label-name: "property-testing-failure"
-          title-template: "Property testing failure"
-          body-template: |
-            GitHub Actions workflow [{{workflow}} #{{runNumber}}](https://github.com/{{repo.owner}}/{{repo.repo}}/actions/runs/{{runId}}) Clarity::V${{ matrix.clarity_version }} failed.
-            ```log
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue create \
+            --title "Failure [${GITHUB_WORKFLOW} #${GITHUB_RUN_NUMBER}] Clarity::V${{ matrix.clarity_version }}" \
+            --label "property-testing-failure" \
+            --body "GitHub Actions workflow [${GITHUB_WORKFLOW} #${GITHUB_RUN_NUMBER}](https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}) Clarity::V${{ matrix.clarity_version }} failed.
+            \`\`\`log
             ${{ env.failure_section }}
-            ```
+            \`\`\`"
 
       - name: Send message to Slack
         uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -3,7 +3,6 @@ name: Property Testings
 on:
   schedule:
     - cron: '0 */4 * * *'
-  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -30,33 +29,10 @@ jobs:
 
       - name: Run Tests
         run: |
-          set +e
           cargo nextest run \
           --features test-clarity-v${{ matrix.clarity_version }} \
           --test wasm-generation \
-          --test standard 2>&1| tee output.log
-          test_exit=${PIPESTATUS[0]}
-          cat output.log | sed 's/\x1b\[[0-9;]*[a-zA-Z]//g' | sed 's/\x0//g' > cleaned_output.log
-          sed -n '/Test failed: assertion/,/FAIL/p' cleaned_output.log >> failure_section.log
-          echo "failure_section<<EOF" >> $GITHUB_ENV
-          cat failure_section.log >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-          if [ $test_exit -ne 0 ]; then
-            exit 101
-          fi
-
-      - name: Create GitHub Issue on Failure
-        if: ${{ failure() }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh issue create \
-            --title "Failure [${GITHUB_WORKFLOW} #${GITHUB_RUN_NUMBER}] Clarity::V${{ matrix.clarity_version }}" \
-            --label "property-testing-failure" \
-            --body "GitHub Actions workflow [${GITHUB_WORKFLOW} #${GITHUB_RUN_NUMBER}](https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}) Clarity::V${{ matrix.clarity_version }} failed.
-            \`\`\`log
-            ${{ env.failure_section }}
-            \`\`\`"
+          --test standard
 
       - name: Send message to Slack
         uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -23,7 +23,7 @@ fn prop_add_uint() {
 #[test]
 fn prop_add_int() {
     utils::test_export_two_signed_args_checked("stdlib.add-int", |a: i128, b: i128| {
-        a.checked_add(a)
+        a.checked_add(b)
     })
 }
 

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -23,7 +23,7 @@ fn prop_add_uint() {
 #[test]
 fn prop_add_int() {
     utils::test_export_two_signed_args_checked("stdlib.add-int", |a: i128, b: i128| {
-        a.checked_add(b)
+        a.checked_add(a)
     })
 }
 


### PR DESCRIPTION
Add a job to notify @stacks-network/clarity-wasm team when property testing has failed.

We can also have a Slack integration as a compliment to the automated issue. To be handled in other PR, if the case.

Issue generated as a test: https://github.com/stacks-network/clarity-wasm/issues/455