### PR TITLE
Prevent the genaration of `ValueTooLarge` in `append` proptests

### DIFF
--- a/clar2wasm/tests/wasm-generation/sequences.rs
+++ b/clar2wasm/tests/wasm-generation/sequences.rs
@@ -12,7 +12,9 @@ proptest! {
 
     #[test]
     fn append_value_to_list(mut values in (prop_signature(), 1usize..16).prop_flat_map(|(ty, size)| PropValue::many_from_type(ty, size))) {
-        let expected = Value::cons_list_unsanitized(values.iter().cloned().map(Value::from).collect()).unwrap();
+        let expected = Value::cons_list_unsanitized(values.iter().cloned().map(Value::from).collect());
+        prop_assume!(expected.is_ok(), "Couldn't generate a valid list");
+        let expected = expected.unwrap();
 
         let elem = values.pop().unwrap();
         let values = PropValue::try_from(values).unwrap();
@@ -22,7 +24,9 @@ proptest! {
 
     #[test]
     fn double_append_value_to_list(mut values in (prop_signature(), 2usize..16).prop_flat_map(|(ty, size)| PropValue::many_from_type(ty, size))) {
-        let expected = Value::cons_list_unsanitized(values.iter().cloned().map(Value::from).collect()).unwrap();
+        let expected = Value::cons_list_unsanitized(values.iter().cloned().map(Value::from).collect());
+        prop_assume!(expected.is_ok(), "Couldn't generate a valid list");
+        let expected = expected.unwrap();
 
         let elem_last = values.pop().unwrap();
         let elem_before_last = values.pop().unwrap();


### PR DESCRIPTION
That was my bad, I unwrapped like a savage.