### PR TITLE
Allocate enough stack space for output in `map`

### DIFF
--- a/clar2wasm/src/words/print.rs
+++ b/clar2wasm/src/words/print.rs
@@ -140,7 +140,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "see issue #411"]
     fn test_large_serialization() {
         // `(list 162141 (string-ascii 0))` results in >1MB serialization (1_310_710)
         let n = 262141;

--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -2008,6 +2008,17 @@ mod tests {
     }
 
     #[test]
+    fn map_repeated() {
+        crosscheck(
+            &"(map + (list 1 2 3) (list 1 2 3) (list 1 2 3))".repeat(700),
+            Ok(Some(
+                Value::cons_list_unsanitized(vec![Value::Int(3), Value::Int(6), Value::Int(9)])
+                    .unwrap(),
+            )),
+        );
+    }
+
+    #[test]
     fn map_large_result() {
         let n = 65535; // max legal `(list <size> uint)` size
         let buf = (0..n)


### PR DESCRIPTION
Fix https://github.com/stacks-network/clarity-wasm/issues/411.

Allocate enough space for the (worst case) output type size.