### PR TITLE
refactor: Remove redundant tuple signature conversion functions

### DIFF
--- a/clar2wasm/src/deserialize.rs
+++ b/clar2wasm/src/deserialize.rs
@@ -1214,7 +1214,7 @@ impl WasmGenerator {
                             &mut case_block,
                             offset_local,
                             end_local,
-                            &field_ty,
+                            field_ty,
                         )?;
                         for &l in field_locals.iter().rev() {
                             case_block.local_set(l);

--- a/clar2wasm/src/deserialize.rs
+++ b/clar2wasm/src/deserialize.rs
@@ -12,7 +12,6 @@ use walrus::{InstrSeqBuilder, LocalId, MemoryId, ValType};
 use crate::wasm_generator::{
     add_placeholder_for_clarity_type, clar2wasm_ty, GeneratorError, WasmGenerator,
 };
-use crate::wasm_utils::ordered_tuple_signature;
 
 impl WasmGenerator {
     /// Deserialize an integer (`int` or `uint`) from memory using consensus
@@ -993,7 +992,7 @@ impl WasmGenerator {
         // We will need to add all the keys to the data to be able to check if
         // they are part of the tuple and find their index. They will be stored as
         // [number of keys as u32 | key 1 offset as u32 | key 2 offset as u32 | key 1 len as u8 | key 2 len as u8 | ... | key 1 | key 2 | ...]
-        let tm = ordered_tuple_signature(tuple_ty);
+        let tm = tuple_ty.get_type_map();
         let (keys_offset, keys_len) = {
             let mut keys = (tm.len() as u32).to_le_bytes().to_vec();
             // add relative offsets
@@ -1188,7 +1187,7 @@ impl WasmGenerator {
                     }
 
                     // switch case for valid fields
-                    for (((&case, &field_ty), field_locals), case_idx) in switch_case_blocks[1..]
+                    for (((&case, field_ty), field_locals), case_idx) in switch_case_blocks[1..]
                         .iter()
                         .zip(tm.values())
                         .zip(values_locals.iter())
@@ -1215,7 +1214,7 @@ impl WasmGenerator {
                             &mut case_block,
                             offset_local,
                             end_local,
-                            field_ty,
+                            &field_ty,
                         )?;
                         for &l in field_locals.iter().rev() {
                             case_block.local_set(l);

--- a/clar2wasm/src/serialize.rs
+++ b/clar2wasm/src/serialize.rs
@@ -7,7 +7,6 @@ use walrus::ir::{BinaryOp, IfElse, InstrSeqType, Loop, MemArg, StoreKind};
 use walrus::{InstrSeqBuilder, LocalId, MemoryId, ValType};
 
 use crate::wasm_generator::{clar2wasm_ty, GeneratorError, WasmGenerator};
-use crate::wasm_utils::ordered_tuple_signature;
 
 impl WasmGenerator {
     /// Serialize an integer (`int` or `uint`) to memory using consensus
@@ -828,7 +827,7 @@ impl WasmGenerator {
             .local_tee(write_ptr);
 
         // Now serialize the keys/values to memory
-        for (key, value_ty) in ordered_tuple_signature(tuple_ty) {
+        for (key, value_ty) in tuple_ty.get_type_map() {
             // Serialize the key length
             builder.i32_const(key.len() as i32).store(
                 memory,

--- a/clar2wasm/src/wasm_utils.rs
+++ b/clar2wasm/src/wasm_utils.rs
@@ -1,7 +1,5 @@
 #![allow(non_camel_case_types)]
 
-use std::collections::BTreeMap;
-
 use clarity::vm::analysis::CheckErrors;
 use clarity::vm::ast::{build_ast_with_rules, ASTRules};
 use clarity::vm::contexts::GlobalContext;
@@ -10,10 +8,9 @@ use clarity::vm::types::signatures::CallableSubtype;
 use clarity::vm::types::{
     ASCIIData, BuffData, BufferLength, CallableData, CharType, ListData, OptionalData,
     PrincipalData, QualifiedContractIdentifier, ResponseData, SequenceData, SequenceSubtype,
-    SequencedValue, StandardPrincipalData, StringSubtype, TupleData, TupleTypeSignature,
-    TypeSignature,
+    SequencedValue, StandardPrincipalData, StringSubtype, TupleData, TypeSignature,
 };
-use clarity::vm::{CallStack, ClarityName, ClarityVersion, ContractContext, ContractName, Value};
+use clarity::vm::{CallStack, ClarityVersion, ContractContext, ContractName, Value};
 use stacks_common::types::StacksEpochId;
 use wasmtime::{AsContextMut, Engine, Linker, Memory, Module, Store, Val, ValType};
 

--- a/clar2wasm/src/wasm_utils.rs
+++ b/clar2wasm/src/wasm_utils.rs
@@ -314,7 +314,7 @@ pub fn wasm_to_clarity_value(
         TypeSignature::TupleType(t) => {
             let mut index = value_index;
             let mut data_map = Vec::new();
-            for (name, ty) in ordered_tuple_signature(t) {
+            for (name, ty) in t.get_type_map() {
                 let (value, increment) =
                     wasm_to_clarity_value(ty, index, buffer, memory, store, epoch)?;
                 data_map.push((
@@ -510,7 +510,7 @@ pub fn read_from_wasm(
         TypeSignature::TupleType(type_sig) => {
             let mut data = Vec::new();
             let mut current_offset = offset;
-            for (field_key, field_ty) in ordered_tuple_signature(type_sig) {
+            for (field_key, field_ty) in type_sig.get_type_map() {
                 let field_length = get_type_size(field_ty);
                 let field_value =
                     read_from_wasm_indirect(memory, store, field_ty, current_offset, epoch)?;
@@ -1057,9 +1057,10 @@ pub fn write_to_wasm(
             let mut written = 0;
             let mut in_mem_written = 0;
 
-            for (key, val) in &tuple_data.data_map {
-                let val_type = type_sig
-                    .field_type(key)
+            for (key, val_type) in type_sig.get_type_map() {
+                let val = tuple_data
+                    .data_map
+                    .get(key)
                     .ok_or(Error::Wasm(WasmError::ValueTypeMismatch))?;
                 let (new_written, new_in_mem_written) = write_to_wasm(
                     store.as_context_mut(),
@@ -1224,7 +1225,7 @@ fn clar2wasm_ty(ty: &TypeSignature) -> Vec<ValType> {
         }
         TypeSignature::TupleType(inner_types) => {
             let mut types = vec![];
-            for &inner_type in ordered_tuple_signature(inner_types).values() {
+            for inner_type in inner_types.get_type_map().values() {
                 types.extend(clar2wasm_ty(inner_type));
             }
             types
@@ -1607,7 +1608,7 @@ fn reserve_space_for_return(
         TypeSignature::TupleType(type_sig) => {
             let mut vals = vec![];
             let mut adjusted = offset;
-            for ty in ordered_tuple_signature(type_sig).values() {
+            for ty in type_sig.get_type_map().values() {
                 let (subexpr_values, new_offset) = reserve_space_for_return(adjusted, ty)?;
                 vals.extend(subexpr_values);
                 adjusted = new_offset;
@@ -1618,22 +1619,6 @@ fn reserve_space_for_return(
             unreachable!("not a valid return type");
         }
     }
-}
-
-pub(crate) fn ordered_tuple_signature(
-    tuple: &TupleTypeSignature,
-) -> BTreeMap<&ClarityName, &TypeSignature> {
-    tuple.get_type_map().iter().collect()
-}
-
-pub(crate) fn owned_ordered_tuple_signature(
-    tuple: &TupleTypeSignature,
-) -> BTreeMap<ClarityName, TypeSignature> {
-    tuple
-        .get_type_map()
-        .iter()
-        .map(|(k, v)| (k.clone(), v.clone()))
-        .collect()
 }
 
 pub fn signature_from_string(

--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -8,7 +8,6 @@ use super::ComplexWord;
 use crate::wasm_generator::{
     clar2wasm_ty, drop_value, ArgumentsExt, GeneratorError, SequenceElementType, WasmGenerator,
 };
-use crate::wasm_utils::{ordered_tuple_signature, owned_ordered_tuple_signature};
 
 #[derive(Debug)]
 pub struct IsEq;
@@ -332,10 +331,11 @@ fn assign_to_locals(
         }
         (TypeSignature::TupleType(t), TypeSignature::TupleType(s)) => {
             let mut remaining_locals = locals;
-            for (tt, ss) in ordered_tuple_signature(t)
+            for (tt, ss) in t
+                .get_type_map()
                 .values()
                 .rev()
-                .zip(ordered_tuple_signature(s).values().rev())
+                .zip(s.get_type_map().values().rev())
             {
                 let tt_size = clar2wasm_ty(tt).len();
                 let (rest, cur_locals) =
@@ -707,7 +707,7 @@ fn wasm_equal_tuple(
     // ```
     // we have to build the if sequence bottom-up
 
-    let field_types = owned_ordered_tuple_signature(tuple_ty);
+    let field_types = tuple_ty.get_type_map();
 
     // this is the number of elements in the tuple. Always >= 1 due to Clarity constraints.
     let mut depth = field_types.len();
@@ -728,7 +728,7 @@ fn wasm_equal_tuple(
     );
 
     // types for nth argument
-    let nth_type_map = ordered_tuple_signature(nth_tuple_ty);
+    let nth_type_map = nth_tuple_ty.get_type_map();
     let mut nth_types = nth_type_map.values().rev();
 
     // if this is a 1-tuple, we can just check for equality of element

--- a/clar2wasm/src/words/tuples.rs
+++ b/clar2wasm/src/words/tuples.rs
@@ -5,7 +5,6 @@ use clarity::vm::{ClarityName, SymbolicExpression};
 
 use super::ComplexWord;
 use crate::wasm_generator::{clar2wasm_ty, drop_value, GeneratorError, WasmGenerator};
-use crate::wasm_utils::{ordered_tuple_signature, owned_ordered_tuple_signature};
 
 #[derive(Debug)]
 pub struct TupleCons;
@@ -28,7 +27,7 @@ impl ComplexWord for TupleCons {
             .clone();
 
         let mut tuple_ty = match ty {
-            TypeSignature::TupleType(ref tuple) => ordered_tuple_signature(tuple),
+            TypeSignature::TupleType(ref tuple) => tuple.get_type_map().clone(),
             _ => return Err(GeneratorError::TypeError("expected tuple type".to_string())),
         };
 
@@ -69,7 +68,7 @@ impl ComplexWord for TupleCons {
             generator.set_expr_type(value, value_ty.clone())?;
 
             generator.traverse_expr(builder, value)?;
-            locals_map.insert(key, generator.save_to_locals(builder, value_ty, true));
+            locals_map.insert(key, generator.save_to_locals(builder, &value_ty, true));
         }
 
         // Make sure that all the tuples keys were defined
@@ -130,7 +129,7 @@ impl ComplexWord for TupleGet {
         generator.traverse_expr(builder, &args[1])?;
 
         // Determine the wasm types for each field of the tuple
-        let field_types = ordered_tuple_signature(&tuple_ty);
+        let field_types = tuple_ty.get_type_map();
 
         // Create locals for the target field
         let wasm_types = clar2wasm_ty(field_types.get(target_field_name).ok_or_else(|| {
@@ -213,7 +212,7 @@ impl ComplexWord for TupleMerge {
                 TypeSignature::TupleType(tuple) => Ok(tuple),
                 _ => Err(GeneratorError::TypeError("expected tuple type".to_string())),
             })
-            .map(owned_ordered_tuple_signature)?
+            .map(|tuple| tuple.get_type_map().clone())?
             .into_iter()
             .map(|(name, ty_)| {
                 (
@@ -231,7 +230,7 @@ impl ComplexWord for TupleMerge {
 
         // We will copy the values from LHS into the result locals iff the key is not
         // present in RHS. Otherwise, we drop the values.
-        for (name, ty_) in ordered_tuple_signature(&lhs_tuple_ty).into_iter().rev() {
+        for (name, ty_) in lhs_tuple_ty.get_type_map().iter().rev() {
             if !rhs_tuple_ty.get_type_map().contains_key(name) {
                 result_locals
                     .get(name)
@@ -254,7 +253,7 @@ impl ComplexWord for TupleMerge {
         generator.traverse_expr(builder, &args[1])?;
 
         // We will copy all values of RHS into the result locals
-        for (name, _) in ordered_tuple_signature(&rhs_tuple_ty).into_iter().rev() {
+        for (name, _) in rhs_tuple_ty.get_type_map().iter().rev() {
             result_locals
                 .get(name)
                 .ok_or_else(|| {

--- a/clar2wasm/src/words/tuples.rs
+++ b/clar2wasm/src/words/tuples.rs
@@ -144,7 +144,7 @@ impl ComplexWord for TupleGet {
         // Loop through the fields of the tuple, in reverse order. When we find
         // the target field, we'll store it in the locals we created above. All
         // other fields will be dropped.
-        for (field_name, field_ty) in field_types.into_iter().rev() {
+        for (field_name, field_ty) in field_types.iter().rev() {
             // If this is the target field, store it in the locals we created
             // above.
             if field_name == target_field_name {


### PR DESCRIPTION
## Description

Removed the `ordered_tuple_signature` and `owned_ordered_tuple_signature` functions from `wasm_utils.rs`. These functions are now redundant as `TupleTypeSignature` uses a `BTreeMap` internally.

Changes:
- Removed redundant functions from `wasm_utils.rs`
- Updated affected code to use `TupleTypeSignature::get_type_map()` directly
- Adjusted type handling in relevant functions

## Checklist

- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `cargo test` passes
- [ ] Changelog is updated

Resolves #504 