### PR TITLE
Add command-line arguments for ClarityVersion and Stacks epoch

### DIFF
--- a/clar2wasm/src/bin/main.rs
+++ b/clar2wasm/src/bin/main.rs
@@ -1,12 +1,12 @@
+mod utils;
 use std::fs;
 
 use clap::Parser;
 use clar2wasm::CompileError;
-use clarity::types::StacksEpochId;
 use clarity::vm::costs::LimitedCostTracker;
 use clarity::vm::database::MemoryBackingStore;
 use clarity::vm::types::QualifiedContractIdentifier;
-use clarity::vm::ClarityVersion;
+use utils::{WrappedClarityVersion, WrappedEpochId};
 
 /// clar2wasm is a compiler for generating WebAssembly from Clarity.
 #[derive(Parser)]
@@ -15,13 +15,11 @@ struct Args {
     /// Clarity source file to compile
     input: String,
     /// Clarity version to use (1, 2 or 3)
-    /// If any other value is provided, default Clarity3
     #[arg(short, long)]
-    clarity_version: Option<u8>,
-    /// Stacks epoch to use (10, 20, 205, 21, 22, 23, 24, 25 or 30)
-    /// If any other value is provided, default to Epoch30
+    clarity_version: Option<WrappedClarityVersion>,
+    /// Stacks epoch to use (1.0, 2.0, 2.05, 2.1, 2.2, 2.3, 2.4, 2.5 or 3.0)
     #[arg(short, long)]
-    epoch: Option<u8>,
+    stacks_epoch: Option<WrappedEpochId>,
     /// Output file to write compiled WebAssembly to
     #[arg(short, long)]
     output: Option<String>,
@@ -47,10 +45,8 @@ fn main() {
 
     // Define some settings
     let contract_id = QualifiedContractIdentifier::transient();
-    let clarity_version = ClarityVersion::from(ClarityVersionMapping::from(
-        args.clarity_version.unwrap_or(2),
-    ));
-    let epoch = StacksEpochId::from(StacksEpochMapping::from(args.epoch.unwrap_or(25)));
+    let clarity_version = args.clarity_version.unwrap_or_default().into();
+    let epoch = args.stacks_epoch.unwrap_or_default().into();
 
     // Setup a datastore and cost tracker
     let mut datastore = MemoryBackingStore::new();
@@ -93,78 +89,5 @@ fn main() {
     if let Err(error) = module.emit_wasm_file(output.as_str()) {
         eprintln!("Error writing Wasm file, {}: {}", output, error);
         std::process::exit(1);
-    }
-}
-
-
-#[derive(Debug)]
-pub enum ClarityVersionMapping {
-    Clarity1,
-    Clarity2,
-    Clarity3,
-}
-
-impl From<u8> for ClarityVersionMapping {
-    fn from(value: u8) -> Self {
-        match value {
-            1 => Self::Clarity1,
-            2 => Self::Clarity2,
-            _ => Self::Clarity3, // Default to Clarity3 for any other value
-        }
-    }
-}
-
-impl From<ClarityVersionMapping> for ClarityVersion {
-    fn from(version: ClarityVersionMapping) -> Self {
-        match version {
-            ClarityVersionMapping::Clarity1 => ClarityVersion::Clarity1,
-            ClarityVersionMapping::Clarity2 => ClarityVersion::Clarity2,
-            ClarityVersionMapping::Clarity3 => ClarityVersion::Clarity3,
-        }
-    }
-}
-
-#[derive(Debug)]
-enum StacksEpochMapping {
-    Epoch10,
-    Epoch20,
-    Epoch2_05,
-    Epoch21,
-    Epoch22,
-    Epoch23,
-    Epoch24,
-    Epoch25,
-    Epoch30,
-}
-
-impl From<u8> for StacksEpochMapping {
-    fn from(value: u8) -> Self {
-        match value {
-            10 => Self::Epoch10,
-            20 => Self::Epoch20,
-            205 => Self::Epoch2_05,
-            21 => Self::Epoch21,
-            22 => Self::Epoch22,
-            23 => Self::Epoch23,
-            24 => Self::Epoch24,
-            25 => Self::Epoch25,
-            _ => Self::Epoch30, // Default to Epoch30 for any other value
-        }
-    }
-}
-
-impl From<StacksEpochMapping> for StacksEpochId {
-    fn from(epoch: StacksEpochMapping) -> Self {
-        match epoch {
-            StacksEpochMapping::Epoch10 => StacksEpochId::Epoch10,
-            StacksEpochMapping::Epoch20 => StacksEpochId::Epoch20,
-            StacksEpochMapping::Epoch2_05 => StacksEpochId::Epoch2_05,
-            StacksEpochMapping::Epoch21 => StacksEpochId::Epoch21,
-            StacksEpochMapping::Epoch22 => StacksEpochId::Epoch22,
-            StacksEpochMapping::Epoch23 => StacksEpochId::Epoch23,
-            StacksEpochMapping::Epoch24 => StacksEpochId::Epoch24,
-            StacksEpochMapping::Epoch25 => StacksEpochId::Epoch25,
-            StacksEpochMapping::Epoch30 => StacksEpochId::Epoch30,
-        }
     }
 }

--- a/clar2wasm/src/bin/main.rs
+++ b/clar2wasm/src/bin/main.rs
@@ -14,6 +14,14 @@ use clarity::vm::ClarityVersion;
 struct Args {
     /// Clarity source file to compile
     input: String,
+    /// Clarity version to use (1, 2 or 3)
+    /// If any other value is provided, default Clarity3
+    #[arg(short, long)]
+    clarity_version: Option<u8>,
+    /// Stacks epoch to use (10, 20, 205, 21, 22, 23, 24, 25 or 30)
+    /// If any other value is provided, default to Epoch30
+    #[arg(short, long)]
+    epoch: Option<u8>,
     /// Output file to write compiled WebAssembly to
     #[arg(short, long)]
     output: Option<String>,
@@ -39,8 +47,10 @@ fn main() {
 
     // Define some settings
     let contract_id = QualifiedContractIdentifier::transient();
-    let clarity_version = ClarityVersion::Clarity2;
-    let epoch = StacksEpochId::Epoch25;
+    let clarity_version = ClarityVersion::from(ClarityVersionMapping::from(
+        args.clarity_version.unwrap_or(2),
+    ));
+    let epoch = StacksEpochId::from(StacksEpochMapping::from(args.epoch.unwrap_or(25)));
 
     // Setup a datastore and cost tracker
     let mut datastore = MemoryBackingStore::new();
@@ -83,5 +93,78 @@ fn main() {
     if let Err(error) = module.emit_wasm_file(output.as_str()) {
         eprintln!("Error writing Wasm file, {}: {}", output, error);
         std::process::exit(1);
+    }
+}
+
+
+#[derive(Debug)]
+pub enum ClarityVersionMapping {
+    Clarity1,
+    Clarity2,
+    Clarity3,
+}
+
+impl From<u8> for ClarityVersionMapping {
+    fn from(value: u8) -> Self {
+        match value {
+            1 => Self::Clarity1,
+            2 => Self::Clarity2,
+            _ => Self::Clarity3, // Default to Clarity3 for any other value
+        }
+    }
+}
+
+impl From<ClarityVersionMapping> for ClarityVersion {
+    fn from(version: ClarityVersionMapping) -> Self {
+        match version {
+            ClarityVersionMapping::Clarity1 => ClarityVersion::Clarity1,
+            ClarityVersionMapping::Clarity2 => ClarityVersion::Clarity2,
+            ClarityVersionMapping::Clarity3 => ClarityVersion::Clarity3,
+        }
+    }
+}
+
+#[derive(Debug)]
+enum StacksEpochMapping {
+    Epoch10,
+    Epoch20,
+    Epoch2_05,
+    Epoch21,
+    Epoch22,
+    Epoch23,
+    Epoch24,
+    Epoch25,
+    Epoch30,
+}
+
+impl From<u8> for StacksEpochMapping {
+    fn from(value: u8) -> Self {
+        match value {
+            10 => Self::Epoch10,
+            20 => Self::Epoch20,
+            205 => Self::Epoch2_05,
+            21 => Self::Epoch21,
+            22 => Self::Epoch22,
+            23 => Self::Epoch23,
+            24 => Self::Epoch24,
+            25 => Self::Epoch25,
+            _ => Self::Epoch30, // Default to Epoch30 for any other value
+        }
+    }
+}
+
+impl From<StacksEpochMapping> for StacksEpochId {
+    fn from(epoch: StacksEpochMapping) -> Self {
+        match epoch {
+            StacksEpochMapping::Epoch10 => StacksEpochId::Epoch10,
+            StacksEpochMapping::Epoch20 => StacksEpochId::Epoch20,
+            StacksEpochMapping::Epoch2_05 => StacksEpochId::Epoch2_05,
+            StacksEpochMapping::Epoch21 => StacksEpochId::Epoch21,
+            StacksEpochMapping::Epoch22 => StacksEpochId::Epoch22,
+            StacksEpochMapping::Epoch23 => StacksEpochId::Epoch23,
+            StacksEpochMapping::Epoch24 => StacksEpochId::Epoch24,
+            StacksEpochMapping::Epoch25 => StacksEpochId::Epoch25,
+            StacksEpochMapping::Epoch30 => StacksEpochId::Epoch30,
+        }
     }
 }


### PR DESCRIPTION
This PR is adding command-line arguments to set the Clarity version and Stacks epoch dynamically when running the compiler. Previously, these values were hardcoded to Clarity2 and Epoch25 in `main.rs` that are now the default versions.

Related issue: #554