### PR TITLE
fix short-return type value in runtime-errors

### DIFF
--- a/clar2wasm/src/error_mapping.rs
+++ b/clar2wasm/src/error_mapping.rs
@@ -222,8 +222,10 @@ fn from_runtime_error_code(
             Some(Vec::new()),
         ),
         ErrorMap::NameAlreadyUsed => {
-            let runtime_error_arg_offset = get_global_i32(&instance, &mut store, "runtime-error-arg-offset");
-            let runtime_error_arg_len = get_global_i32(&instance, &mut store, "runtime-error-arg-len");
+            let runtime_error_arg_offset =
+                get_global_i32(&instance, &mut store, "runtime-error-arg-offset");
+            let runtime_error_arg_len =
+                get_global_i32(&instance, &mut store, "runtime-error-arg-len");
 
             let memory = instance
                 .get_memory(&mut store, "memory")

--- a/clar2wasm/src/error_mapping.rs
+++ b/clar2wasm/src/error_mapping.rs
@@ -1,9 +1,11 @@
+use clarity::types::StacksEpochId;
 use clarity::vm::errors::{CheckErrors, Error, RuntimeErrorType, ShortReturnType, WasmError};
-use clarity::vm::types::ResponseData;
-use clarity::vm::Value;
+use clarity::vm::ClarityVersion;
 use wasmtime::{AsContextMut, Instance, Trap};
 
-use crate::wasm_utils::read_identifier_from_wasm;
+use crate::wasm_utils::{
+    read_from_wasm_indirect, read_identifier_from_wasm, signature_from_string,
+};
 
 const LOG2_ERROR_MESSAGE: &str = "log2 must be passed a positive integer";
 const SQRTI_ERROR_MESSAGE: &str = "sqrti must be passed a positive integer";
@@ -82,6 +84,8 @@ pub(crate) fn resolve_error(
     e: wasmtime::Error,
     instance: Instance,
     mut store: impl AsContextMut,
+    epoch_id: &StacksEpochId,
+    clarity_version: &ClarityVersion,
 ) -> Error {
     if let Some(vm_error) = e.root_cause().downcast_ref::<Error>() {
         // SAFETY:
@@ -139,7 +143,7 @@ pub(crate) fn resolve_error(
     // In this case, runtime errors are handled
     // by being mapped to the corresponding ClarityWasm Errors.
     if let Some(Trap::UnreachableCodeReached) = e.root_cause().downcast_ref::<Trap>() {
-        return from_runtime_error_code(instance, &mut store, e);
+        return from_runtime_error_code(instance, &mut store, e, epoch_id, clarity_version);
     }
 
     // All other errors are treated as general runtime errors.
@@ -150,6 +154,8 @@ fn from_runtime_error_code(
     instance: Instance,
     mut store: impl AsContextMut,
     e: wasmtime::Error,
+    epoch_id: &StacksEpochId,
+    clarity_version: &ClarityVersion,
 ) -> Error {
     let global = "runtime-error-code";
     let runtime_error_code = instance
@@ -184,15 +190,45 @@ fn from_runtime_error_code(
             // This RuntimeErrorType::UnwrapFailure need to have a proper context.
             Error::Runtime(RuntimeErrorType::UnwrapFailure, Some(Vec::new()))
         }
-        // TODO: UInt(42) value below is just a placeholder.
-        // It should be replaced by the current "thrown-value" when issue #385 is resolved.
-        // Tests that reach this code are currently ignored.
-        ErrorMap::ShortReturnAssertionFailure => Error::ShortReturn(
-            ShortReturnType::AssertionFailed(Value::Response(ResponseData {
-                committed: false,
-                data: Box::new(Value::UInt(42)),
-            })),
-        ),
+        ErrorMap::ShortReturnAssertionFailure => {
+            let val_offset = instance
+                .get_global(&mut store, "runtime-error-value-offset")
+                .and_then(|glob| glob.get(&mut store).i32())
+                .unwrap_or_else(|| {
+                    panic!("Could not find $runtime-error-value-offset global with i32 value")
+                });
+
+            let type_ser_offset = instance
+                .get_global(&mut store, "runtime-error-type-ser-offset")
+                .and_then(|glob| glob.get(&mut store).i32())
+                .unwrap_or_else(|| {
+                    panic!("Could not find $runtime-error-type-ser-offset global with i32 value")
+                });
+
+            let type_ser_len = instance
+                .get_global(&mut store, "runtime-error-type-ser-len")
+                .and_then(|glob| glob.get(&mut store).i32())
+                .unwrap_or_else(|| {
+                    panic!("Could not find $runtime-error-type-ser-len global with i32 value")
+                });
+
+            let memory = instance
+                .get_memory(&mut store, "memory")
+                .unwrap_or_else(|| panic!("Could not find wasm instance memory"));
+
+            let type_ser_str =
+                read_identifier_from_wasm(memory, &mut store, type_ser_offset, type_ser_len)
+                    .unwrap_or_else(|e| panic!("Could not recover stringified type: {e}"));
+
+            let value_ty = signature_from_string(&type_ser_str, *clarity_version, *epoch_id)
+                .unwrap_or_else(|e| panic!("Could not recover thrown value: {e}"));
+
+            let clarity_val =
+                read_from_wasm_indirect(memory, &mut store, &value_ty, val_offset, *epoch_id)
+                    .unwrap_or_else(|e| panic!("Could not read thrown value from memory: {e}"));
+
+            Error::ShortReturn(ShortReturnType::AssertionFailed(clarity_val))
+        }
         ErrorMap::ArithmeticPowError => Error::Runtime(
             RuntimeErrorType::Arithmetic(POW_ERROR_MESSAGE.into()),
             Some(Vec::new()),

--- a/clar2wasm/src/initialize.rs
+++ b/clar2wasm/src/initialize.rs
@@ -325,6 +325,7 @@ pub fn initialize_contract(
 
     let mut call_stack = CallStack::new();
     let epoch = global_context.epoch_id;
+    let clarity_version = *contract_context.get_clarity_version();
     let init_context = ClarityWasmContext::new_init(
         global_context,
         contract_context,
@@ -367,7 +368,9 @@ pub fn initialize_contract(
 
     top_level
         .call(&mut store, &[], results.as_mut_slice())
-        .map_err(|e| error_mapping::resolve_error(e, instance, &mut store))?;
+        .map_err(|e| {
+            error_mapping::resolve_error(e, instance, &mut store, &epoch, &clarity_version)
+        })?;
 
     // Save the compiled Wasm module into the contract context
     store.data_mut().contract_context_mut()?.set_wasm_module(

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -261,6 +261,9 @@
     (global $runtime-error-code (mut i32) (i32.const -1))
     (global $runtime-error-arg-offset (mut i32) (i32.const -1))
     (global $runtime-error-arg-len (mut i32) (i32.const -1))
+    (global $runtime-error-value-offset (mut i32) (i32.const -1))
+    (global $runtime-error-type-ser-offset (mut i32) (i32.const -1))
+    (global $runtime-error-type-ser-len (mut i32) (i32.const -1))
 
     ;; (sha256) initial hash values: first 32 bits of the fractional parts of the square roots of the first 8 primes 2..19
     (data (i32.const 0) "\67\e6\09\6a\85\ae\67\bb\72\f3\6e\3c\3a\f5\4f\a5\7f\52\0e\51\8c\68\05\9b\ab\d9\83\1f\19\cd\e0\5b")
@@ -3887,6 +3890,9 @@
     (export "runtime-error-code" (global $runtime-error-code))
     (export "runtime-error-arg-offset" (global $runtime-error-arg-offset))
     (export "runtime-error-arg-len" (global $runtime-error-arg-len))
+    (export "runtime-error-value-offset" (global $runtime-error-value-offset))
+    (export "runtime-error-type-ser-offset" (global $runtime-error-type-ser-offset))
+    (export "runtime-error-type-ser-len" (global $runtime-error-type-ser-len))
 
     ;; Functions
     (export "stdlib.add-uint" (func $stdlib.add-uint))

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -642,6 +642,24 @@ impl WasmGenerator {
         Ok(())
     }
 
+    /// Generates WebAssembly instructions for an early-return of the `asserts!` Clarity function.
+    ///
+    /// This function is responsible for creating the necessary WebAssembly instructions to handle
+    /// the `asserts!` functionality in Clarity, which allows for early-return with an assertion failure.
+    /// It either generates a branch instruction to an early return block if one exists, or sets up
+    /// the context for a runtime error if the assertion fails.
+    ///
+    /// # Behavior
+    ///
+    /// 1. If an early return block ID exists, it generates a branch instruction to that block.
+    /// 2. Otherwise, it sets up the context for a runtime error:
+    ///    - Determines the type of the expression.
+    ///    - Creates a local on the call stack for the value.
+    ///    - Writes the value to memory.
+    ///    - Serializes the type and adds it as a string literal.
+    ///    - Sets up global variables with offsets and lengths for the value and type.
+    ///    - Calls the runtime error function with the appropriate error code.
+    ///
     pub fn asserts_return_early(
         &mut self,
         builder: &mut InstrSeqBuilder,

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -660,7 +660,7 @@ impl WasmGenerator {
     ///    - Sets up global variables with offsets and lengths for the value and type.
     ///    - Calls the runtime error function with the appropriate error code.
     ///
-    pub fn asserts_return_early(
+    pub fn asserts_early_return(
         &mut self,
         builder: &mut InstrSeqBuilder,
         expr: &SymbolicExpression,

--- a/clar2wasm/src/wasm_utils.rs
+++ b/clar2wasm/src/wasm_utils.rs
@@ -1244,6 +1244,7 @@ pub fn call_function<'a>(
     sponsor: Option<PrincipalData>,
 ) -> Result<Value, Error> {
     let epoch = global_context.epoch_id;
+    let clarity_version = *contract_context.get_clarity_version();
     let context = ClarityWasmContext::new_run(
         global_context,
         contract_context,
@@ -1328,7 +1329,9 @@ pub fn call_function<'a>(
 
     // Call the function
     func.call(&mut store, &wasm_args, &mut results)
-        .map_err(|e| error_mapping::resolve_error(e, instance, &mut store))?;
+        .map_err(|e| {
+            error_mapping::resolve_error(e, instance, &mut store, &epoch, &clarity_version)
+        })?;
 
     // If the function returns a value, translate it into a Clarity `Value`
     wasm_to_clarity_value(&return_type, 0, &results, memory, &mut &mut store, epoch)

--- a/clar2wasm/src/words/conditionals.rs
+++ b/clar2wasm/src/words/conditionals.rs
@@ -699,8 +699,9 @@ impl ComplexWord for Asserts {
         if let Some(return_ty) = generator.get_current_function_return_type() {
             generator.set_expr_type(throw, return_ty.clone())?;
         }
+
         generator.traverse_expr(&mut throw_branch, throw)?;
-        generator.return_early(&mut throw_branch)?;
+        generator.asserts_return_early(&mut throw_branch, throw)?;
 
         let throw_branch_id = throw_branch.id();
 
@@ -1230,7 +1231,6 @@ mod tests {
         crosscheck("(asserts! true (err u1))", Ok(Some(Value::Bool(true))));
     }
 
-    #[ignore = "see issue: #385"]
     #[test]
     fn asserts_top_level_false() {
         crosscheck(

--- a/clar2wasm/src/words/conditionals.rs
+++ b/clar2wasm/src/words/conditionals.rs
@@ -701,7 +701,7 @@ impl ComplexWord for Asserts {
         }
 
         generator.traverse_expr(&mut throw_branch, throw)?;
-        generator.asserts_return_early(&mut throw_branch, throw)?;
+        generator.asserts_early_return(&mut throw_branch, throw)?;
 
         let throw_branch_id = throw_branch.id();
 


### PR DESCRIPTION
fix #385 

This PR implements the follwoing errors handling:

- `ShortReturn::AssertionFailed`
- `ShortReturn::ExpectedValue`
- `ShortReturn::ExpectedValueResponse`
- `ShortReturn::ExpectedValueOptional`
