### PR TITLE
`to-consensus-buff?` out of bounds memory access fix

### DIFF
--- a/clar2wasm/src/words/consensus_buff.rs
+++ b/clar2wasm/src/words/consensus_buff.rs
@@ -37,13 +37,17 @@ impl ComplexWord for ToConsensusBuff {
             })?
             .clone();
 
-        // Save the offset (current stack pointer) into a local.
-        // This is where we will serialize the value to.
-        let offset = generator.module.locals.add(walrus::ValType::I32);
+        let expr_ty = generator
+            .get_expr_type(_expr)
+            .ok_or_else(|| {
+                GeneratorError::TypeError(
+                    "to-consensus-buff? value expression must be typed".to_owned(),
+                )
+            })?
+            .clone();
+        let (offset, _) = generator.create_call_stack_local(builder, &expr_ty, false, true);
+
         let length = generator.module.locals.add(walrus::ValType::I32);
-        builder
-            .global_get(generator.stack_pointer)
-            .local_set(offset);
 
         // Write the serialized value to the top of the call stack
         generator.serialize_to_memory(builder, offset, 0, &ty)?;

--- a/clar2wasm/src/words/consensus_buff.rs
+++ b/clar2wasm/src/words/consensus_buff.rs
@@ -21,7 +21,7 @@ impl ComplexWord for ToConsensusBuff {
         &self,
         generator: &mut crate::wasm_generator::WasmGenerator,
         builder: &mut walrus::InstrSeqBuilder,
-        _expr: &clarity::vm::SymbolicExpression,
+        expr: &clarity::vm::SymbolicExpression,
         args: &[clarity::vm::SymbolicExpression],
     ) -> Result<(), crate::wasm_generator::GeneratorError> {
         check_args!(generator, builder, 1, args.len(), ArgumentCountCheck::Exact);
@@ -38,7 +38,7 @@ impl ComplexWord for ToConsensusBuff {
             .clone();
 
         let expr_ty = generator
-            .get_expr_type(_expr)
+            .get_expr_type(expr)
             .ok_or_else(|| {
                 GeneratorError::TypeError(
                     "to-consensus-buff? value expression must be typed".to_owned(),


### PR DESCRIPTION
This PR addresses the out of bounds memory access bug on `to-consensus-buff?`.

Related issue: #571