### PR TITLE
Reserve work space for print serialized value

### DIFF
--- a/clar2wasm/src/serialize.rs
+++ b/clar2wasm/src/serialize.rs
@@ -934,7 +934,7 @@ impl WasmGenerator {
             }
             NoType => {
                 // This type should not actually be serialized. It is
-                // reporesented as an `i32` value of `0`, so we can leave
+                // represented as an `i32` value of `0`, so we can leave
                 // that on top of the stack indicating 0 bytes written.
                 Ok(())
             }

--- a/clar2wasm/src/words/print.rs
+++ b/clar2wasm/src/words/print.rs
@@ -39,7 +39,9 @@ fn ignore_notype(ty: &TypeSignature) -> Result<TypeSignature, GeneratorError> {
                     .collect::<Result<Vec<_>, _>>()?,
             )
             .map_err(|_| {
-                GeneratorError::TypeError("cannot initialize new tuple for ignore_notype".to_owned())
+                GeneratorError::TypeError(
+                    "cannot initialize new tuple for ignore_notype".to_owned(),
+                )
             })?,
         ),
         NoType => IntType,

--- a/clar2wasm/src/words/print.rs
+++ b/clar2wasm/src/words/print.rs
@@ -1,3 +1,4 @@
+use clarity::vm::types::{ListTypeData, SequenceSubtype, TupleTypeSignature, TypeSignature};
 use clarity::vm::{ClarityName, SymbolicExpression};
 use walrus::ValType;
 
@@ -6,6 +7,38 @@ use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 
 #[derive(Debug)]
 pub struct Print;
+
+/// Replace `NoType`s in `ty` with a `IntType` proxy
+fn ignore_notype(ty: &TypeSignature) -> TypeSignature {
+    use clarity::vm::types::signatures::TypeSignature::*;
+    match ty {
+        ResponseType(types) => {
+            ResponseType(Box::new((ignore_notype(&types.0), ignore_notype(&types.1))))
+        }
+        OptionalType(value_ty) => OptionalType(Box::new(ignore_notype(value_ty))),
+        SequenceType(SequenceSubtype::ListType(list_ty)) => {
+            SequenceType(SequenceSubtype::ListType(
+                ListTypeData::new_list(
+                    ignore_notype(list_ty.get_list_item_type()),
+                    list_ty.get_max_len(),
+                )
+                .unwrap(),
+            ))
+        }
+        TupleType(tuple_ty) => TupleType(
+            TupleTypeSignature::try_from(
+                tuple_ty
+                    .get_type_map()
+                    .iter()
+                    .map(|(k, v)| (k.clone(), ignore_notype(v)))
+                    .collect::<Vec<_>>(),
+            )
+            .unwrap(),
+        ),
+        NoType => IntType,
+        t => t.clone(),
+    }
+}
 
 impl ComplexWord for Print {
     fn name(&self) -> ClarityName {
@@ -41,17 +74,16 @@ impl ComplexWord for Print {
             .global_get(generator.stack_pointer)
             .local_set(offset);
 
-        let ty = generator
-            .get_expr_type(value)
-            .ok_or_else(|| {
-                GeneratorError::TypeError("print value expression must be typed".to_owned())
-            })?
-            .clone();
-
         // Push the value back onto the data stack
         for val_local in &val_locals {
             builder.local_get(*val_local);
         }
+
+        generator.ensure_work_space(ignore_notype(&ty).max_serialized_size().map_err(|_| {
+            GeneratorError::TypeError(
+                "cannot determine serialized expression max size to print value".to_owned(),
+            )
+        })?);
 
         // Write the serialized value to the top of the call stack
         generator.serialize_to_memory(builder, offset, 0, &ty)?;
@@ -72,5 +104,33 @@ impl ComplexWord for Print {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clarity::vm::Value;
+
+    use crate::tools::{crosscheck, crosscheck_compare_only};
+
+    #[test]
+    fn test_empty_list() {
+        crosscheck_compare_only("(print (list))");
+    }
+
+    #[test]
+    fn test_complex_notype() {
+        crosscheck_compare_only("(print { a: (list), b: (list none), c: (err 1) })");
+    }
+
+    #[test]
+    fn test_large_buff() {
+        let msg = "a".repeat(1 << 20);
+        crosscheck(
+            &format!(r#"(print "{msg}")"#),
+            Ok(Some(
+                Value::string_ascii_from_bytes(msg.into_bytes()).unwrap(),
+            )),
+        );
     }
 }

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -15,6 +15,7 @@ pub mod hashing;
 pub mod maps;
 pub mod noop;
 pub mod optional;
+pub mod print;
 pub mod regression;
 pub mod response;
 pub mod secp256k1;

--- a/clar2wasm/tests/wasm-generation/print.rs
+++ b/clar2wasm/tests/wasm-generation/print.rs
@@ -1,0 +1,16 @@
+use clar2wasm::tools::crosscheck;
+use proptest::proptest;
+
+use crate::PropValue;
+
+proptest! {
+    #![proptest_config(super::runtime_config())]
+
+    #[test]
+    fn print_any(val in PropValue::any()) {
+        crosscheck(
+            &format!("(print {val})"),
+            Ok(Some(val.into()))
+        );
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/stacks-network/clarity-wasm/issues/407.

Allocate some work space for the serialized print. We need to replace the `NoType`s in the type signature in order to get its `max_serialized_size`.