### PR TITLE
Proptest for define functions

### DIFF
--- a/clar2wasm/tests/wasm-generation/functions.rs
+++ b/clar2wasm/tests/wasm-generation/functions.rs
@@ -7,7 +7,7 @@ use proptest::strategy::Strategy;
 
 use crate::{prop_signature, response, type_string, PropValue};
 
-fn strategies_for_function_siganture() -> impl Strategy<Value = (Vec<TypeSignature>, Vec<PropValue>)>
+fn strategies_for_function_signature() -> impl Strategy<Value = (Vec<TypeSignature>, Vec<PropValue>)>
 {
     prop::collection::vec(
         prop_signature().prop_ind_flat_map2(|ty| PropValue::from_type(ty.clone())),
@@ -51,7 +51,7 @@ proptest! {
 
     #[test]
     fn crossprop_define_private_accepts_any_args(
-        (tys, values) in strategies_for_function_siganture(),
+        (tys, values) in strategies_for_function_signature(),
         result in PropValue::any().no_shrink()
     ) {
         let (args_signature, _) = format_args_signature(&tys);
@@ -71,7 +71,7 @@ proptest! {
 
     #[test]
     fn crossprop_define_private_returns_any_argument(
-        ((tys, values), return_index) in strategies_for_function_siganture().prop_ind_flat_map2(|(tys, _)| 0..tys.len()),
+        ((tys, values), return_index) in strategies_for_function_signature().prop_ind_flat_map2(|(tys, _)| 0..tys.len()),
     ) {
         let (args_signature, args_name) = format_args_signature(&tys);
         let call_args = join_stringified(&values);
@@ -89,7 +89,7 @@ proptest! {
     }
 
     #[test]
-    fn crossprop_define_private_can_use_all_arguments((tys, values) in strategies_for_function_siganture()) {
+    fn crossprop_define_private_can_use_all_arguments((tys, values) in strategies_for_function_signature()) {
         let (args_signature, args_name) = format_args_signature(&tys);
         let call_args = join_stringified(&values);
 
@@ -118,7 +118,7 @@ proptest! {
 
     #[test]
     fn crossprop_define_private_side_effects(
-        (tys, values) in strategies_for_function_siganture(),
+        (tys, values) in strategies_for_function_signature(),
         response in strategies_for_response())
     {
         let (args_signature, _) = format_args_signature(&tys);
@@ -150,7 +150,7 @@ proptest! {
 
     #[test]
     fn crossprop_define_public_accepts_any_args(
-        (tys, values) in strategies_for_function_siganture(),
+        (tys, values) in strategies_for_function_signature(),
         response in strategies_for_response())
     {
         let (args_signature, _) = format_args_signature(&tys);
@@ -170,7 +170,7 @@ proptest! {
 
     #[test]
     fn crossprop_define_public_returns_any_argument(
-        ((tys, values), return_index) in strategies_for_function_siganture().prop_ind_flat_map2(|(tys, _)| 0..tys.len()),
+        ((tys, values), return_index) in strategies_for_function_signature().prop_ind_flat_map2(|(tys, _)| 0..tys.len()),
         response_ok in any::<bool>()
     ) {
         let (args_signature, args_name) = format_args_signature(&tys);
@@ -194,7 +194,7 @@ proptest! {
 
     #[test]
     fn crossprop_define_public_can_use_all_arguments(
-        (tys, values) in strategies_for_function_siganture(),
+        (tys, values) in strategies_for_function_signature(),
         response_ok in any::<bool>()
     ) {
         let (args_signature, args_name) = format_args_signature(&tys);
@@ -227,7 +227,7 @@ proptest! {
 
     #[test]
     fn crossprop_define_public_side_effects(
-        (tys, values) in strategies_for_function_siganture(),
+        (tys, values) in strategies_for_function_signature(),
         response in strategies_for_response())
     {
         let (args_signature, _) = format_args_signature(&tys);
@@ -264,7 +264,7 @@ proptest! {
 
     #[test]
     fn crossprop_define_readonly_accepts_any_args(
-        (tys, values) in strategies_for_function_siganture(),
+        (tys, values) in strategies_for_function_signature(),
         result in PropValue::any().no_shrink()
     ) {
         let (args_signature, _) = format_args_signature(&tys);
@@ -284,7 +284,7 @@ proptest! {
 
     #[test]
     fn crossprop_define_readonly_returns_any_argument(
-        ((tys, values), return_index) in strategies_for_function_siganture().prop_ind_flat_map2(|(tys, _)| 0..tys.len()),
+        ((tys, values), return_index) in strategies_for_function_signature().prop_ind_flat_map2(|(tys, _)| 0..tys.len()),
     ) {
         let (args_signature, args_name) = format_args_signature(&tys);
         let call_args = join_stringified(&values);
@@ -302,7 +302,7 @@ proptest! {
     }
 
     #[test]
-    fn crossprop_define_readonly_can_use_all_arguments((tys, values) in strategies_for_function_siganture()) {
+    fn crossprop_define_readonly_can_use_all_arguments((tys, values) in strategies_for_function_signature()) {
         let (args_signature, args_name) = format_args_signature(&tys);
         let call_args = join_stringified(&values);
 

--- a/clar2wasm/tests/wasm-generation/functions.rs
+++ b/clar2wasm/tests/wasm-generation/functions.rs
@@ -1,0 +1,333 @@
+use clar2wasm::tools::crosscheck;
+use clarity::vm::{
+    types::{ResponseData, TupleData, TypeSignature},
+    ClarityName, Value,
+};
+use proptest::prelude::*;
+use proptest::proptest;
+use proptest::strategy::Strategy;
+
+use crate::{prop_signature, response, type_string, PropValue};
+
+fn strategies_for_function_siganture() -> impl Strategy<Value = (Vec<TypeSignature>, Vec<PropValue>)>
+{
+    prop::collection::vec(
+        prop_signature().prop_ind_flat_map2(|ty| PropValue::from_type(ty.clone())),
+        1..=20,
+    )
+    .prop_map(|arg_ty| arg_ty.into_iter().unzip::<_, _, Vec<_>, Vec<_>>())
+    .no_shrink()
+}
+
+fn strategies_for_response() -> impl Strategy<Value = PropValue> {
+    (prop_signature(), prop_signature())
+        .prop_flat_map(|(ok, err)| response(ok, err))
+        .prop_map(PropValue::from)
+        .no_shrink()
+}
+
+/// Given a list of type signatures, join them together with some generated arguments names
+/// and return both the formatted signature `(arg-0 type-0) ...` and the list of
+/// generated arguments names
+fn format_args_signature(tys: &Vec<TypeSignature>) -> (String, Vec<String>) {
+    let args: Vec<String> = (0..tys.len()).map(|i| format!("arg-{i}")).collect();
+    let sig = args
+        .iter()
+        .zip(tys)
+        .map(|(arg, ty)| format!("({arg} {})", type_string(ty)))
+        .collect::<Vec<_>>()
+        .join(" ");
+    (sig, args)
+}
+
+fn join_stringified(values: &[PropValue]) -> String {
+    values
+        .iter()
+        .map(|v| v.to_string())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+proptest! {
+    #![proptest_config(super::runtime_config())]
+
+    #[test]
+    fn crossprop_define_private_accepts_any_args(
+        (tys, values) in strategies_for_function_siganture(),
+        result in PropValue::any().no_shrink()
+    ) {
+        let (args_signature, _) = format_args_signature(&tys);
+        let call_args = join_stringified(&values);
+        crosscheck(
+            &format!(
+                r#"
+                    (define-private (some-fn {args_signature})
+                        {result}
+                    )
+                    (some-fn {call_args})
+                "#,
+            ),
+            Ok(Some(result.into())),
+        )
+    }
+
+    #[test]
+    fn crossprop_define_private_returns_any_argument(
+        ((tys, values), return_index) in strategies_for_function_siganture().prop_ind_flat_map2(|(tys, _)| 0..tys.len()),
+    ) {
+        let (args_signature, args_name) = format_args_signature(&tys);
+        let call_args = join_stringified(&values);
+        crosscheck(
+            &format!(
+                r#"
+                    (define-private (some-fn {args_signature})
+                        {}
+                    )
+                    (some-fn {call_args})
+                "#, args_name[return_index]
+            ),
+            Ok(Some(values[return_index].clone().into())),
+        )
+    }
+
+    #[test]
+    fn crossprop_define_private_can_use_all_arguments((tys, values) in strategies_for_function_siganture()) {
+        let (args_signature, args_name) = format_args_signature(&tys);
+        let call_args = join_stringified(&values);
+
+        let return_exp = args_name.iter().map(|arg| format!("ret-{arg}: {arg}")).collect::<Vec<_>>().join(", ");
+        let expected = TupleData::from_data(
+            args_name.iter()
+                .map(|arg| ClarityName::try_from(format!("ret-{arg}")).unwrap())
+                .zip(values.into_iter().map(Value::from))
+                .collect(),
+        )
+        .unwrap()
+        .into();
+
+        crosscheck(
+            &format!(
+                r#"
+                    (define-private (some-fn {args_signature})
+                        {{ {return_exp} }}
+                    )
+                    (some-fn {call_args})
+                "#,
+            ),
+            Ok(Some(expected)),
+        )
+    }
+
+    #[test]
+    fn crossprop_define_private_side_effects(
+        (tys, values) in strategies_for_function_siganture(),
+        response in strategies_for_response())
+    {
+        let (args_signature, _) = format_args_signature(&tys);
+        let call_args = join_stringified(&values);
+
+        let expected = TupleData::from_data(vec![
+            (ClarityName::from("fn"), response.clone().into()),
+            // Response does not affect private functions
+            (ClarityName::from("side"), Value::Bool(true)),
+        ]).unwrap().into();
+
+        crosscheck(
+            &format!(
+                r#"
+                    (define-data-var side bool false)
+                    (define-private (some-fn {args_signature})
+                        (begin 
+                            (var-set side true)
+                            {response}
+                        )
+                    )
+                    {{ fn: (some-fn {call_args}), side: (var-get side) }}
+                "#,
+            ),
+            Ok(Some(expected)),
+        )
+    }
+
+
+    #[test]
+    fn crossprop_define_public_accepts_any_args(
+        (tys, values) in strategies_for_function_siganture(),
+        response in strategies_for_response())
+    {
+        let (args_signature, _) = format_args_signature(&tys);
+        let call_args = join_stringified(&values);
+        crosscheck(
+            &format!(
+                r#"
+                    (define-public (some-fn {args_signature})
+                        {response}
+                    )
+                    (some-fn {call_args})
+                "#,
+            ),
+            Ok(Some(response.into())),
+        )
+    }
+
+    #[test]
+    fn crossprop_define_public_returns_any_argument(
+        ((tys, values), return_index) in strategies_for_function_siganture().prop_ind_flat_map2(|(tys, _)| 0..tys.len()),
+        response_ok in any::<bool>()
+    ) {
+        let (args_signature, args_name) = format_args_signature(&tys);
+        let call_args = join_stringified(&values);
+        let expected = Value::Response(ResponseData {
+            committed: response_ok,
+            data: Box::new(values[return_index].clone().into()),
+        });
+        crosscheck(
+            &format!(
+                r#"
+                    (define-public (some-fn {args_signature})
+                        ({} {})
+                    )
+                    (some-fn {call_args})
+                "#, if response_ok { "ok" } else { "err" }, args_name[return_index]
+            ),
+            Ok(Some(expected)),
+        )
+    }
+
+    #[test]
+    fn crossprop_define_public_can_use_all_arguments(
+        (tys, values) in strategies_for_function_siganture(),
+        response_ok in any::<bool>()
+    ) {
+        let (args_signature, args_name) = format_args_signature(&tys);
+        let call_args = join_stringified(&values);
+
+        let return_exp = args_name.iter().map(|arg| format!("ret-{arg}: {arg}")).collect::<Vec<_>>().join(", ");
+        let expected = TupleData::from_data(
+            args_name.iter()
+                .map(|arg| ClarityName::try_from(format!("ret-{arg}")).unwrap())
+                .zip(values.into_iter().map(Value::from))
+                .collect(),
+        ).unwrap();
+        let expected = Value::Response(ResponseData {
+            committed: response_ok,
+            data: Box::new(expected.into()),
+        });
+
+        crosscheck(
+            &format!(
+                r#"
+                    (define-public (some-fn {args_signature})
+                        ({} {{ {return_exp} }})
+                    )
+                    (some-fn {call_args})
+                "#, if response_ok { "ok" } else { "err" }
+            ),
+            Ok(Some(expected)),
+        )
+    }
+
+    #[test]
+    fn crossprop_define_public_side_effects(
+        (tys, values) in strategies_for_function_siganture(),
+        response in strategies_for_response())
+    {
+        let (args_signature, _) = format_args_signature(&tys);
+        let call_args = join_stringified(&values);
+
+        let expected = TupleData::from_data(vec![
+            (ClarityName::from("fn"), response.clone().into()),
+            // Err responses revert changes (`(var-set side true)`)
+            (ClarityName::from("side"), Value::Bool(
+                match response {
+                    PropValue(Value::Response(ResponseData{ committed, ..})) => committed,
+                    _ => unreachable!("Expected a response")
+                }
+            )),
+        ]).unwrap().into();
+
+        crosscheck(
+            &format!(
+                r#"
+                    (define-data-var side bool false)
+                    (define-public (some-fn {args_signature})
+                        (begin 
+                            (var-set side true)
+                            {response}
+                        )
+                    )
+                    {{ fn: (some-fn {call_args}), side: (var-get side) }}
+                "#,
+            ),
+            Ok(Some(expected)),
+        )
+    }
+
+
+    #[test]
+    fn crossprop_define_readonly_accepts_any_args(
+        (tys, values) in strategies_for_function_siganture(),
+        result in PropValue::any().no_shrink()
+    ) {
+        let (args_signature, _) = format_args_signature(&tys);
+        let call_args = join_stringified(&values);
+        crosscheck(
+            &format!(
+                r#"
+                    (define-read-only (some-fn {args_signature})
+                        {result}
+                    )
+                    (some-fn {call_args})
+                "#,
+            ),
+            Ok(Some(result.into())),
+        )
+    }
+
+    #[test]
+    fn crossprop_define_readonly_returns_any_argument(
+        ((tys, values), return_index) in strategies_for_function_siganture().prop_ind_flat_map2(|(tys, _)| 0..tys.len()),
+    ) {
+        let (args_signature, args_name) = format_args_signature(&tys);
+        let call_args = join_stringified(&values);
+        crosscheck(
+            &format!(
+                r#"
+                    (define-read-only (some-fn {args_signature})
+                        {}
+                    )
+                    (some-fn {call_args})
+                "#, args_name[return_index]
+            ),
+            Ok(Some(values[return_index].clone().into())),
+        )
+    }
+
+    #[test]
+    fn crossprop_define_readonly_can_use_all_arguments((tys, values) in strategies_for_function_siganture()) {
+        let (args_signature, args_name) = format_args_signature(&tys);
+        let call_args = join_stringified(&values);
+
+        let return_exp = args_name.iter().map(|arg| format!("ret-{arg}: {arg}")).collect::<Vec<_>>().join(", ");
+        let expected = TupleData::from_data(
+            args_name.iter()
+                .map(|arg| ClarityName::try_from(format!("ret-{arg}")).unwrap())
+                .zip(values.into_iter().map(Value::from))
+                .collect(),
+        )
+        .unwrap()
+        .into();
+
+        crosscheck(
+            &format!(
+                r#"
+                    (define-read-only (some-fn {args_signature})
+                        {{ {return_exp} }}
+                    )
+                    (some-fn {call_args})
+                "#,
+            ),
+            Ok(Some(expected)),
+        )
+    }
+}

--- a/clar2wasm/tests/wasm-generation/functions.rs
+++ b/clar2wasm/tests/wasm-generation/functions.rs
@@ -1,8 +1,6 @@
 use clar2wasm::tools::crosscheck;
-use clarity::vm::{
-    types::{ResponseData, TupleData, TypeSignature},
-    ClarityName, Value,
-};
+use clarity::vm::types::{ResponseData, TupleData, TypeSignature};
+use clarity::vm::{ClarityName, Value};
 use proptest::prelude::*;
 use proptest::proptest;
 use proptest::strategy::Strategy;

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -10,6 +10,7 @@ pub mod contracts;
 pub mod control_flow;
 pub mod default_to;
 pub mod equal;
+pub mod functions;
 pub mod hashing;
 pub mod maps;
 pub mod noop;


### PR DESCRIPTION
This PR adds some basic proptests for `define-(public|private|read-only)` (https://github.com/stacks-network/clarity-wasm/issues/289).

There are 4 tests repeated for the three functions (with small variations):
 - Define a fn accepting random args, returns another random value
 - Define a fn accepting random args, returns one of the args
 - Define a fn accepting random args, returns a tuple using all the args
 - Define a fn accepting random args, do a `var-set` and return a random response (excluding `define-read-only`)

While writing this I encountered two issues (https://github.com/stacks-network/clarity-wasm/issues/473, https://github.com/stacks-network/clarity-wasm/issues/475) that could inspire some more proptests (random fn/arg names, adding more ops in the fn body to ~mess~ interact with the stack); please let me know if you want to add those or some other test.