### PR TITLE
Fix secp256k1-recover error condition

### DIFF
--- a/clar2wasm/src/linker.rs
+++ b/clar2wasm/src/linker.rs
@@ -3842,7 +3842,7 @@ fn link_secp256k1_recover_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<
                 let sig_bytes = read_bytes_from_wasm(memory, &mut caller, sig_offset, sig_length)?;
                 // To match the interpreter behavior, if the signature is the
                 // wrong length, return a Clarity error.
-                if sig_bytes.len() != 65 {
+                if sig_bytes.len() != 65 || sig_bytes[64] > 3 {
                     let result = Value::err_uint(2);
                     write_to_wasm(
                         caller,


### PR DESCRIPTION
(Original PR: https://github.com/stacks-network/clarity-wasm/pull/465)

Fixes https://github.com/stacks-network/clarity-wasm/issues/414

The clarity-vm has an additional check for returning `err(2)`:
https://github.com/stacks-network/stacks-core/blob/47db1d0a8bf70eda1c93cb3e0731bdf5595f7baa/clarity/src/vm/functions/crypto.rs#L164

I've kept the test from the issue, but it's redundant wrt the second test and can be removed.
