### PR TITLE
do not panic! on ErrorMap::Panic

### DIFF
--- a/clar2wasm/src/error_mapping.rs
+++ b/clar2wasm/src/error_mapping.rs
@@ -145,7 +145,9 @@ fn from_runtime_error_code(
             Error::Runtime(RuntimeErrorType::UnwrapFailure, Some(Vec::new()))
         }
         ErrorMap::Panic => {
-            panic!("An error has been detected in the code")
+            // TODO: see issue: #531
+            // This RuntimeErrorType::UnwrapFailure need to have a proper context.
+            Error::Runtime(RuntimeErrorType::UnwrapFailure, Some(Vec::new()))
         }
         // TODO: UInt(42) value below is just a placeholder.
         // It should be replaced by the current "thrown-value" when issue #385 is resolved.


### PR DESCRIPTION
Fix to avoid halt execution when dealing with an `ErrorMap::Panic`.