### PR TITLE
Proptest for secp256k1-verify

### DIFF
--- a/clar2wasm/src/linker.rs
+++ b/clar2wasm/src/linker.rs
@@ -3922,7 +3922,10 @@ fn link_secp256k1_verify_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(
                 let sig_bytes = read_bytes_from_wasm(memory, &mut caller, sig_offset, sig_length)?;
                 // To match the interpreter behavior, if the signature is the
                 // wrong length, return a Clarity error.
-                if sig_bytes.len() < 64 || sig_bytes.len() > 65 {
+                if sig_bytes.len() < 64
+                    || sig_bytes.len() > 65
+                    || sig_bytes.len() == 65 && sig_bytes[64] > 3
+                {
                     return Ok(0i32);
                 }
 

--- a/clar2wasm/src/words/secp256k1.rs
+++ b/clar2wasm/src/words/secp256k1.rs
@@ -133,7 +133,12 @@ mod tests {
             0x03adb8de4bfb65db2cfd6120d55c6526ae9c52e675db7e47308636534ba7786110)", Ok(Some(Value::Bool(true))));
         crosscheck("(secp256k1-verify 0x0000000000000000000000000000000000000000000000000000000000000000
             0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-            0x03adb8de4bfb65db2cfd6120d55c6526ae9c52e675db7e47308636534ba7786110)", Ok(Some(Value::Bool(false))))
+            0x03adb8de4bfb65db2cfd6120d55c6526ae9c52e675db7e47308636534ba7786110)", Ok(Some(Value::Bool(false))));
+
+        // Recovery id (b'\x03') <= b'\x03' (with correct signature[..64])
+        crosscheck("(secp256k1-verify 0xde5b9eb9e7c5592930eb2e30a01369c36586d872082ed8181ee83d2a0ec20f04
+            0x8738487ebe69b93d8e51583be8eee50bb4213fc49c767d329632730cc193b873554428fc936ca3569afc15f1c9365f6591d6251a89fee9c9ac661116824d3a1303
+            0x03adb8de4bfb65db2cfd6120d55c6526ae9c52e675db7e47308636534ba7786110)", Ok(Some(Value::Bool(true))));
     }
 
     #[test]
@@ -217,6 +222,12 @@ mod tests {
             0x{}
             0x03adb8de4bfb65db2cfd6120d55c6526ae9c52e675db7e47308636534ba7786110)", short_sig),
             Ok(Some(Value::Bool(false))));
+
+        // Recovery id (b'\x04') > b'\x03' (with correct signature[..64])
+        crosscheck("(secp256k1-verify 0xde5b9eb9e7c5592930eb2e30a01369c36586d872082ed8181ee83d2a0ec20f04
+            0x8738487ebe69b93d8e51583be8eee50bb4213fc49c767d329632730cc193b873554428fc936ca3569afc15f1c9365f6591d6251a89fee9c9ac661116824d3a1304
+            0x03adb8de4bfb65db2cfd6120d55c6526ae9c52e675db7e47308636534ba7786110)",
+        Ok(Some(Value::Bool(false))));
 
         // Public key is too short
         let short_pubkey = "03adb8de4bfb65db2cfd6120d55c6526ae9c52e675db7e47308636534ba77861";

--- a/clar2wasm/tests/wasm-generation/secp256k1.rs
+++ b/clar2wasm/tests/wasm-generation/secp256k1.rs
@@ -1,7 +1,24 @@
-use clar2wasm::tools::crosscheck_validate;
-use proptest::proptest;
+use std::ops::RangeInclusive;
 
-use crate::buffer;
+use clar2wasm::tools::{crosscheck, crosscheck_validate};
+use clarity::types::PrivateKey;
+use clarity::util::hash::to_hex;
+use clarity::util::secp256k1::{Secp256k1PrivateKey, Secp256k1PublicKey};
+use clarity::vm::types::{SequenceSubtype, TypeSignature};
+use clarity::vm::Value;
+use proptest::prelude::*;
+use proptest::proptest;
+use proptest::strategy::Strategy;
+
+use crate::{buffer, PropValue};
+
+fn buffer_range(len_range: RangeInclusive<u32>) -> impl Strategy<Value = PropValue> {
+    len_range
+        .prop_map(|s| {
+            TypeSignature::SequenceType(SequenceSubtype::BufferType(s.try_into().unwrap()))
+        })
+        .prop_flat_map(PropValue::from_type)
+}
 
 proptest! {
     #![proptest_config(super::runtime_config())]
@@ -33,5 +50,74 @@ proptest! {
                 &format!("(secp256k1-recover? {msg} 0x00000000000000000000000000000000{}{recid:02X})", &sig.to_string()[2..]), |_|{}
             )
         }
+    }
+
+    #[test]
+    fn crossprop_secp256k1_verify_generic(msg in buffer(32), sig in buffer_range(64..=65), pkey in buffer(33))
+    {
+        crosscheck_validate(
+            &format!("(secp256k1-verify {msg} {sig} {pkey})"), |_|{}
+        )
+    }
+
+    #[test]
+    fn crossprop_secp256k1_verify_correct_sig(
+        msg in prop::collection::vec(any::<u8>(), 32usize..=32usize),
+        private_key in prop::collection::vec(any::<u8>(), 32usize..=32usize))
+    {
+        let mut key = Secp256k1PrivateKey::from_slice(&private_key).unwrap();
+        key.set_compress_public(true);
+        let sig = key.sign(&msg).unwrap().to_secp256k1_recoverable().unwrap();
+        let (recid, sig) = sig.serialize_compact();
+
+        // with recovery id
+        crosscheck(
+            &format!("(secp256k1-verify 0x{} 0x{}{:02X} 0x{})",
+                to_hex(&msg),
+                to_hex(&sig),
+                recid.to_i32(),
+                Secp256k1PublicKey::from_private(&key).to_hex()),
+            Ok(Some(Value::Bool(true)))
+        );
+
+        // without recovery id
+        crosscheck(
+            &format!("(secp256k1-verify 0x{} 0x{} 0x{})",
+                to_hex(&msg),
+                to_hex(&sig),
+                Secp256k1PublicKey::from_private(&key).to_hex()),
+            Ok(Some(Value::Bool(true)))
+        );
+
+        // with some other recovery id
+        crosscheck(
+            &format!("(secp256k1-verify 0x{} 0x{}{:02X} 0x{})",
+                to_hex(&msg),
+                to_hex(&sig),
+                (recid.to_i32() + 1) % 4,
+                Secp256k1PublicKey::from_private(&key).to_hex()),
+            Ok(Some(Value::Bool(true)))
+        );
+    }
+
+    #[test]
+    fn crossprop_secp256k1_verify_alter_recid(
+        msg in prop::collection::vec(any::<u8>(), 32usize..=32usize),
+        private_key in prop::collection::vec(any::<u8>(), 32usize..=32usize),
+        recid in any::<u8>())
+    {
+        let mut key = Secp256k1PrivateKey::from_slice(&private_key).unwrap();
+        key.set_compress_public(true);
+        let sig = key.sign(&msg).unwrap().to_secp256k1_recoverable().unwrap();
+        let (_, sig) = sig.serialize_compact();
+
+        crosscheck_validate(
+            &format!("(secp256k1-verify 0x{} 0x{}{:02X} 0x{})",
+                to_hex(&msg),
+                to_hex(&sig),
+                recid,
+                Secp256k1PublicKey::from_private(&key).to_hex()),
+            |_|{}
+        );
     }
 }


### PR DESCRIPTION
This PR adds proptests for `secp256k1-verify` (closes https://github.com/stacks-network/clarity-wasm/issues/256):
 - Random values matching the expected types;
 - Random values with correct signature (both with, without and with a different valid recovery id;
 - Random values with correct signature but random (potentially non valid) recovery id;

It also includes a fix for the function (and relevant test) as it was missing the check on the recovery id present on clarity vm.