### PR TITLE
Add events comparison to all the crosschecks

### DIFF
--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -315,7 +315,6 @@ pub fn evaluate_at_with_amount(
 
 /// Evaluate a Clarity snippet at the latest epoch and clarity version.
 /// Returns an optional value -- the result of the evaluation.
-#[allow(clippy::result_unit_err)]
 pub fn evaluate(snippet: &str) -> Result<Option<Value>, Error> {
     evaluate_at(snippet, StacksEpochId::latest(), ClarityVersion::latest())
 }
@@ -346,7 +345,6 @@ pub fn interpret_at_with_amount(
 
 /// Interprets a Clarity snippet at the latest epoch and clarity version.
 /// Returns an optional value -- the result of the evaluation.
-#[allow(clippy::result_unit_err)]
 pub fn interpret(snippet: &str) -> Result<Option<Value>, Error> {
     interpret_at(snippet, StacksEpochId::latest(), ClarityVersion::latest())
 }
@@ -370,60 +368,74 @@ impl TestConfig {
     }
 }
 
+struct CrossEvalResult {
+    env_interpreted: TestEnvironment,
+    interpreted: Result<Option<Value>, Error>,
+
+    env_compiled: TestEnvironment,
+    compiled: Result<Option<Value>, Error>,
+}
+
+impl CrossEvalResult {
+    fn compare(&self, snippet: &str) {
+        assert_eq!(
+            self.compiled, self.interpreted,
+            "Compiled and interpreted results diverge! {snippet}\ncompiled: {:?}\ninterpreted: {:?}",
+            self.compiled, self.interpreted
+        );
+        compare_events(
+            self.env_interpreted.get_events(),
+            self.env_compiled.get_events(),
+        );
+    }
+}
+
+fn crosseval(snippet: &str, env: TestEnvironment) -> CrossEvalResult {
+    let mut env_interpreted = env.clone();
+    let interpreted = env_interpreted.interpret(snippet);
+
+    let mut env_compiled = env;
+    let compiled = env_compiled.evaluate(snippet);
+
+    CrossEvalResult {
+        env_interpreted,
+        env_compiled,
+        interpreted,
+        compiled,
+    }
+}
+
 pub fn crosscheck(snippet: &str, expected: Result<Option<Value>, Error>) {
-    let compiled = evaluate_at(
+    let eval = crosseval(
         snippet,
-        TestConfig::latest_epoch(),
-        TestConfig::clarity_version(),
+        TestEnvironment::new(TestConfig::latest_epoch(), TestConfig::clarity_version()),
     );
 
-    let interpreted = interpret_at(
-        snippet,
-        TestConfig::latest_epoch(),
-        TestConfig::clarity_version(),
-    );
+    eval.compare(snippet);
 
     assert_eq!(
-        compiled, interpreted,
-        "Compiled and interpreted results diverge!\ncompiled: {:?}\ninterpreted: {:?}",
-        &compiled, &interpreted
-    );
-
-    assert_eq!(
-        compiled, expected,
+        eval.compiled, expected,
         "value is not the expected {:?}",
-        compiled
+        eval.compiled
     );
 }
 
-pub fn crosscheck_with_amount(snippet: &str, amount: u128, expected: Result<Option<Value>, ()>) {
-    let compiled = evaluate_at_with_amount(
+pub fn crosscheck_with_amount(snippet: &str, amount: u128, expected: Result<Option<Value>, Error>) {
+    let eval = crosseval(
         snippet,
-        amount,
-        TestConfig::latest_epoch(),
-        TestConfig::clarity_version(),
+        TestEnvironment::new_with_amount(
+            amount,
+            TestConfig::latest_epoch(),
+            TestConfig::clarity_version(),
+        ),
     );
 
-    let interpreted = interpret_at_with_amount(
-        snippet,
-        amount,
-        TestConfig::latest_epoch(),
-        TestConfig::clarity_version(),
-    );
+    eval.compare(snippet);
 
     assert_eq!(
-        compiled.as_ref().map_err(|_| &()),
-        interpreted.as_ref().map_err(|_| &()),
-        "Compiled and interpreted results diverge!\ncompiled: {:?}\ninterpreted: {:?}",
-        &compiled,
-        &interpreted
-    );
-
-    assert_eq!(
-        compiled.as_ref().map_err(|_| &()),
-        expected.as_ref(),
+        eval.compiled, expected,
         "value is not the expected {:?}",
-        compiled
+        eval.compiled
     );
 }
 
@@ -431,55 +443,45 @@ pub fn crosscheck_compare_only(snippet: &str) {
     // to avoid false positives when both the compiled and interpreted fail,
     // we don't allow failures in these tests
 
-    // Note that we interpret first, to catch logical errors early
-
-    let interpreted = interpret(snippet).expect("Interpreted snippet failed");
-    let compiled = evaluate(snippet).expect("Compiled snippet failed");
-
-    assert_eq!(
-        compiled, interpreted,
-        "Compiled and interpreted results diverge! {}\ncompiled: {:?}\ninterpreted: {:?}",
-        snippet, &compiled, &interpreted
+    let eval = crosseval(
+        snippet,
+        TestEnvironment::new(TestConfig::latest_epoch(), TestConfig::clarity_version()),
     );
+
+    // Note that we interpret first, to catch logical errors early
+    assert!(eval.interpreted.is_ok(), "Interpreted snippet failed");
+    assert!(eval.compiled.is_ok(), "Compiled snippet failed");
+
+    eval.compare(snippet);
 }
 
 pub fn crosscheck_compare_only_with_expected_error<E: Fn(&Error) -> bool>(
     snippet: &str,
     expected: E,
 ) {
-    let compiled = evaluate(snippet);
-    let interpreted = interpret(snippet);
+    let eval = crosseval(
+        snippet,
+        TestEnvironment::new(TestConfig::latest_epoch(), TestConfig::clarity_version()),
+    );
 
-    if let Err(e) = &compiled {
+    if let Err(e) = &eval.compiled {
         if !expected(e) {
             panic!("Compiled snippet failed with unexpected error: {:?}", e);
         }
     }
 
-    assert_eq!(
-        compiled, interpreted,
-        "Compiled and interpreted results diverge! {}\ncompiled: {:?}\ninterpreted: {:?}",
-        snippet, &compiled, &interpreted
-    );
+    eval.compare(snippet);
 }
 
 /// Advance the block height to `count`, and uses identical TestEnvironment copies
 /// to assert the results of a contract snippet running against the compiler and the interpreter.
 pub fn crosscheck_compare_only_advancing_tip(snippet: &str, count: u32) {
-    let mut compiler_env =
-        TestEnvironment::new(TestConfig::latest_epoch(), TestConfig::clarity_version());
-    compiler_env.advance_chain_tip(count);
+    let mut env = TestEnvironment::new(TestConfig::latest_epoch(), TestConfig::clarity_version());
+    env.advance_chain_tip(count);
 
-    let mut interpreter_env = compiler_env.clone();
+    let eval = crosseval(snippet, env);
 
-    let compiled = compiler_env.evaluate(snippet).map_err(|_| ());
-    let interpreted = interpreter_env.interpret(snippet).map_err(|_| ());
-
-    assert_eq!(
-        compiled, interpreted,
-        "Compiled and interpreted results diverge! {}\ncompiled: {:?}\ninterpreted: {:?}",
-        snippet, &compiled, &interpreted
-    );
+    eval.compare(snippet);
 }
 
 pub fn crosscheck_with_epoch(
@@ -487,43 +489,29 @@ pub fn crosscheck_with_epoch(
     expected: Result<Option<Value>, Error>,
     epoch: StacksEpochId,
 ) {
-    let clarity_version = ClarityVersion::default_for_epoch(epoch);
-    let compiled = evaluate_at(snippet, epoch, clarity_version);
-    let interpreted = interpret_at(snippet, epoch, clarity_version);
-
-    assert_eq!(
-        compiled, interpreted,
-        "Compiled and interpreted results diverge!\ncompiled: {:?}\ninterpreted: {:?}",
-        &compiled, &interpreted
+    let eval = crosseval(
+        snippet,
+        TestEnvironment::new(epoch, ClarityVersion::default_for_epoch(epoch)),
     );
 
+    eval.compare(snippet);
+
     assert_eq!(
-        compiled, expected,
+        eval.compiled, expected,
         "value is not the expected {:?}",
-        compiled
+        eval.compiled
     );
 }
 
 pub fn crosscheck_validate<V: Fn(Value)>(snippet: &str, validator: V) {
-    let compiled = evaluate_at(
+    let eval = crosseval(
         snippet,
-        TestConfig::latest_epoch(),
-        TestConfig::clarity_version(),
+        TestEnvironment::new(TestConfig::latest_epoch(), TestConfig::clarity_version()),
     );
 
-    let interpreted = interpret_at(
-        snippet,
-        TestConfig::latest_epoch(),
-        TestConfig::clarity_version(),
-    );
+    eval.compare(snippet);
 
-    assert_eq!(
-        compiled, interpreted,
-        "Compiled and interpreted results diverge! {}\ncompiled: {:?}\ninterpreted: {:?}",
-        snippet, &compiled, &interpreted
-    );
-
-    let value = compiled.unwrap().unwrap();
+    let value = eval.compiled.unwrap().unwrap();
     validator(value)
 }
 
@@ -583,34 +571,6 @@ pub fn crosscheck_expect_failure(snippet: &str) {
         snippet,
         &compiled,
         &interpreted
-    );
-}
-
-// TODO: add compare_events to regular crosscheck instead of having this separate function
-pub fn crosscheck_with_events(snippet: &str, expected: Result<Option<Value>, Error>) {
-    let epoch = StacksEpochId::latest();
-    let version = ClarityVersion::latest();
-
-    let mut env_interpreted = TestEnvironment::new(epoch, version);
-    let interpreted = env_interpreted.interpret(snippet);
-
-    let mut env_compiled = TestEnvironment::new(epoch, version);
-    let compiled = env_compiled.evaluate(snippet);
-
-    assert_eq!(
-        compiled, interpreted,
-        "Compiled and interpreted results diverge!\ncompiled: {:?}\ninterpreted: {:?}",
-        &compiled, &interpreted
-    );
-
-    if compiled.is_ok() {
-        compare_events(env_interpreted.get_events(), env_compiled.get_events());
-    }
-
-    assert_eq!(
-        compiled, expected,
-        "value is not the expected {:?}",
-        compiled
     );
 }
 

--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -618,3 +618,42 @@ fn compare_events(events_a: &[EventBatch], events_b: &[EventBatch]) {
 fn test_evaluate_snippet() {
     assert_eq!(evaluate("(+ 1 2)"), Ok(Some(Value::Int(3))));
 }
+
+#[test]
+fn test_compare_events() {
+    let env = TestEnvironment::new(TestConfig::latest_epoch(), TestConfig::clarity_version());
+
+    let mut env_interpreted = env.clone();
+    let interpreted = env_interpreted.interpret("(stx-transfer-memo? u1 'S1G2081040G2081040G2081040G208105NK8PE5 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM 0x010203)");
+
+    let mut env_compiled = env;
+    let compiled = env_compiled.evaluate("(stx-transfer-memo? u1 'S1G2081040G2081040G2081040G208105NK8PE5 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM 0x010203)");
+
+    CrossEvalResult {
+        env_interpreted,
+        env_compiled,
+        interpreted,
+        compiled,
+    }
+    .compare("");
+}
+
+#[test]
+#[should_panic(expected = "events mismatch")]
+fn test_compare_events_mismatch() {
+    let env = TestEnvironment::new(TestConfig::latest_epoch(), TestConfig::clarity_version());
+
+    let mut env_interpreted = env.clone();
+    let interpreted = env_interpreted.interpret("(stx-transfer-memo? u1 'S1G2081040G2081040G2081040G208105NK8PE5 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM 0x010203)");
+
+    let mut env_compiled = env;
+    let compiled = env_compiled.evaluate("(stx-transfer-memo? u1 'S1G2081040G2081040G2081040G208105NK8PE5 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM 0x0102FF)"); // different memo
+
+    CrossEvalResult {
+        env_interpreted,
+        env_compiled,
+        interpreted,
+        compiled,
+    }
+    .compare("");
+}

--- a/clar2wasm/src/words/print.rs
+++ b/clar2wasm/src/words/print.rs
@@ -128,11 +128,11 @@ mod tests {
     use clarity::vm::types::{ListTypeData, TupleData};
     use clarity::vm::Value;
 
-    use crate::tools::crosscheck_with_events;
+    use crate::tools::crosscheck;
 
     #[test]
     fn test_simple() {
-        crosscheck_with_events("(print 42)", Ok(Some(Value::Int(42))));
+        crosscheck("(print 42)", Ok(Some(Value::Int(42))));
     }
 
     #[test]
@@ -158,7 +158,7 @@ mod tests {
 
     #[test]
     fn test_empty_list() {
-        crosscheck_with_events(
+        crosscheck(
             "(print (list))",
             Ok(Some(
                 Value::list_with_type(
@@ -181,7 +181,7 @@ mod tests {
         .unwrap();
         let none_list = Value::cons_list(vec![Value::none()], &StacksEpochId::latest()).unwrap();
         let err = Value::err_uint(1);
-        crosscheck_with_events(
+        crosscheck(
             "(print { a: (list), b: (list none), c: (err u1) })",
             Ok(Some(Value::Tuple(
                 TupleData::from_data(vec![
@@ -197,7 +197,7 @@ mod tests {
     #[test]
     fn test_large_buff() {
         let msg = "a".repeat(1 << 20);
-        crosscheck_with_events(
+        crosscheck(
             &format!(r#"(print "{msg}")"#),
             Ok(Some(
                 Value::string_ascii_from_bytes(msg.into_bytes()).unwrap(),
@@ -209,7 +209,7 @@ mod tests {
     fn test_large_serialization() {
         // `(list 162141 (string-ascii 0))` results in >1MB serialization (1_310_710)
         let n = 262141;
-        crosscheck_with_events(
+        crosscheck(
             &format!(
                 r#"
 (define-private (foo (a (string-ascii 1))) "")

--- a/clar2wasm/tests/wasm-generation/blockinfo.rs
+++ b/clar2wasm/tests/wasm-generation/blockinfo.rs
@@ -15,13 +15,37 @@ const BURN_BLOCK_INFO: [&str; 2] = ["header-hash", "pox-addrs"];
 const STACKS_BLOCK_HEIGHT_LIMIT: u32 = 100;
 const BURN_BLOCK_HEIGHT_LIMIT: u32 = 100;
 
-proptest! {
-    #![proptest_config(super::runtime_config())]
+#[cfg(any(feature = "test-clarity-v1", feature = "test-clarity-v2"))]
+mod clarity_v1_v2 {
+    use super::*;
+    use crate::runtime_config;
 
-    #[test]
-    fn crossprop_blockinfo_within_controlled_range(block_height in 1..=STACKS_BLOCK_HEIGHT_LIMIT, tip in 1..=80u32) {
-        for info in &BLOCK_INFO {
-            crosscheck_compare_only_advancing_tip(&format!("(get-block-info? {info} u{block_height})"), tip)
+    proptest! {
+        #![proptest_config(runtime_config())]
+
+        #[test]
+        fn crossprop_blockinfo_within_controlled_range(block_height in 1..=STACKS_BLOCK_HEIGHT_LIMIT, tip in 1..=80u32) {
+            for info in &BLOCK_INFO {
+                crosscheck_compare_only_advancing_tip(&format!("(get-block-info? {info} u{block_height})"), tip)
+            }
+        }
+    }
+}
+
+#[cfg(not(any(feature = "test-clarity-v1", feature = "test-clarity-v2")))]
+mod clarity_v3 {
+    use super::*;
+    use crate::runtime_config;
+
+    proptest! {
+        #![proptest_config(runtime_config())]
+
+        #[ignore = "see issue #428"]
+        #[test]
+        fn crossprop_blockinfo_within_controlled_range(block_height in 1..=STACKS_BLOCK_HEIGHT_LIMIT, tip in 1..=80u32) {
+            for info in &BLOCK_INFO {
+                crosscheck_compare_only_advancing_tip(&format!("(get-stacks-block-info? {info} u{block_height})"), tip)
+            }
         }
     }
 }

--- a/clar2wasm/tests/wasm-generation/print.rs
+++ b/clar2wasm/tests/wasm-generation/print.rs
@@ -1,4 +1,4 @@
-use clar2wasm::tools::crosscheck_with_events;
+use clar2wasm::tools::crosscheck;
 use proptest::proptest;
 
 use crate::PropValue;
@@ -8,7 +8,7 @@ proptest! {
 
     #[test]
     fn print_any(val in PropValue::any()) {
-        crosscheck_with_events(
+        crosscheck(
             &format!("(print {val})"),
             Ok(Some(val.into()))
         );

--- a/clar2wasm/tests/wasm-generation/stx.rs
+++ b/clar2wasm/tests/wasm-generation/stx.rs
@@ -115,8 +115,6 @@ proptest! {
             .unwrap(),
         );
 
-        // TODO: check for the correct memo in the events (issue #398)
-
         crosscheck_with_amount(&snippet, amount, Ok(Some(expected)));
     }
 }


### PR DESCRIPTION
Address https://github.com/stacks-network/clarity-wasm/issues/398.

Add events comparison to all the crosschecks. To avoid duplication I've done a small refactoring of the `crosscheck*` scaffolding (and removed the now obsolete `crosscheck_with_events`).

During the refactoring I've removed the error remapping logic since (I guess) it wasn't needed anymore, and in doing so an issue with a not version gated `get-block-info?` test surfaced: it was removed in v3, but we don't support the `get-stacks-block-info?` replacement yet.