### PR TITLE
Remaining proptests for trait functions

### DIFF
--- a/clar2wasm/tests/wasm-generation/contracts.rs
+++ b/clar2wasm/tests/wasm-generation/contracts.rs
@@ -569,18 +569,26 @@ proptest! {
             .unwrap(),
         )
         .into();
+        let expected_res_ty = ('a'..).zip(tys.iter()).fold('{'.to_string(), |mut acc, (c, ty)| {
+            write!(acc, "{c}: {}, ", type_string(ty)).unwrap();
+            acc
+        }) + "}";
+
+        let foofun_res = ('a'..).take(values.len()).fold("{".to_owned(), |mut acc, n| {
+            write!(acc, "{n}: {n}, ").unwrap();
+            acc
+        }) + "}";
 
         let first_snippet = format!(
             r#"
                     (define-trait foo-trait (
-                        (foofun ({function_types}) (response {} {}))
+                        (foofun ({function_types}) (response {expected_res_ty} {}))
                     ))
 
                     (define-public (foofun {function_arguments})
-                        (ok {expected_res})
+                        (ok {foofun_res})
                     )
                 "#,
-            expected_res.type_string(),
             type_string(&err_type),
         );
 

--- a/clar2wasm/tests/wasm-generation/contracts.rs
+++ b/clar2wasm/tests/wasm-generation/contracts.rs
@@ -538,4 +538,87 @@ proptest! {
             }))),
         );
     }
+
+    #[test]
+    fn contract_dynamic_call_use_all_args(
+        (tys, values)
+            in prop::collection::vec(
+                prop_signature().prop_ind_flat_map2(|ty| PropValue::from_type(ty.clone())),
+                1..=20
+            )
+            .prop_map(|arg_ty| arg_ty.into_iter().unzip::<_, _, Vec<_>, Vec<_>>())
+            .no_shrink(),
+        err_type in prop_signature(),
+    ) {
+        // first contract
+        let first_contract_name = "foo".into();
+        let mut function_types = String::new();
+        let mut function_arguments = String::new();
+        for (name, ty) in ('a'..).zip(tys.iter()) {
+            let ty = type_string(ty);
+            write!(function_arguments, "({name} {ty}) ").unwrap();
+            function_types += &(ty + " ");
+        }
+        let expected_res: PropValue = Value::from(
+            TupleData::from_data(
+                ('a'..)
+                    .map(|c| ClarityName::try_from(c.to_string()).unwrap())
+                    .zip(values.iter().cloned().map(Value::from))
+                    .collect(),
+            )
+            .unwrap(),
+        )
+        .into();
+
+        let first_snippet = format!(
+            r#"
+                    (define-trait foo-trait (
+                        (foofun ({function_types}) (response {} {}))
+                    ))
+
+                    (define-public (foofun {function_arguments})
+                        (ok {expected_res})
+                    )
+                "#,
+            expected_res.type_string(),
+            type_string(&err_type),
+        );
+
+        // second contract
+        let second_contract_name = "bar".into();
+
+        let contract_call_args: String =
+            ('a'..)
+                .take(values.len())
+                .fold(String::new(), |mut acc, name| {
+                    write!(acc, "{name} ").unwrap();
+                    acc
+                });
+
+        let mut call_arguments = String::new();
+        for value in values {
+            write!(call_arguments, "{value} ").unwrap();
+        }
+
+        let second_snippet = format!(
+            r#"
+                    (use-trait foo-trait .foo.foo-trait)
+                    (define-private (call-it (tt <foo-trait>) {function_arguments})
+                        (contract-call? tt foofun {contract_call_args})
+                    )
+                    (call-it .foo {call_arguments})
+                "#
+        );
+
+        crosscheck_multi_contract(
+            &[
+                (first_contract_name, &first_snippet),
+                (second_contract_name, &second_snippet),
+            ],
+            Ok(Some(Value::Response(ResponseData {
+                committed: true,
+                data: Box::new(expected_res.into()),
+            }))),
+        );
+    }
 }

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -21,6 +21,7 @@ pub mod secp256k1;
 pub mod sequences;
 pub mod stx;
 pub mod tokens;
+pub mod traits;
 pub mod tuple;
 pub mod values;
 

--- a/clar2wasm/tests/wasm-generation/traits.rs
+++ b/clar2wasm/tests/wasm-generation/traits.rs
@@ -1,0 +1,107 @@
+use std::fmt::Write;
+
+use clar2wasm::tools::crosscheck_multi_contract;
+use clarity::vm::types::TypeSignature;
+use proptest::prelude::*;
+
+use crate::{prop_signature, type_string, PropValue};
+
+#[derive(Debug)]
+struct TraitMethod {
+    name: String,
+    args: Vec<TypeSignature>,
+    returns_ty: TypeSignature,
+    returns_val: PropValue,
+}
+
+prop_compose! {
+    fn trait_method() (
+        name in "[a-zA-Z]{2}([a-zA-Z0-9]|[-_!?+<>=/*]){20,115}",
+        args in prop::collection::vec(
+                prop_signature(),
+                0..=20
+            ),
+        (returns_ty, returns_val) in (prop_signature(), prop_signature()).prop_flat_map(|(ok_ty, err_ty)| {
+            let res_ty = TypeSignature::ResponseType(Box::new((ok_ty, err_ty)));
+            (Just(res_ty.clone()), PropValue::from_type(res_ty))
+        })
+    ) -> TraitMethod {
+        TraitMethod { name, args, returns_ty, returns_val }
+    }
+}
+
+impl TraitMethod {
+    fn method_signature(&self) -> String {
+        let args = self
+            .args
+            .split_first()
+            .map_or_else(String::new, |(fst, rest)| {
+                rest.iter().fold(type_string(fst), |mut acc, arg| {
+                    write!(acc, " {}", type_string(arg)).unwrap();
+                    acc
+                })
+            });
+        format!(
+            "({} ({}) {})",
+            self.name,
+            args,
+            type_string(&self.returns_ty)
+        )
+    }
+
+    fn method_implementation(&self) -> String {
+        let args = self
+            .args
+            .split_first()
+            .map_or_else(String::new, |(fst, rest)| {
+                rest.iter().zip('b'..).fold(
+                    format!("(a {})", type_string(fst)),
+                    |mut acc, (arg, n)| {
+                        write!(acc, " ({n} {})", type_string(arg)).unwrap();
+                        acc
+                    },
+                )
+            });
+        format!(
+            "(define-public ({} {})\n\t{}\n)",
+            self.name, args, self.returns_val,
+        )
+    }
+}
+
+proptest! {
+    #![proptest_config(super::runtime_config())]
+
+    #[test]
+    fn define_and_impl_trait(
+        trait_name in "impl-trait-[a-z]{1,5}",
+        methods in prop::collection::vec(trait_method(), 1..20),
+    ) {
+        let first_contract_name = "foo".into();
+        let first_snippet =
+            methods
+                .iter()
+                .fold(format!("(define-trait {trait_name} ("), |mut acc, meth| {
+                    write!(acc, "\n\t{}", meth.method_signature()).unwrap();
+                    acc
+                })
+                + "\n))";
+
+        let second_contract_name = "bar".into();
+        let second_snippet = methods.iter().fold(
+            format!("(impl-trait .{first_contract_name}.{trait_name})\n"),
+            |mut acc, meth| {
+                writeln!(acc, "{}", meth.method_implementation()).unwrap();
+                acc
+            },
+        );
+
+        crosscheck_multi_contract(
+            &[
+                (first_contract_name, &first_snippet),
+                (second_contract_name, &second_snippet),
+            ],
+            Ok(None),
+        )
+    }
+}


### PR DESCRIPTION
Closes #264

This implements the remainings testing for the trait functions:

- one that checks that `contract-call?` can use all of its arguments
- one that creates a contract that defines a trait with a random number of methods, each having a random number of args and returning a random value, then a second contract that implements that traits.

~~THIS IS A DRAFT: I based this branch on the work of #483, we need this one merged first.~~