### PR TITLE
disallow failures in compare_only

### DIFF
--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -392,6 +392,13 @@ pub fn crosscheck_compare_only(snippet: &str) {
     let compiled = evaluate(snippet);
     let interpreted = interpret(snippet);
 
+    // to avoid false positives when both the compiled and interpreted fail,
+    // we don't allow failures in these tests
+
+    if let Err(e) = compiled {
+        panic!("Compiled snippet failed: {:?}", e);
+    }
+
     assert_eq!(
         compiled, interpreted,
         "Compiled and interpreted results diverge! {}\ncompiled: {:?}\ninterpreted: {:?}",

--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -406,6 +406,29 @@ pub fn crosscheck_compare_only(snippet: &str) {
     );
 }
 
+pub fn crosscheck_compare_only_with_expected_error<E: Fn(&Error) -> bool>(
+    snippet: &str,
+    expected: E,
+) {
+    let compiled = evaluate(snippet);
+    let interpreted = interpret(snippet);
+
+    // to avoid false positives when both the compiled and interpreted fail,
+    // we don't allow failures in these tests
+
+    if let Err(e) = &compiled {
+        if !expected(e) {
+            panic!("Compiled snippet failed with unexpected error: {:?}", e);
+        }
+    }
+
+    assert_eq!(
+        compiled, interpreted,
+        "Compiled and interpreted results diverge! {}\ncompiled: {:?}\ninterpreted: {:?}",
+        snippet, &compiled, &interpreted
+    );
+}
+
 /// Advance the block height to `count`, and uses identical TestEnvironment copies
 /// to assert the results of a contract snippet running against the compiler and the interpreter.
 pub fn crosscheck_compare_only_advancing_tip(snippet: &str, count: u32) {

--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -389,15 +389,11 @@ pub fn crosscheck_with_amount(snippet: &str, amount: u128, expected: Result<Opti
 }
 
 pub fn crosscheck_compare_only(snippet: &str) {
-    let compiled = evaluate(snippet);
-    let interpreted = interpret(snippet);
-
     // to avoid false positives when both the compiled and interpreted fail,
     // we don't allow failures in these tests
 
-    if let Err(e) = compiled {
-        panic!("Compiled snippet failed: {:?}", e);
-    }
+    let compiled = evaluate(snippet).expect("Compiled snippet failed");
+    let interpreted = interpret(snippet).expect("Interpreted snippet failed");
 
     assert_eq!(
         compiled, interpreted,
@@ -412,9 +408,6 @@ pub fn crosscheck_compare_only_with_expected_error<E: Fn(&Error) -> bool>(
 ) {
     let compiled = evaluate(snippet);
     let interpreted = interpret(snippet);
-
-    // to avoid false positives when both the compiled and interpreted fail,
-    // we don't allow failures in these tests
 
     if let Err(e) = &compiled {
         if !expected(e) {


### PR DESCRIPTION
Compare only crosscheck can easily let certain errors slide through, if they affect both sides.

We should only allow compare_only to compare successful test results.