### PR TITLE
Fix: `contract-call?` with trait name in a `let` or `match` binding

### DIFF
--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -3,10 +3,10 @@ use std::collections::HashMap;
 
 use clarity::vm::analysis::ContractAnalysis;
 use clarity::vm::diagnostic::DiagnosableError;
-use clarity::vm::types::signatures::{StringUTF8Length, BUFF_1};
+use clarity::vm::types::signatures::{CallableSubtype, StringUTF8Length, BUFF_1};
 use clarity::vm::types::{
     CharType, FixedFunction, FunctionType, PrincipalData, SequenceData, SequenceSubtype,
-    StringSubtype, TypeSignature,
+    StringSubtype, TraitIdentifier, TypeSignature,
 };
 use clarity::vm::variables::NativeVariables;
 use clarity::vm::{functions, variables, ClarityName, SymbolicExpression, SymbolicExpressionType};
@@ -54,9 +54,49 @@ pub struct WasmGenerator {
     pub(crate) maps_types: HashMap<ClarityName, (TypeSignature, TypeSignature)>,
 
     /// The locals for the current function.
-    pub(crate) bindings: HashMap<String, Vec<LocalId>>,
+    pub(crate) bindings: Bindings,
     /// Size of the current function's stack frame.
     frame_size: i32,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct Bindings(HashMap<ClarityName, InnerBindings>);
+
+#[derive(Debug, Clone)]
+struct InnerBindings {
+    locals: Vec<LocalId>,
+    trait_id: Option<TraitIdentifier>,
+}
+
+impl Bindings {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn insert(&mut self, name: ClarityName, ty: &TypeSignature, locals: Vec<LocalId>) {
+        let callable = match ty {
+            TypeSignature::CallableType(CallableSubtype::Trait(t)) => Some(t.clone()),
+            _ => None,
+        };
+        self.0.insert(
+            name,
+            InnerBindings {
+                locals,
+                trait_id: callable,
+            },
+        );
+    }
+
+    pub(crate) fn get_locals(&self, name: &ClarityName) -> Option<&[LocalId]> {
+        self.0.get(name).map(|b| b.locals.as_slice())
+    }
+
+    pub(crate) fn get_trait_name(&self, name: &ClarityName) -> Option<&ClarityName> {
+        self.0
+            .get(name)
+            .and_then(|b| b.trait_id.as_ref())
+            .map(|t| &t.name)
+    }
 }
 
 #[derive(Hash, Eq, PartialEq)]
@@ -247,7 +287,7 @@ impl WasmGenerator {
             stack_pointer: global_id,
             literal_memory_offset: HashMap::new(),
             constants: HashMap::new(),
-            bindings: HashMap::new(),
+            bindings: Bindings::new(),
             early_return_block_id: None,
             current_function_type: None,
             frame_size: 0,
@@ -457,7 +497,7 @@ impl WasmGenerator {
         // Call the host interface function, `define_function`
         builder.call(self.func_by_name("stdlib.define_function"));
 
-        let mut bindings = HashMap::new();
+        let mut bindings = Bindings::new();
 
         // Setup the parameters
         let mut param_locals = Vec::new();
@@ -471,7 +511,7 @@ impl WasmGenerator {
                 plocals.push(local);
                 params_types.push(ty);
             }
-            bindings.insert(param.name.to_string(), plocals.clone());
+            bindings.insert(param.name.clone(), &param.signature, plocals);
         }
 
         let results_types = clar2wasm_ty(&function_type.returns);
@@ -1409,7 +1449,7 @@ impl WasmGenerator {
         }
 
         // Handle parameters and local bindings
-        let values = self.bindings.get(atom.as_str()).ok_or_else(|| {
+        let values = self.bindings.get_locals(atom).ok_or_else(|| {
             GeneratorError::InternalError(format!("unable to find local for {}", atom.as_str()))
         })?;
 

--- a/clar2wasm/src/words/bindings.rs
+++ b/clar2wasm/src/words/bindings.rs
@@ -49,7 +49,7 @@ impl ComplexWord for Let {
             let locals = generator.save_to_locals(builder, &ty, true);
 
             // Add these named locals to the map
-            generator.bindings.insert(name.to_string(), locals);
+            generator.bindings.insert(name.clone(), &ty, locals);
         }
 
         // WORKAROUND: need to set the last statement type to the type of the let expression

--- a/clar2wasm/src/words/bindings.rs
+++ b/clar2wasm/src/words/bindings.rs
@@ -49,7 +49,7 @@ impl ComplexWord for Let {
             let locals = generator.save_to_locals(builder, &ty, true);
 
             // Add these named locals to the map
-            generator.bindings.insert(name.clone(), &ty, locals);
+            generator.bindings.insert(name.clone(), ty, locals);
         }
 
         // WORKAROUND: need to set the last statement type to the type of the let expression

--- a/clar2wasm/src/words/conditionals.rs
+++ b/clar2wasm/src/words/conditionals.rs
@@ -105,7 +105,7 @@ impl ComplexWord for Match {
 
                 generator
                     .bindings
-                    .insert(success_binding.clone(), &inner_type, some_locals);
+                    .insert(success_binding.clone(), *inner_type, some_locals);
 
                 let some_block = generator.block_from_expr(builder, success_body)?;
 
@@ -142,7 +142,7 @@ impl ComplexWord for Match {
 
                 generator
                     .bindings
-                    .insert(success_binding.clone(), ok_ty, ok_locals);
+                    .insert(success_binding.clone(), ok_ty.clone(), ok_locals);
                 let ok_block = generator.block_from_expr(builder, success_body)?;
 
                 // restore named locals
@@ -151,7 +151,7 @@ impl ComplexWord for Match {
                 // bind err branch local
                 generator
                     .bindings
-                    .insert(err_binding.clone(), err_ty, err_locals);
+                    .insert(err_binding.clone(), err_ty.clone(), err_locals);
 
                 let err_block = generator.block_from_expr(builder, err_body)?;
 

--- a/clar2wasm/src/words/conditionals.rs
+++ b/clar2wasm/src/words/conditionals.rs
@@ -105,7 +105,8 @@ impl ComplexWord for Match {
 
                 generator
                     .bindings
-                    .insert(success_binding.as_str().into(), some_locals);
+                    .insert(success_binding.clone(), &inner_type, some_locals);
+
                 let some_block = generator.block_from_expr(builder, success_body)?;
 
                 // we can restore early, since the none branch does not bind anything
@@ -141,7 +142,7 @@ impl ComplexWord for Match {
 
                 generator
                     .bindings
-                    .insert(success_binding.as_str().into(), ok_locals);
+                    .insert(success_binding.clone(), ok_ty, ok_locals);
                 let ok_block = generator.block_from_expr(builder, success_body)?;
 
                 // restore named locals
@@ -150,7 +151,7 @@ impl ComplexWord for Match {
                 // bind err branch local
                 generator
                     .bindings
-                    .insert(err_binding.as_str().into(), err_locals);
+                    .insert(err_binding.clone(), err_ty, err_locals);
 
                 let err_block = generator.block_from_expr(builder, err_body)?;
 

--- a/clar2wasm/tests/wasm-generation/contracts.rs
+++ b/clar2wasm/tests/wasm-generation/contracts.rs
@@ -321,7 +321,7 @@ proptest! {
             .prop_map(|arg_ty| arg_ty.into_iter().unzip::<_, _, Vec<_>, Vec<_>>())
             .no_shrink(),
         result in PropValue::any().no_shrink(),
-        err_type in prop_signature().no_shrink(),
+        (err_type, err_value) in prop_signature().prop_ind_flat_map2(PropValue::from_type).no_shrink(),
     ) {
         // first contract
         let first_contract_name = "foo".into();
@@ -368,7 +368,7 @@ proptest! {
                 (define-private (call-it (tt (optional <foo-trait>)) {function_arguments})
                     (match tt
                         ttt (contract-call? ttt foofun {contract_call_args})
-                        (ok {result})
+                        (err {err_value})
                     )
                 )
                 (call-it (some .foo) {call_arguments})
@@ -397,7 +397,7 @@ proptest! {
             .prop_map(|arg_ty| arg_ty.into_iter().unzip::<_, _, Vec<_>, Vec<_>>())
             .no_shrink(),
         result in PropValue::any().no_shrink(),
-        err_type in prop_signature().no_shrink(),
+        (err_type, err_value) in prop_signature().prop_ind_flat_map2(PropValue::from_type).no_shrink(),
     ) {
         // first contract
         let first_contract_name = "foo".into();
@@ -444,7 +444,7 @@ proptest! {
                 (define-private (call-it (tt (response <foo-trait> uint)) {function_arguments})
                     (match tt
                         ttt (contract-call? ttt foofun {contract_call_args})
-                        unused (ok {result})
+                        unused (err {err_value})
                     )
                 )
                 (call-it (ok .foo) {call_arguments})
@@ -473,7 +473,7 @@ proptest! {
             .prop_map(|arg_ty| arg_ty.into_iter().unzip::<_, _, Vec<_>, Vec<_>>())
             .no_shrink(),
         result in PropValue::any().no_shrink(),
-        err_type in prop_signature().no_shrink(),
+        (err_type, err_value) in prop_signature().prop_ind_flat_map2(PropValue::from_type).no_shrink(),
     ) {
         // first contract
         let first_contract_name = "foo".into();
@@ -519,7 +519,7 @@ proptest! {
                 (use-trait foo-trait .foo.foo-trait)
                 (define-private (call-it (tt (response uint <foo-trait>)) {function_arguments})
                     (match tt
-                        unused (ok {result})
+                        unused (err {err_value})
                         ttt (contract-call? ttt foofun {contract_call_args})
                     )
                 )


### PR DESCRIPTION
Fixes #481 

This PR adds a new `Binding` struct used in `WasmGenerator`, so that bindings now remember the trait if needed.
