### PR TITLE
Fix new clippy warning from Rust 1.82

### DIFF
--- a/clar2wasm/src/lib.rs
+++ b/clar2wasm/src/lib.rs
@@ -47,7 +47,7 @@ pub struct CompileResult {
 #[derive(Debug)]
 pub enum CompileError {
     Generic {
-        ast: ContractAST,
+        ast: Box<ContractAST>,
         diagnostics: Vec<Diagnostic>,
         cost_tracker: Box<LimitedCostTracker>,
     },
@@ -72,7 +72,7 @@ pub fn compile(
 
     if !success {
         return Err(CompileError::Generic {
-            ast,
+            ast: Box::new(ast),
             diagnostics,
             cost_tracker: Box::new(cost_tracker),
         });
@@ -93,7 +93,7 @@ pub fn compile(
         Err((e, cost_track)) => {
             diagnostics.push(Diagnostic::err(&e.err));
             return Err(CompileError::Generic {
-                ast,
+                ast: Box::new(ast),
                 diagnostics,
                 cost_tracker: Box::new(cost_track),
             });
@@ -108,7 +108,7 @@ pub fn compile(
     if let Err(e) = utils::concretize(&mut contract_analysis) {
         diagnostics.push(e.diagnostic);
         return Err(CompileError::Generic {
-            ast: ast.clone(),
+            ast: Box::new(ast),
             diagnostics: diagnostics.clone(),
             cost_tracker: Box::new(
                 contract_analysis
@@ -130,7 +130,7 @@ pub fn compile(
         Err(e) => {
             diagnostics.push(Diagnostic::err(&e));
             Err(CompileError::Generic {
-                ast,
+                ast: Box::new(ast),
                 diagnostics,
                 cost_tracker: Box::new(
                     contract_analysis


### PR DESCRIPTION
The new Rust update 1.82 created this new clippy warning that prevents the CI from passing:
```
error: the `Err`-variant returned from this function is very large
  --> clar2wasm/src/lib.rs:63:6
   |
49 | /     Generic {
50 | |         ast: ContractAST,
51 | |         diagnostics: Vec<Diagnostic>,
52 | |         cost_tracker: Box<LimitedCostTracker>,
53 | |     },
   | |_____- the largest variant contains at least 240 bytes
...
63 |   ) -> Result<CompileResult, CompileError> {
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: try reducing the size of `CompileError`, for example by boxing large elements or replacing it with `Box<CompileError>`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err
   = note: `-D clippy::result-large-err` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::result_large_err)]`
```

Following the recommendation, I boxed the large element `ast` from `CompileError::Generic`.