### PR TITLE
Add missing clarity v1 feature gate in tests

### DIFF
--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -623,6 +623,7 @@ fn test_evaluate_snippet() {
     assert_eq!(evaluate("(+ 1 2)"), Ok(Some(Value::Int(3))));
 }
 
+#[cfg(not(feature = "test-clarity-v1"))]
 #[test]
 fn test_compare_events() {
     let env = TestEnvironment::new(TestConfig::latest_epoch(), TestConfig::clarity_version());
@@ -642,6 +643,7 @@ fn test_compare_events() {
     .compare("");
 }
 
+#[cfg(not(feature = "test-clarity-v1"))]
 #[test]
 #[should_panic(expected = "events mismatch")]
 fn test_compare_events_mismatch() {

--- a/clar2wasm/tests/wasm-generation/bitwise.rs
+++ b/clar2wasm/tests/wasm-generation/bitwise.rs
@@ -1,110 +1,114 @@
-use clar2wasm::tools::crosscheck_compare_only;
-use proptest::proptest;
+#[cfg(not(feature = "test-clarity-v1"))]
+#[cfg(test)]
+mod clarity_v2_v3 {
+    use clar2wasm::tools::crosscheck_compare_only;
+    use proptest::proptest;
 
-use crate::{int, uint};
+    use crate::{int, runtime_config, uint};
 
-const ONE_OP: [&str; 1] = ["bit-not"];
-const TWO_OPS: [&str; 2] = ["bit-shift-left", "bit-shift-right"];
-const MULTI_OPS: [&str; 3] = ["bit-and", "bit-or", "bit-xor"];
+    const ONE_OP: [&str; 1] = ["bit-not"];
+    const TWO_OPS: [&str; 2] = ["bit-shift-left", "bit-shift-right"];
+    const MULTI_OPS: [&str; 3] = ["bit-and", "bit-or", "bit-xor"];
 
-proptest! {
-    #![proptest_config(super::runtime_config())]
+    proptest! {
+        #![proptest_config(runtime_config())]
 
-    #[test]
-    fn crossprop_bitwise_one_op_int(val in int()) {
-        for op in &ONE_OP {
+        #[test]
+        fn crossprop_bitwise_one_op_int(val in int()) {
+            for op in &ONE_OP {
+                crosscheck_compare_only(
+                    &format!("({op} {val})")
+                )
+            }
+        }
+    }
+
+    proptest! {
+        #![proptest_config(runtime_config())]
+
+        #[test]
+        fn crossprop_bitwise_one_op_uint(val in uint()) {
+            for op in &ONE_OP {
+                crosscheck_compare_only(
+                    &format!("({op} {val})")
+                )
+            }
+        }
+    }
+
+    proptest! {
+        #![proptest_config(runtime_config())]
+
+        #[test]
+        fn crossprop_bitwise_two_ops(val1 in int(), val2 in uint()) {
+            for op in &TWO_OPS {
+                crosscheck_compare_only(
+                    &format!("({op} {val1} {val2})")
+                )
+            }
+        }
+    }
+
+    proptest! {
+        #![proptest_config(runtime_config())]
+
+        #[test]
+        fn crossprop_bitwise_two_ops_uint(val1 in uint(), val2 in uint()) {
+            for op in &TWO_OPS {
+                crosscheck_compare_only(
+                    &format!("({op} {val1} {val2})")
+                )
+            }
+        }
+    }
+
+    proptest! {
+        #![proptest_config(runtime_config())]
+
+        #[test]
+        fn crossprop_bitwise_multi_ops_int(values in proptest::collection::vec(int(), 1..=10)) {
+            for op in &MULTI_OPS {
+                let values_str = values.iter().map(|v| v.to_string()).collect::<Vec<_>>().join(" ");
+                crosscheck_compare_only(
+                    &format!("({op} {values_str})")
+                )
+            }
+        }
+    }
+
+    proptest! {
+        #![proptest_config(runtime_config())]
+
+        #[test]
+        fn crossprop_bitwise_multi_ops_uint(values in proptest::collection::vec(uint(), 1..=10)) {
+            for op in &MULTI_OPS {
+                let values_str = values.iter().map(|v| v.to_string()).collect::<Vec<_>>().join(" ");
+                crosscheck_compare_only(
+                    &format!("({op} {values_str})")
+                )
+            }
+        }
+    }
+
+    proptest! {
+        #![proptest_config(runtime_config())]
+
+        #[test]
+        fn crossprop_xor_int(val1 in int(), val2 in int()) {
             crosscheck_compare_only(
-                &format!("({op} {val})")
+                &format!("(xor {val1} {val2})")
             )
         }
     }
-}
 
-proptest! {
-    #![proptest_config(super::runtime_config())]
+    proptest! {
+        #![proptest_config(runtime_config())]
 
-    #[test]
-    fn crossprop_bitwise_one_op_uint(val in uint()) {
-        for op in &ONE_OP {
+        #[test]
+        fn crossprop_xor_uint(val1 in uint(), val2 in uint()) {
             crosscheck_compare_only(
-                &format!("({op} {val})")
+                &format!("(xor {val1} {val2})")
             )
         }
-    }
-}
-
-proptest! {
-    #![proptest_config(super::runtime_config())]
-
-    #[test]
-    fn crossprop_bitwise_two_ops(val1 in int(), val2 in uint()) {
-        for op in &TWO_OPS {
-            crosscheck_compare_only(
-                &format!("({op} {val1} {val2})")
-            )
-        }
-    }
-}
-
-proptest! {
-    #![proptest_config(super::runtime_config())]
-
-    #[test]
-    fn crossprop_bitwise_two_ops_uint(val1 in uint(), val2 in uint()) {
-        for op in &TWO_OPS {
-            crosscheck_compare_only(
-                &format!("({op} {val1} {val2})")
-            )
-        }
-    }
-}
-
-proptest! {
-    #![proptest_config(super::runtime_config())]
-
-    #[test]
-    fn crossprop_bitwise_multi_ops_int(values in proptest::collection::vec(int(), 1..=10)) {
-        for op in &MULTI_OPS {
-            let values_str = values.iter().map(|v| v.to_string()).collect::<Vec<_>>().join(" ");
-            crosscheck_compare_only(
-                &format!("({op} {values_str})")
-            )
-        }
-    }
-}
-
-proptest! {
-    #![proptest_config(super::runtime_config())]
-
-    #[test]
-    fn crossprop_bitwise_multi_ops_uint(values in proptest::collection::vec(uint(), 1..=10)) {
-        for op in &MULTI_OPS {
-            let values_str = values.iter().map(|v| v.to_string()).collect::<Vec<_>>().join(" ");
-            crosscheck_compare_only(
-                &format!("({op} {values_str})")
-            )
-        }
-    }
-}
-
-proptest! {
-    #![proptest_config(super::runtime_config())]
-
-    #[test]
-    fn crossprop_xor_int(val1 in int(), val2 in int()) {
-        crosscheck_compare_only(
-            &format!("(xor {val1} {val2})")
-        )
-    }
-}
-
-proptest! {
-    #![proptest_config(super::runtime_config())]
-
-    #[test]
-    fn crossprop_xor_uint(val1 in uint(), val2 in uint()) {
-        crosscheck_compare_only(
-            &format!("(xor {val1} {val2})")
-        )
     }
 }

--- a/clar2wasm/tests/wasm-generation/blockinfo.rs
+++ b/clar2wasm/tests/wasm-generation/blockinfo.rs
@@ -1,22 +1,19 @@
 use clar2wasm::tools::crosscheck_compare_only_advancing_tip;
 use proptest::proptest;
 
-const BLOCK_INFO: [&str; 8] = [
+const BLOCK_INFO_V1: [&str; 5] = [
     "burnchain-header-hash",
     "id-header-hash",
     "header-hash",
     "miner-address",
-    "block-reward",
-    "miner-spend-total",
-    "miner-spend-winner",
     "time",
 ];
-const BURN_BLOCK_INFO: [&str; 2] = ["header-hash", "pox-addrs"];
-const STACKS_BLOCK_HEIGHT_LIMIT: u32 = 100;
-const BURN_BLOCK_HEIGHT_LIMIT: u32 = 100;
+const BLOCK_INFO_V2: [&str; 3] = ["block-reward", "miner-spend-total", "miner-spend-winner"];
 
-#[cfg(any(feature = "test-clarity-v1", feature = "test-clarity-v2"))]
-mod clarity_v1_v2 {
+const STACKS_BLOCK_HEIGHT_LIMIT: u32 = 100;
+
+#[cfg(feature = "test-clarity-v1")]
+mod clarity_v1 {
     use super::*;
     use crate::runtime_config;
 
@@ -25,7 +22,24 @@ mod clarity_v1_v2 {
 
         #[test]
         fn crossprop_blockinfo_within_controlled_range(block_height in 1..=STACKS_BLOCK_HEIGHT_LIMIT, tip in 1..=80u32) {
-            for info in &BLOCK_INFO {
+            for info in &BLOCK_INFO_V1 {
+                crosscheck_compare_only_advancing_tip(&format!("(get-block-info? {info} u{block_height})"), tip)
+            }
+        }
+    }
+}
+
+#[cfg(feature = "test-clarity-v2")]
+mod clarity_v2 {
+    use super::*;
+    use crate::runtime_config;
+
+    proptest! {
+        #![proptest_config(runtime_config())]
+
+        #[test]
+        fn crossprop_blockinfo_within_controlled_range(block_height in 1..=STACKS_BLOCK_HEIGHT_LIMIT, tip in 1..=80u32) {
+            for info in BLOCK_INFO_V1.iter().chain(BLOCK_INFO_V2.iter()) {
                 crosscheck_compare_only_advancing_tip(&format!("(get-block-info? {info} u{block_height})"), tip)
             }
         }
@@ -43,22 +57,31 @@ mod clarity_v3 {
         #[ignore = "see issue #428"]
         #[test]
         fn crossprop_blockinfo_within_controlled_range(block_height in 1..=STACKS_BLOCK_HEIGHT_LIMIT, tip in 1..=80u32) {
-            for info in &BLOCK_INFO {
+            for info in BLOCK_INFO_V1.iter().chain(BLOCK_INFO_V2.iter()) {
                 crosscheck_compare_only_advancing_tip(&format!("(get-stacks-block-info? {info} u{block_height})"), tip)
             }
         }
     }
 }
 
-proptest! {
-    #![proptest_config(super::runtime_config())]
+#[cfg(not(feature = "test-clarity-v1"))]
+mod clarity_v2_v3 {
+    use super::*;
+    use crate::runtime_config;
 
-    # [test]
-    fn crossprop_blockinfo_burnchain_within_controlled_range(block_height in 1..=BURN_BLOCK_HEIGHT_LIMIT, tip in 1..=80u32) {
-        for info in &BURN_BLOCK_INFO {
-            crosscheck_compare_only_advancing_tip(
-                &format!("(get-burn-block-info? {info} u{block_height})"), tip
-            )
+    const BURN_BLOCK_INFO: [&str; 2] = ["header-hash", "pox-addrs"];
+    const BURN_BLOCK_HEIGHT_LIMIT: u32 = 100;
+
+    proptest! {
+        #![proptest_config(runtime_config())]
+
+        # [test]
+        fn crossprop_blockinfo_burnchain_within_controlled_range(block_height in 1..=BURN_BLOCK_HEIGHT_LIMIT, tip in 1..=80u32) {
+            for info in &BURN_BLOCK_INFO {
+                crosscheck_compare_only_advancing_tip(
+                    &format!("(get-burn-block-info? {info} u{block_height})"), tip
+                )
+            }
         }
     }
 }

--- a/clar2wasm/tests/wasm-generation/comparison.rs
+++ b/clar2wasm/tests/wasm-generation/comparison.rs
@@ -1,5 +1,7 @@
 use clar2wasm::tools::crosscheck_compare_only;
-use clarity::vm::types::{SequenceSubtype, StringSubtype, TypeSignature};
+use clarity::vm::types::TypeSignature;
+#[cfg(not(feature = "test-clarity-v1"))]
+use clarity::vm::types::{SequenceSubtype, StringSubtype};
 use proptest::strategy::{Just, Strategy};
 use proptest::{prop_oneof, proptest};
 
@@ -7,6 +9,12 @@ use crate::PropValue;
 
 const COMPARISONS_FUNC: [&str; 4] = ["<", "<=", ">", ">="];
 
+#[cfg(feature = "test-clarity-v1")]
+fn strategies_for_comparison() -> impl Strategy<Value = TypeSignature> {
+    prop_oneof![Just(TypeSignature::IntType), Just(TypeSignature::UIntType),]
+}
+
+#[cfg(not(feature = "test-clarity-v1"))]
 fn strategies_for_comparison() -> impl Strategy<Value = TypeSignature> {
     prop_oneof![
         Just(TypeSignature::IntType),

--- a/clar2wasm/tests/wasm-generation/stx.rs
+++ b/clar2wasm/tests/wasm-generation/stx.rs
@@ -3,7 +3,9 @@ use clarity::vm::types::{TupleData, TypeSignature};
 use clarity::vm::{ClarityName, Value};
 use proptest::prelude::*;
 
-use crate::{buffer, PropValue};
+#[cfg(not(feature = "test-clarity-v1"))]
+use crate::buffer;
+use crate::PropValue;
 
 proptest! {
     #![proptest_config(super::runtime_config())]
@@ -78,6 +80,7 @@ proptest! {
         crosscheck_with_amount(&snippet, amount, Ok(Some(expected)));
     }
 
+    #[cfg(not(feature = "test-clarity-v1"))]
     #[test]
     fn stx_balance_transfermemo_balance(
         amount in any::<u128>(),


### PR DESCRIPTION
This add some missing feature gates for clarity v1 tests. For some reason GH messes up the diff for `bitwise.rs`, consider hiding whitespaces for the review.

The v1 tests are still flaky because of `crosscheck_index_of` (https://github.com/stacks-network/clarity-wasm/issues/496, https://github.com/stacks-network/clarity-wasm/issues/503) and `tokens::nft_mint*` (https://github.com/stacks-network/clarity-wasm/issues/515).