### PR TITLE
Set the correct type for NFT identifiers

### DIFF
--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -53,6 +53,8 @@ pub struct WasmGenerator {
     pub(crate) datavars_types: HashMap<ClarityName, TypeSignature>,
     /// The types of (key, value) in defined maps
     pub(crate) maps_types: HashMap<ClarityName, (TypeSignature, TypeSignature)>,
+    /// The type of defined NFTs
+    pub(crate) nft_types: HashMap<ClarityName, TypeSignature>,
 
     /// The locals for the current function.
     pub(crate) bindings: Bindings,
@@ -319,6 +321,7 @@ impl WasmGenerator {
             datavars_types: HashMap::new(),
             maps_types: HashMap::new(),
             local_pool: Rc::new(RefCell::new(HashMap::new())),
+            nft_types: HashMap::new(),
         })
     }
 

--- a/clar2wasm/src/words/tokens.rs
+++ b/clar2wasm/src/words/tokens.rs
@@ -500,10 +500,8 @@ impl ComplexWord for GetOwnerOfNonFungibleToken {
 
 #[cfg(test)]
 mod tests {
-    use clarity::vm::{
-        types::{PrincipalData, TupleData},
-        Value,
-    };
+    use clarity::vm::types::{PrincipalData, TupleData};
+    use clarity::vm::Value;
 
     use crate::tools::{crosscheck, crosscheck_expect_failure};
 

--- a/clar2wasm/src/words/tokens.rs
+++ b/clar2wasm/src/words/tokens.rs
@@ -361,7 +361,7 @@ impl ComplexWord for TransferNonFungibleToken {
 
         // Push the identifier onto the stack
         let identifier_ty = generator.nft_types.get(token).cloned().ok_or_else(|| {
-            GeneratorError::TypeError("Usage of nft-burn? on an unknown nft token".to_owned())
+            GeneratorError::TypeError("Usage of nft-transfer? on an unknown nft token".to_owned())
         })?;
         generator.set_expr_type(identifier, identifier_ty.clone())?;
         generator.traverse_expr(builder, identifier)?;
@@ -416,7 +416,7 @@ impl ComplexWord for MintNonFungibleToken {
 
         // Push the identifier onto the stack
         let identifier_ty = generator.nft_types.get(token).cloned().ok_or_else(|| {
-            GeneratorError::TypeError("Usage of nft-burn? on an unknown nft token".to_owned())
+            GeneratorError::TypeError("Usage of nft-mint? on an unknown nft token".to_owned())
         })?;
         generator.set_expr_type(identifier, identifier_ty.clone())?;
         generator.traverse_expr(builder, identifier)?;
@@ -467,7 +467,7 @@ impl ComplexWord for GetOwnerOfNonFungibleToken {
 
         // Push the identifier onto the stack
         let identifier_ty = generator.nft_types.get(token).cloned().ok_or_else(|| {
-            GeneratorError::TypeError("Usage of nft-burn? on an unknown nft token".to_owned())
+            GeneratorError::TypeError("Usage of nft-get-owner? on an unknown nft token".to_owned())
         })?;
         generator.set_expr_type(identifier, identifier_ty.clone())?;
         generator.traverse_expr(builder, identifier)?;

--- a/clar2wasm/src/words/tokens.rs
+++ b/clar2wasm/src/words/tokens.rs
@@ -249,7 +249,16 @@ impl ComplexWord for DefineNonFungibleToken {
             )));
         }
 
-        let _nft_type = args.get_expr(1)?;
+        // we will save the NFT type for reuse with the nft-x functions
+        // (a wrong NFT type is an issue only with Clarity1, but it doesn't
+        // hurt to use it with all Clarity versions)
+        let nft_type = TypeSignature::parse_type_repr(
+            generator.contract_analysis.epoch,
+            args.get_expr(1)?,
+            &mut (),
+        )
+        .map_err(|e| GeneratorError::TypeError(e.to_string()))?;
+        generator.nft_types.insert(name.clone(), nft_type);
 
         // Store the identifier as a string literal in the memory
         let (name_offset, name_length) = generator.add_string_literal(name)?;
@@ -298,12 +307,11 @@ impl ComplexWord for BurnNonFungibleToken {
             .i32_const(id_length as i32);
 
         // Push the identifier onto the stack
+        let identifier_ty = generator.nft_types.get(token).cloned().ok_or_else(|| {
+            GeneratorError::TypeError("Usage of nft-burn? on an unknown nft token".to_owned())
+        })?;
+        generator.set_expr_type(identifier, identifier_ty.clone())?;
         generator.traverse_expr(builder, identifier)?;
-
-        let identifier_ty = generator
-            .get_expr_type(identifier)
-            .ok_or_else(|| GeneratorError::TypeError("NFT identifier must be typed".to_owned()))?
-            .clone();
 
         // Allocate space on the stack for the identifier
         let (id_offset, id_size) =
@@ -352,12 +360,11 @@ impl ComplexWord for TransferNonFungibleToken {
             .i32_const(id_length as i32);
 
         // Push the identifier onto the stack
+        let identifier_ty = generator.nft_types.get(token).cloned().ok_or_else(|| {
+            GeneratorError::TypeError("Usage of nft-burn? on an unknown nft token".to_owned())
+        })?;
+        generator.set_expr_type(identifier, identifier_ty.clone())?;
         generator.traverse_expr(builder, identifier)?;
-
-        let identifier_ty = generator
-            .get_expr_type(identifier)
-            .ok_or_else(|| GeneratorError::TypeError("NFT identifier must be typed".to_owned()))?
-            .clone();
 
         // Allocate space on the stack for the identifier
         let (id_offset, id_size) =
@@ -408,12 +415,11 @@ impl ComplexWord for MintNonFungibleToken {
             .i32_const(id_length as i32);
 
         // Push the identifier onto the stack
+        let identifier_ty = generator.nft_types.get(token).cloned().ok_or_else(|| {
+            GeneratorError::TypeError("Usage of nft-burn? on an unknown nft token".to_owned())
+        })?;
+        generator.set_expr_type(identifier, identifier_ty.clone())?;
         generator.traverse_expr(builder, identifier)?;
-
-        let identifier_ty = generator
-            .get_expr_type(identifier)
-            .ok_or_else(|| GeneratorError::TypeError("NFT identifier must be typed".to_owned()))?
-            .clone();
 
         // Allocate space on the stack for the identifier
         let (id_offset, id_size) =
@@ -460,12 +466,11 @@ impl ComplexWord for GetOwnerOfNonFungibleToken {
             .i32_const(id_length as i32);
 
         // Push the identifier onto the stack
+        let identifier_ty = generator.nft_types.get(token).cloned().ok_or_else(|| {
+            GeneratorError::TypeError("Usage of nft-burn? on an unknown nft token".to_owned())
+        })?;
+        generator.set_expr_type(identifier, identifier_ty.clone())?;
         generator.traverse_expr(builder, identifier)?;
-
-        let identifier_ty = generator
-            .get_expr_type(identifier)
-            .ok_or_else(|| GeneratorError::TypeError("NFT identifier must be typed".to_owned()))?
-            .clone();
 
         // Allocate space on the stack for the identifier
         let (id_offset, id_size) =


### PR DESCRIPTION
Fixes #515 

The problem happens only with Clarity1, the typechecker doesn't set the defined type for the asset identifier, it just interpolates it from the value.

The fix is applied without regards to the version of Clarity, since it doesn't harm the process.