### PR TITLE
Fix the erasing of functions returned values

### DIFF
--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -16,7 +16,7 @@ use clarity::vm::types::{
 use clarity::vm::variables::NativeVariables;
 use clarity::vm::{functions, variables, ClarityName, SymbolicExpression, SymbolicExpressionType};
 use walrus::ir::{
-    BinaryOp, IfElse, InstrSeqId, InstrSeqType, LoadKind, MemArg, StoreKind, UnaryOp,
+    BinaryOp, IfElse, InstrSeqId, InstrSeqType, LoadKind, Loop, MemArg, StoreKind, UnaryOp,
 };
 use walrus::{
     ActiveData, DataKind, FunctionBuilder, FunctionId, GlobalId, InstrSeqBuilder, LocalId,
@@ -25,8 +25,8 @@ use walrus::{
 
 use crate::error_mapping::ErrorMap;
 use crate::wasm_utils::{
-    check_argument_count, get_type_in_memory_size, get_type_size, is_in_memory_type,
-    signature_from_string, ArgumentCountCheck,
+    check_argument_count, get_type_in_memory_size, get_type_size, signature_from_string,
+    ArgumentCountCheck,
 };
 use crate::{check_args, debug_msg, words};
 
@@ -1707,6 +1707,12 @@ impl WasmGenerator {
         return_ty: &TypeSignature,
         name: &ClarityName,
     ) -> Result<(), GeneratorError> {
+        // Reserve space to copy return value from function
+        // TODO: this is to much space allocated, we just need space
+        // for the parts written in memory (see issue #362)
+        let (return_offset, _len_offset) =
+            self.create_call_stack_local(builder, return_ty, true, true);
+
         if self
             .contract_analysis
             .get_public_function_type(name.as_str())
@@ -1734,35 +1740,190 @@ impl WasmGenerator {
 
         // If an in-memory value is returned from a function, we need to copy
         // it to our frame, from the callee's frame.
-        if is_in_memory_type(return_ty) {
-            // The result may be in the callee's call frame, can be overwritten
-            // after returning, so we need to copy it to our frame.
-            let result_offset = self.module.locals.add(ValType::I32);
-            let result_length = self.module.locals.add(ValType::I32);
-            builder.local_set(result_length).local_set(result_offset);
+        if has_in_memory_type(return_ty) {
+            let locals = self.save_to_locals(builder, return_ty, true);
+            self.copy_value(builder, return_ty, &locals, return_offset)?;
 
-            // Reserve space to store the returned value.
-            let offset = self.module.locals.add(ValType::I32);
-            builder.global_get(self.stack_pointer).local_tee(offset);
-            builder
-                .local_get(result_length)
-                .binop(BinaryOp::I32Add)
-                .global_set(self.stack_pointer);
-
-            let memory = self.get_memory()?;
-
-            // Copy the result to our frame.
-            builder
-                .local_get(offset)
-                .local_get(result_offset)
-                .local_get(result_length)
-                .memory_copy(memory, memory);
-
-            // Push the copied offset and length to the stack
-            builder.local_get(offset).local_get(result_length);
+            for l in locals {
+                builder.local_get(l);
+            }
         }
 
         Ok(())
+    }
+
+    /// Copies a value in *locals* to *copy_offset* while taking care of the in-memory values
+    /// , especilly inner in-memory values.
+    ///
+    /// This is a subroutine of [`Self::visit_call_user_defined`].
+    fn copy_value(
+        &mut self,
+        builder: &mut InstrSeqBuilder,
+        ty: &TypeSignature,
+        locals: &[LocalId],
+        copy_offset: LocalId,
+    ) -> Result<(), GeneratorError> {
+        match ty {
+            TypeSignature::NoType
+            | TypeSignature::IntType
+            | TypeSignature::UIntType
+            | TypeSignature::BoolType => Ok(()),
+            TypeSignature::SequenceType(SequenceSubtype::ListType(ltd)) => {
+                let [offset, len] = locals else {
+                    return Err(GeneratorError::InternalError(
+                        "Copy: a list type should be (offset, length)".to_owned(),
+                    ));
+                };
+                let memory = self.get_memory()?;
+
+                // we will copy the entire list as is to its destination first
+                builder
+                    .local_get(copy_offset)
+                    .local_get(*offset)
+                    .local_get(*len)
+                    .memory_copy(memory, memory);
+
+                // update the offset to copy_offset, then move copy_offset to point after the list
+                builder.local_get(copy_offset).local_set(*offset);
+                builder
+                    .local_get(copy_offset)
+                    .local_get(*len)
+                    .binop(BinaryOp::I32Add)
+                    .local_set(copy_offset);
+
+                // now we will iterate through the list elements, copy the in-memory parts and update the pointers
+                let copy_loop = {
+                    let mut loop_ = builder.dangling_instr_seq(None);
+                    let loop_id = loop_.id();
+
+                    let elem_ty = ltd.get_list_item_type();
+
+                    let size = self.read_from_memory(&mut loop_, *offset, 0, elem_ty)?;
+                    let elem_locals = self.save_to_locals(&mut loop_, elem_ty, true);
+
+                    self.copy_value(&mut loop_, elem_ty, &elem_locals, copy_offset)?;
+                    for l in elem_locals {
+                        loop_.local_get(l);
+                    }
+                    self.write_to_memory(&mut loop_, *offset, 0, elem_ty)?;
+
+                    loop_
+                        .local_get(*offset)
+                        .i32_const(size)
+                        .binop(BinaryOp::I32Add)
+                        .local_set(*offset);
+                    loop_
+                        .local_get(*len)
+                        .i32_const(size)
+                        .binop(BinaryOp::I32Sub)
+                        .local_tee(*len)
+                        .br_if(loop_id);
+
+                    loop_id
+                };
+
+                // if we have elements, we will store the (offset, len) on the stack, execute the copy loop, then get back the (offset, len)
+                builder.local_get(*len).if_else(
+                    None,
+                    |then| {
+                        then.local_get(*offset)
+                            .local_get(*len)
+                            .instr(Loop { seq: copy_loop })
+                            .local_set(*len)
+                            .local_set(*offset);
+                    },
+                    |_| {},
+                );
+
+                Ok(())
+            }
+            TypeSignature::SequenceType(_)
+            | TypeSignature::PrincipalType
+            | TypeSignature::CallableType(_)
+            | TypeSignature::TraitReferenceType(_) => {
+                let [offset, len] = locals else {
+                    return Err(GeneratorError::InternalError(
+                        "Copy: a simple in-memory type should be (offset, length)".to_owned(),
+                    ));
+                };
+
+                let memory = self.get_memory()?;
+                builder
+                    .local_get(copy_offset)
+                    .local_get(*offset)
+                    .local_get(*len)
+                    .memory_copy(memory, memory);
+                // Set the new offset
+                builder.local_get(copy_offset).local_set(*offset);
+                // Increment the copy offset
+                builder
+                    .local_get(copy_offset)
+                    .local_get(*len)
+                    .binop(BinaryOp::I32Add)
+                    .local_set(copy_offset);
+                Ok(())
+            }
+            TypeSignature::OptionalType(opt) => {
+                let some_id = {
+                    let mut some = builder.dangling_instr_seq(None);
+                    self.copy_value(&mut some, opt, &locals[1..], copy_offset)?;
+                    some.id()
+                };
+                let none_id = builder.dangling_instr_seq(None).id();
+
+                builder.local_get(locals[0]).instr(IfElse {
+                    consequent: some_id,
+                    alternative: none_id,
+                });
+
+                Ok(())
+            }
+            TypeSignature::ResponseType(resp) => {
+                let (ok_ty, err_ty) = &**resp;
+                let variant = locals[0];
+                let (ok_locals, err_locals) = locals[1..].split_at(clar2wasm_ty(ok_ty).len());
+                let ok_id = {
+                    let mut ok = builder.dangling_instr_seq(None);
+                    if has_in_memory_type(ok_ty) {
+                        self.copy_value(&mut ok, ok_ty, ok_locals, copy_offset)?;
+                    }
+                    ok.id()
+                };
+                let err_id = {
+                    let mut err = builder.dangling_instr_seq(None);
+                    if has_in_memory_type(err_ty) {
+                        self.copy_value(&mut err, err_ty, err_locals, copy_offset)?;
+                    }
+                    err.id()
+                };
+                builder.local_get(variant).instr(IfElse {
+                    consequent: ok_id,
+                    alternative: err_id,
+                });
+                Ok(())
+            }
+            TypeSignature::TupleType(tuple_type_signature) => {
+                let inner_ty_and_locals = tuple_type_signature.get_type_map().values().scan(
+                    locals,
+                    |remaining_locals, ty| {
+                        let current_locals;
+                        (current_locals, *remaining_locals) =
+                            remaining_locals.split_at(clar2wasm_ty(ty).len());
+                        Some((ty, current_locals))
+                    },
+                );
+
+                for (ty, locals) in inner_ty_and_locals {
+                    if has_in_memory_type(ty) {
+                        self.copy_value(builder, ty, locals, copy_offset)?;
+                    }
+                }
+                Ok(())
+            }
+            TypeSignature::ListUnionType(_) => {
+                unreachable!("ListUnionType is not a value type")
+            }
+        }
     }
 
     /// Call a function defined in the current contract.

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -1982,6 +1982,26 @@ impl WasmGenerator {
     }
 }
 
+/// Returns true if a composed type has an inner in-memory type.
+fn has_in_memory_type(ty: &TypeSignature) -> bool {
+    match ty {
+        TypeSignature::OptionalType(opt) => has_in_memory_type(opt),
+        TypeSignature::ResponseType(resp) => {
+            has_in_memory_type(&resp.0) || has_in_memory_type(&resp.1)
+        }
+        TypeSignature::TupleType(tup) => tup.get_type_map().values().any(has_in_memory_type),
+        TypeSignature::NoType
+        | TypeSignature::IntType
+        | TypeSignature::UIntType
+        | TypeSignature::BoolType => false,
+        TypeSignature::SequenceType(_)
+        | TypeSignature::PrincipalType
+        | TypeSignature::CallableType(_)
+        | TypeSignature::TraitReferenceType(_) => true,
+        TypeSignature::ListUnionType(_) => unreachable!("not a value type"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::env;

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -1709,11 +1709,10 @@ impl WasmGenerator {
     ) -> Result<(), GeneratorError> {
         // this local contains the offset at which we will copy the each new element of the result
         // if there is an in-memory type
-        let in_memory_offset =
-            has_in_memory_type(return_ty).then(|| self.module.locals.add(ValType::I32));
+        let in_memory_offset = has_in_memory_type(return_ty).then(|| {
+            let return_offset = self.module.locals.add(ValType::I32);
 
-        // in case there is an in-memory type to copy, we reserve some space in memory
-        if let Some(return_offset) = in_memory_offset {
+            // in case there is an in-memory type to copy, we reserve some space in memory
             let return_size = count_in_memory_space(return_ty) as i32;
             self.frame_size += return_size;
 
@@ -1723,7 +1722,9 @@ impl WasmGenerator {
                 .i32_const(return_size)
                 .binop(BinaryOp::I32Add)
                 .global_set(self.stack_pointer);
-        }
+
+            return_offset
+        });
 
         if self
             .contract_analysis

--- a/clar2wasm/tests/wasm-generation/function_calls.rs
+++ b/clar2wasm/tests/wasm-generation/function_calls.rs
@@ -6,6 +6,8 @@ use proptest::prelude::*;
 use crate::PropValue;
 
 proptest! {
+    #![proptest_config(super::runtime_config())]
+
     #[test]
     fn subsequent_func_calls_dont_erase_previous_results(
         result1 in PropValue::any(),

--- a/clar2wasm/tests/wasm-generation/function_calls.rs
+++ b/clar2wasm/tests/wasm-generation/function_calls.rs
@@ -1,0 +1,33 @@
+use clar2wasm::tools::crosscheck;
+use clarity::vm::types::TupleData;
+use clarity::vm::Value;
+use proptest::prelude::*;
+
+use crate::PropValue;
+
+proptest! {
+    #[test]
+    fn subsequent_func_calls_dont_erase_previous_results(
+        result1 in PropValue::any(),
+        result2 in PropValue::any(),
+    ) {
+        let snippet = format!(
+            r#"
+                (define-private (foo) {result1})
+                (define-private (bar) {result2})
+
+                {{ foo: (foo), bar: (bar) }}
+            "#
+        );
+
+        let expected = Value::from(
+            TupleData::from_data(vec![
+                ("foo".into(), result1.into()),
+                ("bar".into(), result2.into()),
+            ])
+            .unwrap(),
+        );
+
+        crosscheck(&snippet, Ok(Some(expected)));
+    }
+}

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -11,6 +11,7 @@ pub mod contracts;
 pub mod control_flow;
 pub mod default_to;
 pub mod equal;
+pub mod function_calls;
 pub mod functions;
 pub mod hashing;
 pub mod maps;


### PR DESCRIPTION
Issue #475 showed that our current handling of returned values after functions calls was incomplete.
Our current handling would copy the returned values for in-memory types, such as lists or strings.

But it completely missed in-memory types inside composed types. So a function that would return an `(optional string)` was not copied and could have its string overwritten.

This PR completes the copying to any possible types. It also adds the testing of the failing example in the issue and a property test that checks if the call of a function doesn't overwrite the result of a previous function.

This fix broke the `print::test_large_serialization` test at first. This is due to a bug in our memory allocation in the `map` function.
To mitigate it, I created a function that computes the amount of bytes needed for for handling a type with in-memory parts. This function might be a clue on the answer of #362 .


Fixes #475 