### PR TITLE
Add events crosscheck

### DIFF
--- a/clar2wasm/tests/wasm-generation/print.rs
+++ b/clar2wasm/tests/wasm-generation/print.rs
@@ -1,4 +1,4 @@
-use clar2wasm::tools::crosscheck;
+use clar2wasm::tools::crosscheck_with_events;
 use proptest::proptest;
 
 use crate::PropValue;
@@ -8,7 +8,7 @@ proptest! {
 
     #[test]
     fn print_any(val in PropValue::any()) {
-        crosscheck(
+        crosscheck_with_events(
             &format!("(print {val})"),
             Ok(Some(val.into()))
         );


### PR DESCRIPTION
Add a crosscheck variation checking also the emitted events (first step for https://github.com/stacks-network/clarity-wasm/issues/398).

I've added a separate crosscheck for now to avoid overlapping with https://github.com/stacks-network/clarity-wasm/pull/498. 
Once both are merged we can add the events check directly in the usual crosschecks (and remove the variant introduced here), closing https://github.com/stacks-network/clarity-wasm/issues/398.

Events are compared using their serialized representation, as the interpreted clarity can emit arbitrary `Value`s -- eg `CallableType`s -- that may not have a sip5 specific representation -- eg they are coerced to contract principal. See `words::traits::tests::trait_list` for an example of this (in particular, we are talking about the `print` event, not the returned value issue fixed in https://github.com/stacks-network/clarity-wasm/pull/499; the changes in `crosscheck_multi_contract` in this PR applies to that test).
Please lmk if this way of comparing events sounds good :)