### PR TITLE
Proptest for `as-contract`

### DIFF
--- a/clar2wasm/tests/contracts/as-contract.clar
+++ b/clar2wasm/tests/contracts/as-contract.clar
@@ -6,7 +6,7 @@
   (ok (as-contract contract-caller))
 )
 
-;; Make sure that `as-contract` doesn't leak outside of it's scope
+;; Make sure that `as-contract` doesn't leak outside of its scope
 (define-public (check-sender-after-as-contract)
   (begin
     (as-contract 42)
@@ -14,7 +14,7 @@
   )
 )
 
-;; Make sure that `as-contract` doesn't leak outside of it's scope
+;; Make sure that `as-contract` doesn't leak outside of its scope
 (define-public (check-caller-after-as-contract)
   (begin
     (as-contract 42)

--- a/clar2wasm/tests/contracts/as-contract.clar
+++ b/clar2wasm/tests/contracts/as-contract.clar
@@ -5,3 +5,19 @@
 (define-public (check-caller)
   (ok (as-contract contract-caller))
 )
+
+;; Make sure that `as-contract` doesn't leak outside of it's scope
+(define-public (check-sender-after-as-contract)
+  (begin
+    (as-contract 42)
+    (ok tx-sender)
+  )
+)
+
+;; Make sure that `as-contract` doesn't leak outside of it's scope
+(define-public (check-caller-after-as-contract)
+  (begin
+    (as-contract 42)
+    (ok contract-caller)
+  )
+)

--- a/clar2wasm/tests/lib_tests.rs
+++ b/clar2wasm/tests/lib_tests.rs
@@ -591,6 +591,32 @@ test_contract_call_response!(
     }
 );
 
+test_contract_call_response!(
+    test_as_contract_sender_no_leak,
+    "as-contract",
+    "check-sender-after-as-contract",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(
+            *response.data,
+            Value::Principal(PrincipalData::Standard(StandardPrincipalData::transient()))
+        );
+    }
+);
+
+test_contract_call_response!(
+    test_as_contract_caller_no_leak,
+    "as-contract",
+    "check-caller-after-as-contract",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(
+            *response.data,
+            Value::Principal(PrincipalData::Standard(StandardPrincipalData::transient()))
+        );
+    }
+);
+
 test_contract_init!(
     test_define_ft,
     "define-tokens",

--- a/clar2wasm/tests/wasm-generation/contracts.rs
+++ b/clar2wasm/tests/wasm-generation/contracts.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write;
 
-use clar2wasm::tools::crosscheck_multi_contract;
+use clar2wasm::tools::{crosscheck, crosscheck_multi_contract};
 use clarity::vm::types::{ResponseData, TupleData};
 use clarity::vm::{ClarityName, Value};
 use proptest::prelude::*;
@@ -146,5 +146,16 @@ proptest! {
                 data: Box::new(expected),
             }))),
         );
+    }
+}
+
+proptest! {
+    #![proptest_config(super::runtime_config())]
+
+    #[test]
+    fn as_contract_can_return_any_value(
+        value in PropValue::any()
+    ) {
+        crosscheck(&format!("(as-contract {value})"), Ok(Some(value.into())));
     }
 }


### PR DESCRIPTION
Closes #287 

Not a lot of testing needed for `as-contract`:

- one to make sure that its scope doesn't leak
- a proptest to make sure it can return any value.