### PR TITLE
chore: update stacks-core dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core?branch=feat/clarity-wasm-develop#21cabdf7acd17ab3b4ac8ba28db89a9b3c70d6cc"
+source = "git+https://github.com/stacks-network/stacks-core?branch=feat/clarity-wasm-develop#04313767085cfb224a0c56efabcd3d47a743488c"
 dependencies = [
  "hashbrown 0.14.5",
  "integer-sqrt",
@@ -2335,7 +2335,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core?branch=feat/clarity-wasm-develop#21cabdf7acd17ab3b4ac8ba28db89a9b3c70d6cc"
+source = "git+https://github.com/stacks-network/stacks-core?branch=feat/clarity-wasm-develop#04313767085cfb224a0c56efabcd3d47a743488c"
 dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",

--- a/clar2wasm/src/datastore.rs
+++ b/clar2wasm/src/datastore.rs
@@ -225,6 +225,14 @@ impl ClarityBackingStore for Datastore {
         }
     }
 
+    // this is not meant to be used in the clarity vm
+    fn get_data_from_path(
+        &mut self,
+        _hash: &clarity::types::chainstate::TrieHash,
+    ) -> Result<Option<String>> {
+        unreachable!()
+    }
+
     fn has_entry(&mut self, key: &str) -> Result<bool> {
         Ok(self.get_data(key)?.is_some())
     }
@@ -292,6 +300,14 @@ impl ClarityBackingStore for Datastore {
 
     fn get_data_with_proof(&mut self, _key: &str) -> Result<Option<(String, Vec<u8>)>> {
         Ok(None)
+    }
+
+    // this is not meant to be used in the clarity vm
+    fn get_data_with_proof_from_path(
+        &mut self,
+        _hash: &clarity::types::chainstate::TrieHash,
+    ) -> Result<Option<(String, Vec<u8>)>> {
+        unreachable!()
     }
 
     fn get_contract_hash(


### PR DESCRIPTION
The new functions in the trait are not supposed to be called in the clarity vm, so it should not impact clarity-wasm i believe.

See [this comment](https://github.com/stacks-network/stacks-core/blob/e13958def1e367cbe088ec6475828440983cf355/clarity/src/vm/database/key_value_wrapper.rs#L410-L416)