### PR TITLE
Allocate stack space when loading constants

### DIFF
--- a/clar2wasm/src/words/constants.rs
+++ b/clar2wasm/src/words/constants.rs
@@ -114,7 +114,9 @@ mod tests {
     use clarity::vm::types::{ASCIIData, CharType, ListData, ListTypeData, SequenceData};
     use clarity::vm::Value;
 
-    use crate::tools::{crosscheck, crosscheck_expect_failure, crosscheck_with_epoch, evaluate};
+    use crate::tools::{
+        crosscheck, crosscheck_expect_failure, crosscheck_with_epoch, evaluate, TestEnvironment,
+    };
 
     #[test]
     fn define_constant_const() {
@@ -271,5 +273,46 @@ mod tests {
                 .unwrap(),
             )),
         )
+    }
+
+    #[test]
+    fn test_large_complex_via_contract_call() {
+        let a = "aa".repeat(1 << 18);
+        let b = "bb".repeat(1 << 18);
+
+        let mut env = TestEnvironment::default();
+        env.init_contract_with_snippet(
+            "contract-callee",
+            &format!(
+                r#"
+                (define-constant cst (list 0x{a} 0x{b}))
+                (define-public (return-cst)
+                    (ok cst)
+                )
+            "#
+            ),
+        )
+        .expect("Failed to init contract.");
+        let val = env
+            .init_contract_with_snippet(
+                "contract-caller",
+                r#"(contract-call? .contract-callee return-cst)"#,
+            )
+            .expect("Failed to init contract.");
+
+        assert_eq!(
+            val.unwrap(),
+            Value::okay(
+                Value::cons_list(
+                    vec![
+                        Value::buff_from(hex::decode(a).unwrap()).unwrap(),
+                        Value::buff_from(hex::decode(b).unwrap()).unwrap(),
+                    ],
+                    &StacksEpochId::latest(),
+                )
+                .unwrap()
+            )
+            .unwrap()
+        );
     }
 }

--- a/clar2wasm/src/words/constants.rs
+++ b/clar2wasm/src/words/constants.rs
@@ -244,4 +244,13 @@ mod tests {
             )))),
         )
     }
+
+    #[test]
+    fn test_large_buff() {
+        let buff = "aa".repeat(1 << 20);
+        crosscheck(
+            &format!("(define-constant cst 0x{}) cst", buff),
+            Ok(Some(Value::buff_from(hex::decode(buff).unwrap()).unwrap())),
+        )
+    }
 }

--- a/clar2wasm/src/words/constants.rs
+++ b/clar2wasm/src/words/constants.rs
@@ -253,4 +253,23 @@ mod tests {
             Ok(Some(Value::buff_from(hex::decode(buff).unwrap()).unwrap())),
         )
     }
+
+    #[test]
+    fn test_large_complex() {
+        let a = "aa".repeat(1 << 18);
+        let b = "bb".repeat(1 << 18);
+        crosscheck(
+            &format!("(define-constant cst (list 0x{a} 0x{b})) cst"),
+            Ok(Some(
+                Value::cons_list(
+                    vec![
+                        Value::buff_from(hex::decode(a).unwrap()).unwrap(),
+                        Value::buff_from(hex::decode(b).unwrap()).unwrap(),
+                    ],
+                    &StacksEpochId::latest(),
+                )
+                .unwrap(),
+            )),
+        )
+    }
 }

--- a/clar2wasm/tests/wasm-generation/constants.rs
+++ b/clar2wasm/tests/wasm-generation/constants.rs
@@ -1,4 +1,8 @@
 use clar2wasm::tools::crosscheck;
+use clarity::types::StacksEpochId;
+use clarity::vm::ast::parse;
+use clarity::vm::types::{QualifiedContractIdentifier, TypeSignature};
+use clarity::vm::ClarityVersion;
 use proptest::prelude::*;
 
 use crate::{
@@ -15,6 +19,17 @@ fn literal() -> impl Strategy<Value = PropValue> {
         (0..32u32).prop_flat_map(string_utf8)
     ]
     .prop_map_into()
+}
+
+fn type_from_string(val: &str) -> TypeSignature {
+    let expr = &parse(
+        &QualifiedContractIdentifier::transient(),
+        val,
+        ClarityVersion::latest(),
+        StacksEpochId::latest(),
+    )
+    .unwrap()[0];
+    TypeSignature::parse_type_repr(StacksEpochId::latest(), expr, &mut ()).unwrap()
 }
 
 proptest! {
@@ -37,5 +52,13 @@ proptest! {
             (define-constant cst (foo)) cst
         "#);
         crosscheck(&snippet, Ok(Some(val.into())));
+    }
+
+    #[test]
+    fn define_constant_from_large_complex(val in PropValue::from_type(type_from_string("(list 18 (list 31 (string-ascii 105)))"))) {
+        crosscheck(
+            &format!("(define-constant cst {val}) cst"),
+            Ok(Some(val.into())),
+        )
     }
 }


### PR DESCRIPTION
Fixes https://github.com/stacks-network/clarity-wasm/issues/450.

When loading a constant, allocate stack space for it.
Note that, as `frame_size` is never reclaimed, loading consts multiple times will make the stack grow for each call, even if they are not used at the same time. 