### PR TITLE
Added Checks for the Length of Arguments List

### DIFF
--- a/clar2wasm/src/words/bindings.rs
+++ b/clar2wasm/src/words/bindings.rs
@@ -18,6 +18,13 @@ impl ComplexWord for Let {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() < 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "let expected at least 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let bindings = args.get_list(0)?;
 
         // Save the current named locals

--- a/clar2wasm/src/words/blockinfo.rs
+++ b/clar2wasm/src/words/blockinfo.rs
@@ -18,6 +18,13 @@ impl ComplexWord for GetBlockInfo {
         expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "get-block-info? expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let prop_name = args.get_name(0)?;
         let block = args.get_expr(1)?;
 
@@ -70,6 +77,13 @@ impl ComplexWord for GetBurnBlockInfo {
         expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "get-burn-block-info? expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let prop_name = args.get_name(0)?;
         let block = args.get_expr(1)?;
 
@@ -124,6 +138,13 @@ impl ComplexWord for AtBlock {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "at-block expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let block_hash = args.get_expr(0)?;
         let e = args.get_expr(1)?;
 

--- a/clar2wasm/src/words/conditionals.rs
+++ b/clar2wasm/src/words/conditionals.rs
@@ -25,6 +25,13 @@ impl ComplexWord for If {
         expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 3 {
+            return Err(GeneratorError::InternalError(format!(
+                "if expected 3 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let conditional = args.get_expr(0)?;
         let true_branch = args.get_expr(1)?;
         let false_branch = args.get_expr(2)?;
@@ -96,6 +103,13 @@ impl ComplexWord for Match {
 
         match generator.get_expr_type(match_on).cloned() {
             Some(TypeSignature::OptionalType(inner_type)) => {
+                if args.len() != 4 {
+                    return Err(GeneratorError::InternalError(format!(
+                        "match expected 4 arguments, got {}",
+                        args.len()
+                    )));
+                };
+
                 let none_body = args.get_expr(3)?;
 
                 // WORKAROUND: set type on none body
@@ -122,6 +136,13 @@ impl ComplexWord for Match {
                 Ok(())
             }
             Some(TypeSignature::ResponseType(inner_types)) => {
+                if args.len() != 5 {
+                    return Err(GeneratorError::InternalError(format!(
+                        "match expected 5 arguments, got {}",
+                        args.len()
+                    )));
+                };
+
                 let (ok_ty, err_ty) = &*inner_types;
 
                 let err_binding = args.get_name(3)?;
@@ -185,6 +206,13 @@ impl ComplexWord for Filter {
         expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "filter expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let discriminator = args.get_name(0)?;
         let sequence = args.get_expr(1)?;
 
@@ -408,6 +436,10 @@ impl ComplexWord for And {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.is_empty() {
+            return Err(GeneratorError::InternalError("and expected at least 1 argument, got 0".to_owned()));
+        };
+
         traverse_short_circuiting_list(generator, builder, args, false)
     }
 }
@@ -449,6 +481,10 @@ impl ComplexWord for Or {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.is_empty() {
+            return Err(GeneratorError::InternalError("or expected at least 1 argument, got 0".to_owned()));
+        };
+
         traverse_short_circuiting_list(generator, builder, args, true)
     }
 }
@@ -490,6 +526,13 @@ impl ComplexWord for Unwrap {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "unwrap! expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let input = args.get_expr(0)?;
         let throw = args.get_expr(1)?;
 
@@ -571,6 +614,13 @@ impl ComplexWord for UnwrapErr {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "unwrap-err! expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let input = args.get_expr(0)?;
         let throw = args.get_expr(1)?;
 
@@ -660,6 +710,13 @@ impl ComplexWord for Asserts {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "asserts! expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let input = args.get_expr(0)?;
         let throw = args.get_expr(1)?;
 
@@ -730,6 +787,13 @@ impl ComplexWord for Try {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 1 {
+            return Err(GeneratorError::InternalError(format!(
+                "try! expected 1 argument, got {}",
+                args.len()
+            )));
+        };
+
         let input = args.get_expr(0)?;
         generator.traverse_expr(builder, input)?;
 

--- a/clar2wasm/src/words/consensus_buff.rs
+++ b/clar2wasm/src/words/consensus_buff.rs
@@ -22,6 +22,13 @@ impl ComplexWord for ToConsensusBuff {
         _expr: &clarity::vm::SymbolicExpression,
         args: &[clarity::vm::SymbolicExpression],
     ) -> Result<(), crate::wasm_generator::GeneratorError> {
+        if args.len() != 1 {
+            return Err(GeneratorError::InternalError(format!(
+                "to-consensus-buff? expected 1 argument, got {}",
+                args.len()
+            )));
+        };
+
         generator.traverse_args(builder, args)?;
 
         let ty = generator
@@ -93,6 +100,13 @@ impl ComplexWord for FromConsensusBuff {
         _expr: &clarity::vm::SymbolicExpression,
         args: &[clarity::vm::SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "from-consensus-buff? expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         // Rather than parsing the type from args[0], we can just use the type
         // of this expression.
         let ty = generator

--- a/clar2wasm/src/words/constants.rs
+++ b/clar2wasm/src/words/constants.rs
@@ -20,6 +20,13 @@ impl ComplexWord for DefineConstant {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "define-constant expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         // Constant name
         let name = args.get_name(0)?;
 

--- a/clar2wasm/src/words/contract.rs
+++ b/clar2wasm/src/words/contract.rs
@@ -23,6 +23,13 @@ impl ComplexWord for AsContract {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 1 {
+            return Err(GeneratorError::InternalError(format!(
+                "as-contract expected 1 argument, got {}",
+                args.len()
+            )));
+        };
+
         let inner = args.get_expr(0)?;
 
         // Call the host interface function, `enter_as_contract`
@@ -53,6 +60,13 @@ impl ComplexWord for ContractCall {
         expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() < 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "contract-call? expected at least 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let function_name = args.get_name(1)?;
         let contract_expr = args.get_expr(0)?;
         if let SymbolicExpressionType::LiteralValue(Value::Principal(PrincipalData::Contract(

--- a/clar2wasm/src/words/control_flow.rs
+++ b/clar2wasm/src/words/control_flow.rs
@@ -21,6 +21,13 @@ impl ComplexWord for Begin {
         expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.is_empty() {
+            return Err(GeneratorError::InternalError(format!(
+                "begin expected at least 1 argument, got {}",
+                args.len()
+            )));
+        };
+
         generator.set_expr_type(
             args.last().ok_or_else(|| {
                 GeneratorError::TypeError("begin must have at least one arg".to_string())
@@ -49,6 +56,13 @@ impl ComplexWord for UnwrapPanic {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 1 {
+            return Err(GeneratorError::InternalError(format!(
+                "unwrap-panic expected 1 argument, got {}",
+                args.len()
+            )));
+        };
+
         let input = args.get_expr(0)?;
         generator.traverse_expr(builder, input)?;
         // There must be either an `optional` or a `response` on the top of the
@@ -185,6 +199,13 @@ impl ComplexWord for UnwrapErrPanic {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 1 {
+            return Err(GeneratorError::InternalError(format!(
+                "unwrap-err-panic expected 1 argument, got {}",
+                args.len()
+            )));
+        };
+
         let input = args.get_expr(0)?;
         generator.traverse_expr(builder, input)?;
         // The input must be a `response` type. It uses an i32 indicator, where

--- a/clar2wasm/src/words/data_vars.rs
+++ b/clar2wasm/src/words/data_vars.rs
@@ -20,6 +20,13 @@ impl ComplexWord for DefineDataVar {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 3 {
+            return Err(GeneratorError::InternalError(format!(
+                "define-data-var expected 3 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let name = args.get_name(0)?;
         // Making sure if name is not reserved
         if generator.is_reserved_name(name) {
@@ -108,6 +115,13 @@ impl ComplexWord for SetDataVar {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "var-set expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let name = args.get_name(0)?;
         let value = args.get_expr(1)?;
 
@@ -179,6 +193,13 @@ impl ComplexWord for GetDataVar {
         expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 1 {
+            return Err(GeneratorError::InternalError(format!(
+                "var-get expected 1 argument, got {}",
+                args.len()
+            )));
+        };
+
         let name = args.get_name(0)?;
 
         // Get the offset and length for this identifier in the literal memory

--- a/clar2wasm/src/words/default_to.rs
+++ b/clar2wasm/src/words/default_to.rs
@@ -22,6 +22,13 @@ impl ComplexWord for DefaultTo {
         expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "default-to expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         // There are a `default` value and an `optional` arguments.
         // (default-to 767 (some 1))
         // i64              i64               i32        i64           i64

--- a/clar2wasm/src/words/enums.rs
+++ b/clar2wasm/src/words/enums.rs
@@ -21,6 +21,13 @@ impl ComplexWord for ClaritySome {
         expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 1 {
+            return Err(GeneratorError::InternalError(format!(
+                "some expected 1 argument, got {}",
+                args.len()
+            )));
+        };
+
         let value = args.get_expr(0)?;
         // (some <val>) is represented by an i32 1, followed by the value
         builder.i32_const(1);
@@ -56,6 +63,13 @@ impl ComplexWord for ClarityOk {
         expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 1 {
+            return Err(GeneratorError::InternalError(format!(
+                "ok expected 1 argument, got {}",
+                args.len()
+            )));
+        };
+
         let value = args.get_expr(0)?;
 
         let TypeSignature::ResponseType(inner_types) = generator
@@ -101,6 +115,13 @@ impl ComplexWord for ClarityErr {
         expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 1 {
+            return Err(GeneratorError::InternalError(format!(
+                "err expected 1 argument, got {}",
+                args.len()
+            )));
+        };
+
         let value = args.get_expr(0)?;
         // (err <val>) is represented by an i32 0, followed by a placeholder
         // for the ok value, followed by the err value

--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -24,6 +24,13 @@ impl ComplexWord for IsEq {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() < 1 {
+            return Err(GeneratorError::InternalError(format!(
+                "is-eq expected at least 1 argument, got {}",
+                args.len()
+            )));
+        };
+
         // Traverse the first operand pushing it onto the stack
         let first_op = args.get_expr(0)?;
         generator.traverse_expr(builder, first_op)?;
@@ -113,6 +120,13 @@ impl ComplexWord for IndexOf {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "index-of expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         // Traverse the sequence, leaving its offset and size on the stack.
         let seq = args.get_expr(0)?;
         generator.traverse_expr(builder, seq)?;

--- a/clar2wasm/src/words/functions.rs
+++ b/clar2wasm/src/words/functions.rs
@@ -18,6 +18,13 @@ impl ComplexWord for DefinePrivateFunction {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "define-private expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let Some(signature) = args.get_expr(0)?.match_list() else {
             return Err(GeneratorError::NotImplemented);
         };
@@ -52,6 +59,13 @@ impl ComplexWord for DefineReadonlyFunction {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "define-read-only expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let Some(signature) = args.get_expr(0)?.match_list() else {
             return Err(GeneratorError::NotImplemented);
         };
@@ -88,6 +102,13 @@ impl ComplexWord for DefinePublicFunction {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "define-public expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let Some(signature) = args.get_expr(0)?.match_list() else {
             return Err(GeneratorError::NotImplemented);
         };

--- a/clar2wasm/src/words/maps.rs
+++ b/clar2wasm/src/words/maps.rs
@@ -19,6 +19,13 @@ impl ComplexWord for MapDefinition {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 3 {
+            return Err(GeneratorError::InternalError(format!(
+                "define-map expected 3 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let name = args.get_name(0)?;
         // Making sure if name is not reserved
         if generator.is_reserved_name(name) {
@@ -79,6 +86,13 @@ impl ComplexWord for MapGet {
         expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "map-get expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let name = args.get_name(0)?;
         let key = args.get_expr(1)?;
 
@@ -156,6 +170,13 @@ impl ComplexWord for MapSet {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 3 {
+            return Err(GeneratorError::InternalError(format!(
+                "map-insert expected 3 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let name = args.get_name(0)?;
         let key = args.get_expr(1)?;
         let value = args.get_expr(2)?;
@@ -236,6 +257,13 @@ impl ComplexWord for MapInsert {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 3 {
+            return Err(GeneratorError::InternalError(format!(
+                "map-insert expected 3 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let name = args.get_name(0)?;
         let key = args.get_expr(1)?;
         let value = args.get_expr(2)?;
@@ -316,6 +344,13 @@ impl ComplexWord for MapDelete {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "map-delete expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let name = args.get_name(0)?;
         let key = args.get_expr(1)?;
 

--- a/clar2wasm/src/words/noop.rs
+++ b/clar2wasm/src/words/noop.rs
@@ -67,6 +67,13 @@ impl ComplexWord for ContractOf {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 1 {
+            return Err(GeneratorError::InternalError(format!(
+                "contract-of expected 1 argument, got {}",
+                args.len()
+            )));
+        };
+
         generator.traverse_args(builder, args)?;
 
         Ok(())

--- a/clar2wasm/src/words/options.rs
+++ b/clar2wasm/src/words/options.rs
@@ -50,6 +50,13 @@ impl ComplexWord for IsSome {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 1 {
+            return Err(GeneratorError::InternalError(format!(
+                "is-some expected 1 argument, got {}",
+                args.len()
+            )));
+        };
+
         traverse_optional(generator, builder, args)
     }
 }
@@ -69,6 +76,13 @@ impl ComplexWord for IsNone {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 1 {
+            return Err(GeneratorError::InternalError(format!(
+                "is-none expected 1 argument, got {}",
+                args.len()
+            )));
+        };
+
         traverse_optional(generator, builder, args)?;
 
         // Add one to stack

--- a/clar2wasm/src/words/principal.rs
+++ b/clar2wasm/src/words/principal.rs
@@ -98,6 +98,13 @@ impl ComplexWord for Construct {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 2 && args.len() != 3 {
+            return Err(GeneratorError::InternalError(format!(
+                "principal-construct? expected 2 or 3 arguments, got {}",
+                args.len()
+            )));
+        };
+
         // Traverse the version byte
         generator.traverse_expr(builder, args.get_expr(0)?)?;
         // [ version_offset, version_length ]
@@ -272,6 +279,13 @@ impl ComplexWord for PrincipalOf {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 1 {
+            return Err(GeneratorError::InternalError(format!(
+                "principal-of? expected 1 argument, got {}",
+                args.len()
+            )));
+        };
+
         // Traverse the public key
         generator.traverse_expr(builder, args.get_expr(0)?)?;
 

--- a/clar2wasm/src/words/print.rs
+++ b/clar2wasm/src/words/print.rs
@@ -61,6 +61,13 @@ impl ComplexWord for Print {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 1 {
+            return Err(GeneratorError::InternalError(format!(
+                "print expected 1 argument, got {}",
+                args.len()
+            )));
+        };
+
         let value = args.get_expr(0)?;
 
         // Traverse the value, leaving it on the data stack

--- a/clar2wasm/src/words/responses.rs
+++ b/clar2wasm/src/words/responses.rs
@@ -53,6 +53,13 @@ impl ComplexWord for IsOk {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 1 {
+            return Err(GeneratorError::InternalError(format!(
+                "is-ok expected 1 argument, got {}",
+                args.len()
+            )));
+        };
+
         traverse_response(generator, builder, args)
     }
 }
@@ -72,6 +79,13 @@ impl ComplexWord for IsErr {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 1 {
+            return Err(GeneratorError::InternalError(format!(
+                "is-err expected 1 argument, got {}",
+                args.len()
+            )));
+        };
+
         traverse_response(generator, builder, args)?;
 
         // Add one to stack

--- a/clar2wasm/src/words/secp256k1.rs
+++ b/clar2wasm/src/words/secp256k1.rs
@@ -18,6 +18,13 @@ impl ComplexWord for Recover {
         expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "secp256k1-recover? expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         generator.traverse_expr(builder, args.get_expr(0)?)?;
         generator.traverse_expr(builder, args.get_expr(1)?)?;
 
@@ -65,6 +72,13 @@ impl ComplexWord for Verify {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 3 {
+            return Err(GeneratorError::InternalError(format!(
+                "secp256k1-verify expected 3 arguments, got {}",
+                args.len()
+            )));
+        };
+
         generator.traverse_expr(builder, args.get_expr(0)?)?;
         generator.traverse_expr(builder, args.get_expr(1)?)?;
         generator.traverse_expr(builder, args.get_expr(2)?)?;

--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -84,6 +84,13 @@ impl ComplexWord for Fold {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 3 {
+            return Err(GeneratorError::InternalError(format!(
+                "fold expected 3 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let func = args.get_name(0)?;
         let sequence = args.get_expr(1)?;
         let initial = args.get_expr(2)?;
@@ -268,6 +275,13 @@ impl ComplexWord for Append {
         expr: &SymbolicExpression,
         args: &[clarity::vm::SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "append expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let ty = generator
             .get_expr_type(expr)
             .ok_or_else(|| GeneratorError::TypeError("append result must be typed".to_string()))?
@@ -355,6 +369,13 @@ impl ComplexWord for AsMaxLen {
         _expr: &SymbolicExpression,
         args: &[clarity::vm::SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "as-max-len? expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         // Push a `0` and a `1` to the stack, to be used by the `select`
         // instruction later.
         builder.i32_const(0).i32_const(1);
@@ -455,6 +476,13 @@ impl ComplexWord for Concat {
         expr: &SymbolicExpression,
         args: &[clarity::vm::SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "concat expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let memory = generator.get_memory()?;
 
         // Create a new sequence to hold the result in the stack frame
@@ -526,6 +554,13 @@ impl ComplexWord for Map {
         expr: &SymbolicExpression,
         args: &[clarity::vm::SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() < 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "map expected at least 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let fname = args.get_name(0)?;
 
         let seq_ty = generator
@@ -806,6 +841,13 @@ impl ComplexWord for Len {
         _expr: &SymbolicExpression,
         args: &[clarity::vm::SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 1 {
+            return Err(GeneratorError::InternalError(format!(
+                "len expected 1 argument, got {}",
+                args.len()
+            )));
+        };
+
         // Traverse the sequence, leaving the offset and length on the stack.
         let seq = args.get_expr(0)?;
         generator.traverse_expr(builder, seq)?;
@@ -886,6 +928,13 @@ impl ComplexWord for ElementAt {
         expr: &SymbolicExpression,
         args: &[clarity::vm::SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "element-at expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         // Traverse the sequence, leaving the offset and length on the stack.
         let seq = args.get_expr(0)?;
         generator.traverse_expr(builder, seq)?;
@@ -1065,6 +1114,13 @@ impl ComplexWord for ReplaceAt {
         expr: &SymbolicExpression,
         args: &[clarity::vm::SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 3 {
+            return Err(GeneratorError::InternalError(format!(
+                "replace-at? expected 3 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let seq = args.get_expr(0)?;
         let seq_ty = generator
             .get_expr_type(seq)
@@ -1314,6 +1370,13 @@ impl ComplexWord for Slice {
         _expr: &SymbolicExpression,
         args: &[clarity::vm::SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 3 {
+            return Err(GeneratorError::InternalError(format!(
+                "slice? expected 3 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let seq = args.get_expr(0)?;
 
         // Traverse the sequence, leaving the offset and length on the stack.

--- a/clar2wasm/src/words/stx.rs
+++ b/clar2wasm/src/words/stx.rs
@@ -62,6 +62,13 @@ impl ComplexWord for StxTransfer {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 3 {
+            return Err(GeneratorError::InternalError(format!(
+                "stx-transfer? expected 3 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let amount = args.get_expr(0)?;
         let sender = args.get_expr(1)?;
         let recipient = args.get_expr(2)?;
@@ -92,6 +99,13 @@ impl ComplexWord for StxTransferMemo {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 4 {
+            return Err(GeneratorError::InternalError(format!(
+                "stx-transfer-memo? expected 4 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let amount = args.get_expr(0)?;
         let sender = args.get_expr(1)?;
         let recipient = args.get_expr(2)?;

--- a/clar2wasm/src/words/tokens.rs
+++ b/clar2wasm/src/words/tokens.rs
@@ -19,6 +19,13 @@ impl ComplexWord for DefineFungibleToken {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 1 && args.len() != 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "define-fungible-token expected 1 or 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let name = args.get_name(0)?;
         // Making sure if name is not reserved
         if generator.is_reserved_name(name) {
@@ -67,6 +74,13 @@ impl ComplexWord for BurnFungibleToken {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 3 {
+            return Err(GeneratorError::InternalError(format!(
+                "ft-burn? expected 3 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let token = args.get_name(0)?;
         let amount = args.get_expr(1)?;
         let sender = args.get_expr(2)?;
@@ -103,6 +117,13 @@ impl ComplexWord for TransferFungibleToken {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 4 {
+            return Err(GeneratorError::InternalError(format!(
+                "ft-transfer? expected 4 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let token = args.get_name(0)?;
         let amount = args.get_expr(1)?;
         let sender = args.get_expr(2)?;
@@ -141,6 +162,13 @@ impl ComplexWord for MintFungibleToken {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 3 {
+            return Err(GeneratorError::InternalError(format!(
+                "ft-mint? expected 3 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let token = args.get_name(0)?;
         let amount = args.get_expr(1)?;
         let recipient = args.get_expr(2)?;
@@ -176,6 +204,13 @@ impl ComplexWord for GetSupplyOfFungibleToken {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 1 {
+            return Err(GeneratorError::InternalError(format!(
+                "ft-get-supply expected 1 argument, got {}",
+                args.len()
+            )));
+        };
+
         let token = args.get_name(0)?;
 
         let (id_offset, id_length) = generator.add_string_literal(token)?;
@@ -204,6 +239,13 @@ impl ComplexWord for GetBalanceOfFungibleToken {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "ft-get-balance expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let token = args.get_name(0)?;
         let owner = args.get_expr(1)?;
 
@@ -240,6 +282,13 @@ impl ComplexWord for DefineNonFungibleToken {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "define-non-fungible-token expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let name = args.get_name(0)?;
         // Making sure if name is not reserved
         if generator.is_reserved_name(name) {
@@ -287,6 +336,13 @@ impl ComplexWord for BurnNonFungibleToken {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 3 {
+            return Err(GeneratorError::InternalError(format!(
+                "nft-burn? expected 3 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let token = args.get_name(0)?;
         let identifier = args.get_expr(1)?;
         let sender = args.get_expr(2)?;
@@ -340,6 +396,13 @@ impl ComplexWord for TransferNonFungibleToken {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 4 {
+            return Err(GeneratorError::InternalError(format!(
+                "nft-transfer? expected 4 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let token = args.get_name(0)?;
         let identifier = args.get_expr(1)?;
         let sender = args.get_expr(2)?;
@@ -397,6 +460,13 @@ impl ComplexWord for MintNonFungibleToken {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 3 {
+            return Err(GeneratorError::InternalError(format!(
+                "nft-mint? expected 3 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let token = args.get_name(0)?;
         let identifier = args.get_expr(1)?;
         let recipient = args.get_expr(2)?;
@@ -450,6 +520,13 @@ impl ComplexWord for GetOwnerOfNonFungibleToken {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "nft-get-owner? expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let token = args.get_name(0)?;
         let identifier = args.get_expr(1)?;
 

--- a/clar2wasm/src/words/traits.rs
+++ b/clar2wasm/src/words/traits.rs
@@ -18,6 +18,13 @@ impl ComplexWord for DefineTrait {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "define-trait expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         let name = args.get_name(0)?;
         // Making sure if name is not reserved
         if generator.is_reserved_name(name) {
@@ -63,6 +70,13 @@ impl ComplexWord for UseTrait {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 2 {
+            return Err(GeneratorError::InternalError(format!(
+                "use-trait expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
+
         // We simply add the trait alias to the memory so that contract-call?
         // can retrieve a correct function return type at call.
         let name = &args
@@ -95,6 +109,13 @@ impl ComplexWord for ImplTrait {
         _expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.len() != 1 {
+            return Err(GeneratorError::InternalError(format!(
+                "impl-trait expected 1 argument, got {}",
+                args.len()
+            )));
+        };
+
         let trait_identifier = match &args.get_expr(0)?.expr {
             SymbolicExpressionType::Field(trait_identifier) => trait_identifier,
             _ => {

--- a/clar2wasm/src/words/tuples.rs
+++ b/clar2wasm/src/words/tuples.rs
@@ -21,6 +21,10 @@ impl ComplexWord for TupleCons {
         expr: &SymbolicExpression,
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
+        if args.is_empty() {
+            return Err(GeneratorError::InternalError("tuple expected at least 1 argument, got 0".to_owned()));
+        };
+
         let ty = generator
             .get_expr_type(expr)
             .ok_or_else(|| GeneratorError::TypeError("tuple expression must be typed".to_string()))?
@@ -103,10 +107,11 @@ impl ComplexWord for TupleGet {
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
         if args.len() != 2 {
-            return Err(GeneratorError::InternalError(
-                "expected two arguments to tuple get".to_string(),
-            ));
-        }
+            return Err(GeneratorError::InternalError(format!(
+                "get expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
 
         let target_field_name = args[0]
             .match_atom()
@@ -181,10 +186,11 @@ impl ComplexWord for TupleMerge {
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
         if args.len() != 2 {
-            return Err(GeneratorError::InternalError(
-                "expected two arguments to tuple merge".to_string(),
-            ));
-        }
+            return Err(GeneratorError::InternalError(format!(
+                "merge expected 2 arguments, got {}",
+                args.len()
+            )));
+        };
 
         let lhs_tuple_ty = generator
             .get_expr_type(&args[0])


### PR DESCRIPTION
Added checks in `traverse` functions throughout the code in order to verify that the number of arguments provided at compile-time is the expected one for the given function.

Reference issue: https://github.com/stacks-network/clarity-wasm/issues/159