### PR TITLE
Return runtime error if data var is missing

### DIFF
--- a/clar2wasm/src/words/blockinfo.rs
+++ b/clar2wasm/src/words/blockinfo.rs
@@ -146,6 +146,7 @@ impl ComplexWord for AtBlock {
 #[cfg(test)]
 mod tests {
     use clarity::types::StacksEpochId;
+    use clarity::vm::errors::{CheckErrors, Error};
     use clarity::vm::types::{OptionalData, PrincipalData, TupleData};
     use clarity::vm::Value;
 
@@ -331,23 +332,19 @@ mod tests {
         )
     }
 
-    #[ignore = "see issue: #381"]
     #[test]
     fn at_block_var() {
-        let mut env = TestEnvironment::default();
-        env.advance_chain_tip(1);
-        // Should error, since the data var is not yet defined in block 0
-        let e = env
-            .evaluate(
-                r#"
+        let e = evaluate(
+                "
 (define-data-var data int 1)
-(at-block (unwrap-panic (get-block-info? id-header-hash u0))
-    (var-get data)
-)
-"#,
+(at-block 0xb5e076ab7609c7f8c763b5c571d07aea80b06b41452231b1437370f4964ed66e (var-get data)) ;; block 0
+",
             )
             .unwrap_err();
-        println!("{:?}", e);
+        assert_eq!(
+            e,
+            Error::Unchecked(CheckErrors::NoSuchDataVariable("data".into()))
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes https://github.com/stacks-network/clarity-wasm/issues/381.

Given that we would not be able to distinguish between a data var containing `none` and a missing one, I used a different approach instead of the workarounds suggested in the issue.
Also note that we cannot crosscheck, since the interpreter is happily returning `none` (despite the [docs making this exact example](https://docs.stacks.co/reference/functions#at-block:~:text=(at%2Dblock%20(get%2Dblock%2Dinfo%3F%20id%2Dheader%2Dhash%200)%20(var%2Dget%20data))) and stating it would throw).

Also changed the test since for v3 we should use `get-stacks-block-info`, but this one is still not implemented.