### PR TITLE
Proptest for `secp256k1-recover`

### DIFF
--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -16,6 +16,7 @@ pub mod noop;
 pub mod optional;
 pub mod regression;
 pub mod response;
+pub mod secp256k1;
 pub mod sequences;
 pub mod stx;
 pub mod tokens;

--- a/clar2wasm/tests/wasm-generation/secp256k1.rs
+++ b/clar2wasm/tests/wasm-generation/secp256k1.rs
@@ -1,4 +1,4 @@
-use clar2wasm::tools::crosscheck_compare_only;
+use clar2wasm::tools::crosscheck_validate;
 use proptest::proptest;
 
 use crate::buffer;
@@ -9,8 +9,8 @@ proptest! {
     #[test]
     fn crossprop_secp256k1_recover_generic(msg in buffer(32), sig in buffer(65))
     {
-        crosscheck_compare_only(
-            &format!("(secp256k1-recover? {msg} {sig})")
+        crosscheck_validate(
+            &format!("(secp256k1-recover? {msg} {sig})"), |_|{}
         )
     }
 
@@ -18,8 +18,8 @@ proptest! {
     fn crossprop_secp256k1_recover_recid(msg in buffer(32), sig in buffer(64))
     {
         for recid in 0..4 {
-            crosscheck_compare_only(
-                &format!("(secp256k1-recover? {msg} {sig}{recid:02X})")
+            crosscheck_validate(
+                &format!("(secp256k1-recover? {msg} {sig}{recid:02X})"), |_|{}
             )
         }
     }
@@ -29,8 +29,8 @@ proptest! {
     {
         // Generate "low" R signatures to hope for valid recovery_id=(2|3) values
         for recid in 0..4 {
-            crosscheck_compare_only(
-                &format!("(secp256k1-recover? {msg} 0x00000000000000000000000000000000{}{recid:02X})", &sig.to_string()[2..])
+            crosscheck_validate(
+                &format!("(secp256k1-recover? {msg} 0x00000000000000000000000000000000{}{recid:02X})", &sig.to_string()[2..]), |_|{}
             )
         }
     }

--- a/clar2wasm/tests/wasm-generation/secp256k1.rs
+++ b/clar2wasm/tests/wasm-generation/secp256k1.rs
@@ -1,0 +1,37 @@
+use clar2wasm::tools::crosscheck_compare_only;
+use proptest::proptest;
+
+use crate::buffer;
+
+proptest! {
+    #![proptest_config(super::runtime_config())]
+
+    #[test]
+    fn crossprop_secp256k1_recover_generic(msg in buffer(32), sig in buffer(65))
+    {
+        crosscheck_compare_only(
+            &format!("(secp256k1-recover? {msg} {sig})")
+        )
+    }
+
+    #[test]
+    fn crossprop_secp256k1_recover_recid(msg in buffer(32), sig in buffer(64))
+    {
+        for recid in 0..4 {
+            crosscheck_compare_only(
+                &format!("(secp256k1-recover? {msg} {sig}{recid:02X})")
+            )
+        }
+    }
+
+    #[test]
+    fn crossprop_secp256k1_recover_recid_23(msg in buffer(32), sig in buffer(48))
+    {
+        // Generate "low" R signatures to hope for valid recovery_id=(2|3) values
+        for recid in 0..4 {
+            crosscheck_compare_only(
+                &format!("(secp256k1-recover? {msg} 0x00000000000000000000000000000000{}{recid:02X})", &sig.to_string()[2..])
+            )
+        }
+    }
+}


### PR DESCRIPTION
Property testing for `secp256k1-recover` (https://github.com/stacks-network/clarity-wasm/issues/256):
 - Random buffers of correct size
 - Random buffers with valid recovery id
 - Random buffers with small signature for recovery id 2,3
