### PR TITLE
Fix wrong type of argument for `define-data-var` in Clarity1

### DIFF
--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -604,6 +604,30 @@ pub fn crosscheck_with_epoch(
     );
 }
 
+pub fn crosscheck_with_clarity_version(
+    snippet: &str,
+    expected: Result<Option<Value>, Error>,
+    version: ClarityVersion,
+) {
+    let eval = match crosseval(
+        snippet,
+        TestEnvironment::new(TestConfig::latest_epoch(), version),
+    ) {
+        Ok(result) => result,
+        Err(_bug) => {
+            return;
+        }
+    };
+
+    eval.compare(snippet);
+
+    assert_eq!(
+        eval.compiled, expected,
+        "value is not the expected {:?}",
+        eval.compiled
+    );
+}
+
 pub fn crosscheck_validate<V: Fn(Value)>(snippet: &str, validator: V) {
     let eval = match crosseval(
         snippet,

--- a/clar2wasm/src/words/data_vars.rs
+++ b/clar2wasm/src/words/data_vars.rs
@@ -225,9 +225,12 @@ impl ComplexWord for GetDataVar {
 
 #[cfg(test)]
 mod tests {
-    use clarity::types::StacksEpochId;
+    use clarity::{types::StacksEpochId, vm::Value};
 
-    use crate::tools::{crosscheck, crosscheck_expect_failure, crosscheck_with_epoch, evaluate};
+    use crate::tools::{
+        crosscheck, crosscheck_expect_failure, crosscheck_with_clarity_version,
+        crosscheck_with_epoch, evaluate,
+    };
 
     #[test]
     fn test_var_get() {
@@ -282,5 +285,21 @@ mod tests {
         );
 
         crosscheck_expect_failure("(define-data-var index-of? int 0)");
+    }
+
+    #[test]
+    fn define_data_var_has_correct_type_with_clarity1() {
+        // https://github.com/stacks-network/clarity-wasm/issues/497
+        let snippet = "
+            (define-data-var v (optional uint) none)
+            (var-set v (some u171713071701372222108711587))
+            (var-get v)
+        ";
+
+        crosscheck_with_clarity_version(
+            snippet,
+            Ok(Value::some(Value::UInt(171713071701372222108711587)).ok()),
+            clarity::vm::ClarityVersion::Clarity1,
+        );
     }
 }


### PR DESCRIPTION
Fixes #497 

This was a simple one. The typechecker used in Clarity1 doesn't set the type of the Value with the type given as argument in `define-data-var`.
This fixes it.