### PR TITLE
Proptest for hashing

### DIFF
--- a/clar2wasm/tests/wasm-generation/hashing.rs
+++ b/clar2wasm/tests/wasm-generation/hashing.rs
@@ -1,0 +1,32 @@
+use clar2wasm::tools::crosscheck_compare_only;
+use clarity::vm::types::{SequenceSubtype, TypeSignature};
+use proptest::strategy::{Just, Strategy};
+use proptest::{prop_oneof, proptest};
+
+use crate::PropValue;
+
+const HASH_FUNC: [&str; 5] = ["hash160", "keccak256", "sha256", "sha512", "sha512/256"];
+
+fn strategies_for_hashing() -> impl Strategy<Value = TypeSignature> {
+    prop_oneof![
+        Just(TypeSignature::IntType),
+        Just(TypeSignature::UIntType),
+        (0u32..=300).prop_map(|s| TypeSignature::SequenceType(SequenceSubtype::BufferType(
+            s.try_into().unwrap()
+        ))),
+    ]
+}
+
+proptest! {
+    #![proptest_config(super::runtime_config())]
+
+    #[test]
+    fn crossprop_hashing(val in strategies_for_hashing().prop_flat_map(PropValue::from_type))
+    {
+        for func in &HASH_FUNC {
+            crosscheck_compare_only(
+                &format!("({func} {val})")
+            )
+        }
+    }
+}

--- a/clar2wasm/tests/wasm-generation/hashing.rs
+++ b/clar2wasm/tests/wasm-generation/hashing.rs
@@ -1,13 +1,11 @@
-use clar2wasm::tools::crosscheck_compare_only;
+use clar2wasm::tools::crosscheck_validate;
 use clarity::vm::types::{SequenceSubtype, TypeSignature};
 use proptest::strategy::{Just, Strategy};
 use proptest::{prop_oneof, proptest};
 
 use crate::PropValue;
 
-const HASH_FUNC: [&str; 5] = ["hash160", "keccak256", "sha256", "sha512", "sha512/256"];
-
-fn strategies_for_hashing() -> impl Strategy<Value = TypeSignature> {
+fn strategies_for_hashing() -> impl Strategy<Value = PropValue> {
     prop_oneof![
         Just(TypeSignature::IntType),
         Just(TypeSignature::UIntType),
@@ -15,18 +13,49 @@ fn strategies_for_hashing() -> impl Strategy<Value = TypeSignature> {
             s.try_into().unwrap()
         ))),
     ]
+    .prop_flat_map(PropValue::from_type)
 }
 
 proptest! {
     #![proptest_config(super::runtime_config())]
 
     #[test]
-    fn crossprop_hashing(val in strategies_for_hashing().prop_flat_map(PropValue::from_type))
+    fn crossprop_hashing_hash160(val in strategies_for_hashing())
     {
-        for func in &HASH_FUNC {
-            crosscheck_compare_only(
-                &format!("({func} {val})")
-            )
-        }
+        crosscheck_validate(
+            &format!("(hash160 {val})"), |_|{}
+        )
+    }
+
+    #[test]
+    fn crossprop_hashing_keccak256(val in strategies_for_hashing())
+    {
+        crosscheck_validate(
+            &format!("(keccak256 {val})"), |_|{}
+        )
+    }
+
+    #[test]
+    fn crossprop_hashing_sha256(val in strategies_for_hashing())
+    {
+        crosscheck_validate(
+            &format!("(sha256 {val})"), |_|{}
+        )
+    }
+
+    #[test]
+    fn crossprop_hashing_sha512(val in strategies_for_hashing())
+    {
+        crosscheck_validate(
+            &format!("(sha512 {val})"), |_|{}
+        )
+    }
+
+    #[test]
+    fn crossprop_hashing_sha512_256(val in strategies_for_hashing())
+    {
+        crosscheck_validate(
+            &format!("(sha512/256 {val})"), |_|{}
+        )
     }
 }

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -10,6 +10,7 @@ pub mod contracts;
 pub mod control_flow;
 pub mod default_to;
 pub mod equal;
+pub mod hashing;
 pub mod maps;
 pub mod noop;
 pub mod optional;


### PR DESCRIPTION
Address the easy ones from https://github.com/stacks-network/clarity-wasm/issues/256.

As suggested by the comment, generates `buff|uint|int` values and crosschecks them. I've used the same `300` as upper bound as the one used in [`standard/property_tests.rs`](https://github.com/stacks-network/clarity-wasm/blob/main/clar2wasm/tests/standard/property_tests.rs#L524). Using the "real" upperbound of `1_048_576` causes OOM (~I guess it's related to https://github.com/stacks-network/clarity-wasm/issues/450,~ opened https://github.com/stacks-network/clarity-wasm/issues/471 to track it).
<details><summary>Failing tests (OOM)</summary>
<p>

```rust
#[test]
fn test_big_buff() {
    let mut expected = [0u8; 32];
    hex::decode_to_slice(
        "c4145364a3ba46002fb14242872f795535bae6738b1e47ba21eb405cfdf820a5",
        &mut expected,
    )
    .unwrap();
    crosscheck(
        &format!("(sha256 0x{})", "aa".repeat(1048576)),
        Ok(Some(Value::buff_from(expected.to_vec()).unwrap())),
    )
}
```
results in:
```
assertion `left == right` failed: Compiled and interpreted results diverge!
compiled: Err(Wasm(Runtime(error while executing at wasm backtrace:
    0: 0x1deb - <unknown>!extend-data
    1: 0x2ce6 - <unknown>!stdlib.sha256-buf
    2: 0x3407 - <unknown>!<wasm function 157>

Caused by:
    wasm trap: out of bounds memory access
[...]
interpreted: Ok(Some(Sequence(Buffer(c4145364a3ba46002fb14242872f795535bae6738b1e47ba21eb405cfdf820a5))))
```
---

```rust
#[test]
fn test_big_buff() {
    let buff = "aa".repeat(1048576);
    crosscheck(
        &format!("(define-constant cst 0x{}) cst", buff),
        Ok(Some(Value::buff_from(hex::decode(buff).unwrap()).unwrap())),
    )
}
```
results in:
```
assertion `left == right` failed: Compiled and interpreted results diverge!
compiled: Err(Wasm(UnableToWriteMemory(out of bounds memory access

Stack backtrace:
   0: std::backtrace_rs::backtrace::libunwind::trace
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/../../backtrace/src/backtrace/libunwind.rs:104:5
   1: std::backtrace_rs::backtrace::trace_unsynchronized
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2: std::backtrace::Backtrace::create
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/backtrace.rs:331:13
   3: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from
             at /Users/matteoalmanza/.cargo/registry/src/index.crates.io-6f17d22bba15001f/anyhow-1.0.86/src/error.rs:565:25
   4: <T as core::convert::Into<U>>::into
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/convert/mod.rs:758:9
   5: clar2wasm::wasm_utils::write_to_wasm::{{closure}}
             at ./src/wasm_utils.rs:756:73
   6: core::result::Result<T,E>::map_err
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/result.rs:829:27
   7: clar2wasm::wasm_utils::write_to_wasm
             at ./src/wasm_utils.rs:750:13
   8: clar2wasm::linker::link_load_constant_fn::{{closure}}
             at ./src/linker.rs:4125:17
   9: <F as wasmtime::func::IntoFunc<T,(wasmtime::func::Caller<T>,A1,A2,A3,A4),R>>::into_func::native_call_shim::{{closure}}::{{closure}}
             at /Users/matteoalmanza/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasmtime-15.0.1/src/func.rs:2011:41
  10: core::ops::function::FnOnce::call_once
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/ops/function.rs:250:5
  11: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/panic/unwind_safe.rs:272:9
  12: std::panicking::try::do_call
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/panicking.rs:554:40
  13: ___rust_try
  14: std::panicking::try
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/panicking.rs:518:19
  15: std::panic::catch_unwind
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/panic.rs:142:14
  16: <F as wasmtime::func::IntoFunc<T,(wasmtime::func::Caller<T>,A1,A2,A3,A4),R>>::into_func::native_call_shim::{{closure}}
             at /Users/matteoalmanza/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasmtime-15.0.1/src/func.rs:2006:29
  17: wasmtime::func::Caller<T>::with::{{closure}}
             at /Users/matteoalmanza/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasmtime-15.0.1/src/func.rs:1823:13
  18: wasmtime_runtime::instance::Instance::from_vmctx
             at /Users/matteoalmanza/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasmtime-runtime-15.0.1/src/instance.rs:240:9
  19: wasmtime::func::Caller<T>::with
             at /Users/matteoalmanza/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasmtime-15.0.1/src/func.rs:1821:9
  20: <F as wasmtime::func::IntoFunc<T,(wasmtime::func::Caller<T>,A1,A2,A3,A4),R>>::into_func::native_call_shim
             at /Users/matteoalmanza/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasmtime-15.0.1/src/func.rs:1995:34
  21: <unknown>)))
interpreted: Ok(Some(Sequence(Buffer(aaaaaaa...))))
```
</p>
</details> 