### PR TITLE
Ignore the list of qualified principal in tests

### DIFF
--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -732,14 +732,19 @@ pub fn crosscheck_with_network(
     snippet: &str,
     expected: Result<Option<Value>, Error>,
 ) {
-    let eval = crosseval(
+    let eval = match crosseval(
         snippet,
         TestEnvironment::new_with_network(
             TestConfig::latest_epoch(),
             TestConfig::clarity_version(),
             network,
         ),
-    );
+    ) {
+        Ok(result) => result,
+        Err(_bug) => {
+            return;
+        }
+    };
 
     eval.compare(snippet);
 

--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -668,48 +668,55 @@ pub fn crosscheck_with_network(
         eval.compiled
     );
 }
-#[test]
-fn test_evaluate_snippet() {
-    assert_eq!(evaluate("(+ 1 2)"), Ok(Some(Value::Int(3))));
-}
 
-#[cfg(not(feature = "test-clarity-v1"))]
-#[test]
-fn test_compare_events() {
-    let env = TestEnvironment::new(TestConfig::latest_epoch(), TestConfig::clarity_version());
+#[cfg(test)]
+mod tests {
 
-    let mut env_interpreted = env.clone();
-    let interpreted = env_interpreted.interpret("(stx-transfer-memo? u1 'S1G2081040G2081040G2081040G208105NK8PE5 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM 0x010203)");
+    use super::*;
 
-    let mut env_compiled = env;
-    let compiled = env_compiled.evaluate("(stx-transfer-memo? u1 'S1G2081040G2081040G2081040G208105NK8PE5 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM 0x010203)");
-
-    CrossEvalResult {
-        env_interpreted,
-        env_compiled,
-        interpreted,
-        compiled,
+    #[test]
+    fn test_evaluate_snippet() {
+        assert_eq!(evaluate("(+ 1 2)"), Ok(Some(Value::Int(3))));
     }
-    .compare("");
-}
 
-#[cfg(not(feature = "test-clarity-v1"))]
-#[test]
-#[should_panic(expected = "events mismatch")]
-fn test_compare_events_mismatch() {
-    let env = TestEnvironment::new(TestConfig::latest_epoch(), TestConfig::clarity_version());
+    #[cfg(not(feature = "test-clarity-v1"))]
+    #[test]
+    fn test_compare_events() {
+        let env = TestEnvironment::new(TestConfig::latest_epoch(), TestConfig::clarity_version());
 
-    let mut env_interpreted = env.clone();
-    let interpreted = env_interpreted.interpret("(stx-transfer-memo? u1 'S1G2081040G2081040G2081040G208105NK8PE5 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM 0x010203)");
+        let mut env_interpreted = env.clone();
+        let interpreted = env_interpreted.interpret("(stx-transfer-memo? u1 'S1G2081040G2081040G2081040G208105NK8PE5 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM 0x010203)");
 
-    let mut env_compiled = env;
-    let compiled = env_compiled.evaluate("(stx-transfer-memo? u1 'S1G2081040G2081040G2081040G208105NK8PE5 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM 0x0102FF)"); // different memo
+        let mut env_compiled = env;
+        let compiled = env_compiled.evaluate("(stx-transfer-memo? u1 'S1G2081040G2081040G2081040G208105NK8PE5 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM 0x010203)");
 
-    CrossEvalResult {
-        env_interpreted,
-        env_compiled,
-        interpreted,
-        compiled,
+        CrossEvalResult {
+            env_interpreted,
+            env_compiled,
+            interpreted,
+            compiled,
+        }
+        .compare("");
     }
-    .compare("");
+
+    #[cfg(not(feature = "test-clarity-v1"))]
+    #[test]
+    #[should_panic(expected = "events mismatch")]
+    fn test_compare_events_mismatch() {
+        let env = TestEnvironment::new(TestConfig::latest_epoch(), TestConfig::clarity_version());
+
+        let mut env_interpreted = env.clone();
+        let interpreted = env_interpreted.interpret("(stx-transfer-memo? u1 'S1G2081040G2081040G2081040G208105NK8PE5 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM 0x010203)");
+
+        let mut env_compiled = env;
+        let compiled = env_compiled.evaluate("(stx-transfer-memo? u1 'S1G2081040G2081040G2081040G208105NK8PE5 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM 0x0102FF)"); // different memo
+
+        CrossEvalResult {
+            env_interpreted,
+            env_compiled,
+            interpreted,
+            compiled,
+        }
+        .compare("");
+    }
 }

--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -478,8 +478,7 @@ pub fn crosscheck(snippet: &str, expected: Result<Option<Value>, Error>) {
         TestEnvironment::new(TestConfig::latest_epoch(), TestConfig::clarity_version()),
     ) {
         Ok(result) => result,
-        Err(bug) => {
-            println!("KNOW BUG TRIGGERED <{bug:?}>:\n\t{snippet}");
+        Err(_bug) => {
             return;
         }
     };
@@ -503,8 +502,7 @@ pub fn crosscheck_with_amount(snippet: &str, amount: u128, expected: Result<Opti
         ),
     ) {
         Ok(result) => result,
-        Err(bug) => {
-            println!("KNOW BUG TRIGGERED <{bug:?}>:\n\t{snippet}");
+        Err(_bug) => {
             return;
         }
     };
@@ -527,8 +525,7 @@ pub fn crosscheck_compare_only(snippet: &str) {
         TestEnvironment::new(TestConfig::latest_epoch(), TestConfig::clarity_version()),
     ) {
         Ok(result) => result,
-        Err(bug) => {
-            println!("KNOW BUG TRIGGERED <{bug:?}>:\n\t{snippet}");
+        Err(_bug) => {
             return;
         }
     };
@@ -549,8 +546,7 @@ pub fn crosscheck_compare_only_with_expected_error<E: Fn(&Error) -> bool>(
         TestEnvironment::new(TestConfig::latest_epoch(), TestConfig::clarity_version()),
     ) {
         Ok(result) => result,
-        Err(bug) => {
-            println!("KNOW BUG TRIGGERED <{bug:?}>:\n\t{snippet}");
+        Err(_bug) => {
             return;
         }
     };
@@ -572,8 +568,7 @@ pub fn crosscheck_compare_only_advancing_tip(snippet: &str, count: u32) {
 
     let eval = match crosseval(snippet, env) {
         Ok(result) => result,
-        Err(bug) => {
-            println!("KNOW BUG TRIGGERED <{bug:?}>:\n\t{snippet}");
+        Err(_bug) => {
             return;
         }
     };
@@ -591,8 +586,7 @@ pub fn crosscheck_with_epoch(
         TestEnvironment::new(epoch, ClarityVersion::default_for_epoch(epoch)),
     ) {
         Ok(result) => result,
-        Err(bug) => {
-            println!("KNOW BUG TRIGGERED <{bug:?}>:\n\t{snippet}");
+        Err(_bug) => {
             return;
         }
     };
@@ -612,8 +606,7 @@ pub fn crosscheck_validate<V: Fn(Value)>(snippet: &str, validator: V) {
         TestEnvironment::new(TestConfig::latest_epoch(), TestConfig::clarity_version()),
     ) {
         Ok(result) => result,
-        Err(bug) => {
-            println!("KNOW BUG TRIGGERED <{bug:?}>:\n\t{snippet}");
+        Err(_bug) => {
             return;
         }
     };

--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -805,17 +805,15 @@ mod tests {
     fn detect_list_of_qualified_principal_issue() {
         let snippet_simple = r#"(index-of (list (some 'S53AR76V04QBY9CKZFQZ6FZF0730CEQS2AH761HTX.FoUtMZdXvouVYyvtvceMcRGotjQlzb)) (some 'S53AR76V04QBY9CKZFQZ6FZF0730CEQS2AH761HTX.FoUtMZdXvouVYyvtvceMcRGotjQlzb))"#;
 
-        if let Err(e) = interpret(snippet_simple) {
-            assert!(KnownBug::has_list_of_qualified_principal_issue(&e));
-            crosscheck(snippet_simple, Ok(None)); // we don't care about the expected result
-        }
+        let e = interpret(snippet_simple).expect_err("Snippet should err due to bug");
+        assert!(KnownBug::has_list_of_qualified_principal_issue(&e));
+        crosscheck(snippet_simple, Ok(None)); // we don't care about the expected result
 
         let snippet_no_rgx_2nd_match = r#"(index-of (list (ok 'S932CK89GTZ50W6ZHYT9FR8A625KMXTBN4FDHXFNW.a) (ok 'SH3MZSPN84M1NC77YFD2EV36NAS4EW9RNBXF4TGY3.A) (ok 'SME80C5G10ZJGHJA8Q1R4WH99ZV794GPH050DG87.A) (err u1409580484) (err u78298087165342409770641973297847909482) (ok 'ST1305A3CKDY8C2M3K9E7D8ZESND3W9RV4G7TSEAH.sSzXanZZmDqBadhzkhYweAFAdHVzWrlqToalG) (ok 'S61F1MAGPTM4Y3WEYE757PTZEGRY5D3FV2BG53STB.VXSrEfeDQmDpUQpbLcpTcpHhytHKnXQnbLLhw) (ok 'S939MQP0630GPK1S5RRKWDEXT5X8DEBW5T5PHXBTA.pBvEuNMOoLNHAkBpAyWkOgMQRXsuqs) (err u130787449693949619415771523117179796343) (ok 'SZ1NX5BPB8JTT5FZ86FD4R2H2A4FRSZYYYADEZPVM.GNlVpg)) (ok 'S61F1MAGPTM4Y3WEYE757PTZEGRY5D3FV2BG53STB.VXSrEfeDQmDpUQpbLcpTcpHhytHKnXQnbLLhw))"#;
 
-        if let Err(e) = interpret(snippet_no_rgx_2nd_match) {
-            assert!(KnownBug::has_list_of_qualified_principal_issue(&e));
-            crosscheck(snippet_simple, Ok(None)); // we don't care about the expected result
-        }
+        let e = interpret(snippet_no_rgx_2nd_match).expect_err("Snippet should err due to bug");
+        assert!(KnownBug::has_list_of_qualified_principal_issue(&e));
+        crosscheck(snippet_simple, Ok(None)); // we don't care about the expected result
 
         let snippet_wrapped = r#"(replace-at?
             (list
@@ -826,10 +824,9 @@ mod tests {
             (err 'SX3M0F9YG3TS7YZDDV7B22H2C5J0BHG0WD0T3QSSN.DAHdSGMHgxMWaithtPBEqfuTWZGMqy)
         )"#;
 
-        if let Err(e) = interpret(snippet_wrapped) {
-            assert!(KnownBug::has_list_of_qualified_principal_issue(&e));
-            crosscheck(snippet_wrapped, Ok(None)); // we don't care about expected result
-        }
+        let e = interpret(snippet_wrapped).expect_err("Snippet should err due to bug");
+        assert!(KnownBug::has_list_of_qualified_principal_issue(&e));
+        crosscheck(snippet_wrapped, Ok(None)); // we don't care about expected result
 
         let working_snippet = r#"(replace-at?
             (list

--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -463,7 +463,10 @@ fn crosseval(snippet: &str, env: TestEnvironment) -> Result<CrossEvalResult, Kno
     let compiled = env_compiled.evaluate(snippet);
 
     match KnownBug::check_for_known_bugs(&compiled, &interpreted) {
-        Some(bug) => Err(bug),
+        Some(bug) => {
+            println!("KNOW BUG TRIGGERED <{bug:?}>:\n\t{snippet}");
+            Err(bug)
+        }
         None => Ok(CrossEvalResult {
             env_interpreted,
             env_compiled,

--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -407,7 +407,7 @@ enum KnownBug {
 }
 
 impl KnownBug {
-    fn check_for_knonw_bugs(
+    fn check_for_known_bugs(
         compiled: &Result<Option<Value>, Error>,
         interpreted: &Result<Option<Value>, Error>,
     ) -> Option<Self> {
@@ -461,7 +461,7 @@ fn crosseval(snippet: &str, env: TestEnvironment) -> Result<CrossEvalResult, Kno
     let mut env_compiled = env;
     let compiled = env_compiled.evaluate(snippet);
 
-    match KnownBug::check_for_knonw_bugs(&compiled, &interpreted) {
+    match KnownBug::check_for_known_bugs(&compiled, &interpreted) {
         Some(bug) => Err(bug),
         None => Ok(CrossEvalResult {
             env_interpreted,


### PR DESCRIPTION
Lists of principal as arguments of some functions can cause [this bug](https://github.com/stacks-network/stacks-core/issues/4622).

This PR changes the `crosseval` function so that it can detect if this bug happen, and ignore the results comparisons.

There is actually an entire new enum `KnowBugs` so that it's easy to add more detection of bugs if we find some other ones.

It would have been nice to compare the errors from interpreted and compiled, but we need this issue fixed first: #421 
I would have been nice to use a logger instead of the `println` also, or have a counter to check how many times such bugs happen, but I think this is overkill for this PR.