### PR TITLE
Fix OOM issue on `int-to-ascii` and `int-to-utf8`

### DIFF
--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -2649,9 +2649,9 @@
         )
     )
 
-    (func $stdlib.uint-to-string (param $lo i64) (param $hi i64) (result i32 i32)
+    (func $stdlib.uint-to-string (param $lo i64) (param $hi i64) (param $offset i32) (result i32 i32)
         (local $i i32) (local $j i32)
-        (local.set $j (local.tee $i (global.get $stack-pointer)))
+        (local.set $j (local.tee $i (local.get $offset)))
 
         ;; slow loop while $hi > 0
         (if (i64.ne (local.get $hi) (i64.const 0))
@@ -2697,8 +2697,8 @@
         ;; final result offset and length on the stack
         (local.get $j)
         (i32.sub (local.get $i) (local.get $j))
-        ;; update stack-pointer
-        (global.set $stack-pointer (local.get $i))
+        ;; update offset
+        (local.set $offset (local.get $i))
 
         ;; reverse answer in memory
         (local.set $i (i32.sub (local.get $i) (i32.const 1)))
@@ -2723,14 +2723,14 @@
         ;; final result is already on the stack
     )
 
-    (func $stdlib.int-to-string (param $lo i64) (param $hi i64) (result i32 i32)
+    (func $stdlib.int-to-string (param $lo i64) (param $hi i64) (param $offset i32) (result i32 i32)
         (local $negative i32) (local $len i32)
         (local.set $negative (i64.lt_s (local.get $hi) (i64.const 0)))
         ;; add a '-' if n < 0
         (if (local.get $negative)
             (then
-                (i32.store8 (global.get $stack-pointer) (i32.const 45))
-                (global.set $stack-pointer (i32.add (global.get $stack-pointer) (i32.const 1)))
+                (i32.store8 (local.get $offset) (i32.const 45))
+                (local.set $offset (i32.add (local.get $offset) (i32.const 1)))
             )
         )
 
@@ -2741,11 +2741,12 @@
                 (i64.ge_s (local.get $hi) (i64.const 0))
                 (i64.eq (local.get $hi) (i64.const 0x8000000000000000))
             )
-            (then (call $stdlib.uint-to-string (local.get $lo) (local.get $hi)))
+            (then (call $stdlib.uint-to-string (local.get $lo) (local.get $hi) (local.get $offset)))
             (else
                 (call $stdlib.uint-to-string
                     (i64.sub (i64.const 0) (local.get $lo))
                     (i64.sub (i64.const 0) (i64.add (local.get $hi) (i64.extend_i32_u (i64.ne (local.get $lo) (i64.const 0)))))
+                    (local.get $offset)
                 )
             )
         )
@@ -2758,9 +2759,9 @@
         (local.get $len)
     )
 
-    (func $stdlib.uint-to-utf8 (param $lo i64) (param $hi i64) (result i32 i32)
+    (func $stdlib.uint-to-utf8 (param $lo i64) (param $hi i64) (param $offset i32) (result i32 i32)
         (local $i i32) (local $j i32)
-        (local.set $j (local.tee $i (global.get $stack-pointer)))
+        (local.set $j (local.tee $i (local.get $offset)))
 
         ;; slow loop while $hi > 0
         (if (i64.ne (local.get $hi) (i64.const 0))
@@ -2809,8 +2810,8 @@
         ;; final result offset and length on the stack
         (local.get $j)
         (i32.sub (local.get $i) (local.get $j))
-        ;; update stack-pointer
-        (global.set $stack-pointer (local.get $i))
+        ;; update offset
+        (local.set $offset (local.get $i))
 
         ;; reverse answer in memory
         (local.set $i (i32.sub (local.get $i) (i32.const 4)))
@@ -2835,15 +2836,15 @@
         ;; final result is already on the stack
     )
 
-    (func $stdlib.int-to-utf8 (param $lo i64) (param $hi i64) (result i32 i32)
+    (func $stdlib.int-to-utf8 (param $lo i64) (param $hi i64) (param $offset i32) (result i32 i32)
         (local $negative i32) (local $len i32)
         (local.set $negative (i32.shl (i64.lt_s (local.get $hi) (i64.const 0)) (i32.const 2)))
         ;; add a '-' if n < 0
         (if (local.get $negative)
             (then
                 ;; store "-" in big-endian
-                (i32.store (global.get $stack-pointer) (i32.const 754974720))
-                (global.set $stack-pointer (i32.add (global.get $stack-pointer) (i32.const 4)))
+                (i32.store (local.get $offset) (i32.const 754974720))
+                (local.set $offset (i32.add (local.get $offset) (i32.const 4)))
             )
         )
 
@@ -2854,11 +2855,12 @@
                 (i64.ge_s (local.get $hi) (i64.const 0))
                 (i64.eq (local.get $hi) (i64.const 0x8000000000000000))
             )
-            (then (call $stdlib.uint-to-utf8 (local.get $lo) (local.get $hi)))
+            (then (call $stdlib.uint-to-utf8 (local.get $lo) (local.get $hi) (local.get $offset)))
             (else
                 (call $stdlib.uint-to-utf8
                     (i64.sub (i64.const 0) (local.get $lo))
                     (i64.sub (i64.const 0) (i64.add (local.get $hi) (i64.extend_i32_u (i64.ne (local.get $lo) (i64.const 0)))))
+                    (local.get $offset)
                 )
             )
         )

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -2649,9 +2649,9 @@
         )
     )
 
-    (func $stdlib.uint-to-string (param $lo i64) (param $hi i64) (param $offset i32) (result i32 i32)
+    (func $stdlib.uint-to-string (param $lo i64) (param $hi i64) (param $result_offset i32) (result i32 i32)
         (local $i i32) (local $j i32)
-        (local.set $j (local.tee $i (local.get $offset)))
+        (local.set $j (local.tee $i (local.get $result_offset)))
 
         ;; slow loop while $hi > 0
         (if (i64.ne (local.get $hi) (i64.const 0))
@@ -2697,8 +2697,8 @@
         ;; final result offset and length on the stack
         (local.get $j)
         (i32.sub (local.get $i) (local.get $j))
-        ;; update offset
-        (local.set $offset (local.get $i))
+        ;; update result_offset
+        (local.set $result_offset (local.get $i))
 
         ;; reverse answer in memory
         (local.set $i (i32.sub (local.get $i) (i32.const 1)))
@@ -2723,14 +2723,14 @@
         ;; final result is already on the stack
     )
 
-    (func $stdlib.int-to-string (param $lo i64) (param $hi i64) (param $offset i32) (result i32 i32)
+    (func $stdlib.int-to-string (param $lo i64) (param $hi i64) (param $result_offset i32) (result i32 i32)
         (local $negative i32) (local $len i32)
         (local.set $negative (i64.lt_s (local.get $hi) (i64.const 0)))
         ;; add a '-' if n < 0
         (if (local.get $negative)
             (then
-                (i32.store8 (local.get $offset) (i32.const 45))
-                (local.set $offset (i32.add (local.get $offset) (i32.const 1)))
+                (i32.store8 (local.get $result_offset) (i32.const 45))
+                (local.set $result_offset (i32.add (local.get $result_offset) (i32.const 1)))
             )
         )
 
@@ -2741,12 +2741,12 @@
                 (i64.ge_s (local.get $hi) (i64.const 0))
                 (i64.eq (local.get $hi) (i64.const 0x8000000000000000))
             )
-            (then (call $stdlib.uint-to-string (local.get $lo) (local.get $hi) (local.get $offset)))
+            (then (call $stdlib.uint-to-string (local.get $lo) (local.get $hi) (local.get $result_offset)))
             (else
                 (call $stdlib.uint-to-string
                     (i64.sub (i64.const 0) (local.get $lo))
                     (i64.sub (i64.const 0) (i64.add (local.get $hi) (i64.extend_i32_u (i64.ne (local.get $lo) (i64.const 0)))))
-                    (local.get $offset)
+                    (local.get $result_offset)
                 )
             )
         )
@@ -2759,9 +2759,9 @@
         (local.get $len)
     )
 
-    (func $stdlib.uint-to-utf8 (param $lo i64) (param $hi i64) (param $offset i32) (result i32 i32)
+    (func $stdlib.uint-to-utf8 (param $lo i64) (param $hi i64) (param $result_offset i32) (result i32 i32)
         (local $i i32) (local $j i32)
-        (local.set $j (local.tee $i (local.get $offset)))
+        (local.set $j (local.tee $i (local.get $result_offset)))
 
         ;; slow loop while $hi > 0
         (if (i64.ne (local.get $hi) (i64.const 0))
@@ -2810,8 +2810,8 @@
         ;; final result offset and length on the stack
         (local.get $j)
         (i32.sub (local.get $i) (local.get $j))
-        ;; update offset
-        (local.set $offset (local.get $i))
+        ;; update result_offset
+        (local.set $result_offset (local.get $i))
 
         ;; reverse answer in memory
         (local.set $i (i32.sub (local.get $i) (i32.const 4)))
@@ -2836,15 +2836,15 @@
         ;; final result is already on the stack
     )
 
-    (func $stdlib.int-to-utf8 (param $lo i64) (param $hi i64) (param $offset i32) (result i32 i32)
+    (func $stdlib.int-to-utf8 (param $lo i64) (param $hi i64) (param $result_offset i32) (result i32 i32)
         (local $negative i32) (local $len i32)
         (local.set $negative (i32.shl (i64.lt_s (local.get $hi) (i64.const 0)) (i32.const 2)))
         ;; add a '-' if n < 0
         (if (local.get $negative)
             (then
                 ;; store "-" in big-endian
-                (i32.store (local.get $offset) (i32.const 754974720))
-                (local.set $offset (i32.add (local.get $offset) (i32.const 4)))
+                (i32.store (local.get $result_offset) (i32.const 754974720))
+                (local.set $result_offset (i32.add (local.get $result_offset) (i32.const 4)))
             )
         )
 
@@ -2855,12 +2855,12 @@
                 (i64.ge_s (local.get $hi) (i64.const 0))
                 (i64.eq (local.get $hi) (i64.const 0x8000000000000000))
             )
-            (then (call $stdlib.uint-to-utf8 (local.get $lo) (local.get $hi) (local.get $offset)))
+            (then (call $stdlib.uint-to-utf8 (local.get $lo) (local.get $hi) (local.get $result_offset)))
             (else
                 (call $stdlib.uint-to-utf8
                     (i64.sub (i64.const 0) (local.get $lo))
                     (i64.sub (i64.const 0) (i64.add (local.get $hi) (i64.extend_i32_u (i64.ne (local.get $lo) (i64.const 0)))))
-                    (local.get $offset)
+                    (local.get $result_offset)
                 )
             )
         )

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -2653,28 +2653,6 @@
         (local $i i32) (local $j i32)
         (local.set $j (local.tee $i (global.get $stack-pointer)))
 
-        ;; Check if we need more memory (40 bytes is max needed for uint128)
-        (if (i32.gt_u 
-            (i32.add (local.get $i) (i32.const 40))
-            (i32.mul (memory.size) (i32.const 65536)))
-            (then
-                ;; Calculate needed pages (64KB per page)
-                (memory.grow 
-                    (i32.add
-                        (i32.div_u
-                            (i32.sub
-                                (i32.add (local.get $i) (i32.const 40))
-                                (i32.mul (memory.size) (i32.const 65536))
-                            )
-                            (i32.const 65536)
-                        )
-                        (i32.const 1)  ;; Add one extra page for safety
-                    )
-                )
-                drop  ;; Drop the previous memory size returned by memory.grow
-            )
-        )
-
         ;; slow loop while $hi > 0
         (if (i64.ne (local.get $hi) (i64.const 0))
             (then
@@ -2747,28 +2725,6 @@
 
     (func $stdlib.int-to-string (param $lo i64) (param $hi i64) (result i32 i32)
         (local $negative i32) (local $len i32)
-
-        ;; Grow memory if needed (41 bytes: 40 for digits + 1 for minus sign)
-        (if (i32.gt_u
-            (i32.add (global.get $stack-pointer) (i32.const 41))
-            (i32.mul (memory.size) (i32.const 65536))) ;; 0x10000 = memory size of a page
-            (then
-                (memory.grow
-                    (i32.add
-                        (i32.shr_u
-                            (i32.sub
-                                (i32.add (global.get $stack-pointer) (i32.const 41))
-                                (i32.mul (memory.size) (i32.const 65536))
-                            )
-                            (i32.const 16) ;; 2^16 = 65536
-                        )
-                        (i32.const 1) ;; Extra page for safety
-                    )
-                )
-                drop
-            )
-        )
-
         (local.set $negative (i64.lt_s (local.get $hi) (i64.const 0)))
         ;; add a '-' if n < 0
         (if (local.get $negative)
@@ -2805,28 +2761,6 @@
     (func $stdlib.uint-to-utf8 (param $lo i64) (param $hi i64) (result i32 i32)
         (local $i i32) (local $j i32)
         (local.set $j (local.tee $i (global.get $stack-pointer)))
-
-        ;; Check if we need more memory (40 bytes is max needed for uint128)
-        (if (i32.gt_u 
-            (i32.add (local.get $i) (i32.const 40))
-            (i32.mul (memory.size) (i32.const 65536))) ;; 0x10000 = memory size of a page
-            (then
-                ;; Calculate needed pages (64KB per page)
-                (memory.grow
-                    (i32.add
-                        (i32.div_u
-                            (i32.sub
-                                (i32.add (local.get $i) (i32.const 40))
-                                (i32.mul (memory.size) (i32.const 65536))
-                            )
-                            (i32.const 65536)
-                        )
-                        (i32.const 1) ;; Add one extra page for safety
-                    )
-                )
-                drop ;; Drop the previous memory size returned by memory.grow
-            )
-        )
 
         ;; slow loop while $hi > 0
         (if (i64.ne (local.get $hi) (i64.const 0))
@@ -2903,29 +2837,6 @@
 
     (func $stdlib.int-to-utf8 (param $lo i64) (param $hi i64) (result i32 i32)
         (local $negative i32) (local $len i32)
-
-        ;; Grow memory if needed (44 bytes: 40 for digits + 4 for UTF-8 minus sign)
-        (if (i32.gt_u 
-            (i32.add (global.get $stack-pointer) (i32.const 44))
-            (i32.mul (memory.size) (i32.const 65536))
-        )
-            (then
-                (memory.grow 
-                    (i32.add
-                        (i32.shr_u  ;; Use shift instead of division
-                            (i32.sub
-                                (i32.add (global.get $stack-pointer) (i32.const 44))
-                                (i32.mul (memory.size) (i32.const 65536))
-                            )
-                            (i32.const 16)  ;; 2^16 = 65536
-                        )
-                        (i32.const 1)  ;; Extra page for safety
-                    )
-                )
-                drop
-            )
-        )
-
         (local.set $negative (i32.shl (i64.lt_s (local.get $hi) (i64.const 0)) (i32.const 2)))
         ;; add a '-' if n < 0
         (if (local.get $negative)

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -2653,6 +2653,28 @@
         (local $i i32) (local $j i32)
         (local.set $j (local.tee $i (global.get $stack-pointer)))
 
+        ;; Check if we need more memory (40 bytes is max needed for uint128)
+        (if (i32.gt_u 
+            (i32.add (local.get $i) (i32.const 40))
+            (i32.mul (memory.size) (i32.const 65536)))
+            (then
+                ;; Calculate needed pages (64KB per page)
+                (memory.grow 
+                    (i32.add
+                        (i32.div_u
+                            (i32.sub
+                                (i32.add (local.get $i) (i32.const 40))
+                                (i32.mul (memory.size) (i32.const 65536))
+                            )
+                            (i32.const 65536)
+                        )
+                        (i32.const 1)  ;; Add one extra page for safety
+                    )
+                )
+                drop  ;; Drop the previous memory size returned by memory.grow
+            )
+        )
+
         ;; slow loop while $hi > 0
         (if (i64.ne (local.get $hi) (i64.const 0))
             (then
@@ -2725,6 +2747,28 @@
 
     (func $stdlib.int-to-string (param $lo i64) (param $hi i64) (result i32 i32)
         (local $negative i32) (local $len i32)
+
+        ;; Grow memory if needed (41 bytes: 40 for digits + 1 for minus sign)
+        (if (i32.gt_u
+            (i32.add (global.get $stack-pointer) (i32.const 41))
+            (i32.mul (memory.size) (i32.const 65536))) ;; 0x10000 = memory size of a page
+            (then
+                (memory.grow
+                    (i32.add
+                        (i32.shr_u
+                            (i32.sub
+                                (i32.add (global.get $stack-pointer) (i32.const 41))
+                                (i32.mul (memory.size) (i32.const 65536))
+                            )
+                            (i32.const 16) ;; 2^16 = 65536
+                        )
+                        (i32.const 1) ;; Extra page for safety
+                    )
+                )
+                drop
+            )
+        )
+
         (local.set $negative (i64.lt_s (local.get $hi) (i64.const 0)))
         ;; add a '-' if n < 0
         (if (local.get $negative)
@@ -2761,6 +2805,28 @@
     (func $stdlib.uint-to-utf8 (param $lo i64) (param $hi i64) (result i32 i32)
         (local $i i32) (local $j i32)
         (local.set $j (local.tee $i (global.get $stack-pointer)))
+
+        ;; Check if we need more memory (40 bytes is max needed for uint128)
+        (if (i32.gt_u 
+            (i32.add (local.get $i) (i32.const 40))
+            (i32.mul (memory.size) (i32.const 65536))) ;; 0x10000 = memory size of a page
+            (then
+                ;; Calculate needed pages (64KB per page)
+                (memory.grow
+                    (i32.add
+                        (i32.div_u
+                            (i32.sub
+                                (i32.add (local.get $i) (i32.const 40))
+                                (i32.mul (memory.size) (i32.const 65536))
+                            )
+                            (i32.const 65536)
+                        )
+                        (i32.const 1) ;; Add one extra page for safety
+                    )
+                )
+                drop ;; Drop the previous memory size returned by memory.grow
+            )
+        )
 
         ;; slow loop while $hi > 0
         (if (i64.ne (local.get $hi) (i64.const 0))
@@ -2837,6 +2903,29 @@
 
     (func $stdlib.int-to-utf8 (param $lo i64) (param $hi i64) (result i32 i32)
         (local $negative i32) (local $len i32)
+
+        ;; Grow memory if needed (44 bytes: 40 for digits + 4 for UTF-8 minus sign)
+        (if (i32.gt_u 
+            (i32.add (global.get $stack-pointer) (i32.const 44))
+            (i32.mul (memory.size) (i32.const 65536))
+        )
+            (then
+                (memory.grow 
+                    (i32.add
+                        (i32.shr_u  ;; Use shift instead of division
+                            (i32.sub
+                                (i32.add (global.get $stack-pointer) (i32.const 44))
+                                (i32.mul (memory.size) (i32.const 65536))
+                            )
+                            (i32.const 16)  ;; 2^16 = 65536
+                        )
+                        (i32.const 1)  ;; Extra page for safety
+                    )
+                )
+                drop
+            )
+        )
+
         (local.set $negative (i32.shl (i64.lt_s (local.get $hi) (i64.const 0)) (i32.const 2)))
         ;; add a '-' if n < 0
         (if (local.get $negative)

--- a/clar2wasm/src/words/conversion.rs
+++ b/clar2wasm/src/words/conversion.rs
@@ -89,7 +89,7 @@ impl SimpleWord for IntToAscii {
         generator: &mut crate::wasm_generator::WasmGenerator,
         builder: &mut walrus::InstrSeqBuilder,
         arg_types: &[TypeSignature],
-        _return_type: &TypeSignature,
+        return_type: &TypeSignature,
     ) -> Result<(), crate::wasm_generator::GeneratorError> {
         let type_prefix = match arg_types[0] {
             TypeSignature::IntType => "int",
@@ -100,6 +100,8 @@ impl SimpleWord for IntToAscii {
                 ));
             }
         };
+
+        generator.create_call_stack_local(builder, return_type, false, true);
 
         let func = generator.func_by_name(&format!("stdlib.{type_prefix}-to-string"));
 
@@ -122,7 +124,7 @@ impl SimpleWord for IntToUtf8 {
         generator: &mut crate::wasm_generator::WasmGenerator,
         builder: &mut walrus::InstrSeqBuilder,
         arg_types: &[TypeSignature],
-        _return_type: &TypeSignature,
+        return_type: &TypeSignature,
     ) -> Result<(), GeneratorError> {
         let type_prefix = match arg_types[0] {
             TypeSignature::IntType => "int",
@@ -133,6 +135,8 @@ impl SimpleWord for IntToUtf8 {
                 ));
             }
         };
+
+        generator.create_call_stack_local(builder, return_type, false, true);
 
         let func = generator.func_by_name(&format!("stdlib.{type_prefix}-to-utf8"));
 

--- a/clar2wasm/src/words/conversion.rs
+++ b/clar2wasm/src/words/conversion.rs
@@ -101,7 +101,9 @@ impl SimpleWord for IntToAscii {
             }
         };
 
-        generator.create_call_stack_local(builder, return_type, false, true);
+        let (result_offset, _) =
+            generator.create_call_stack_local(builder, return_type, false, true);
+        builder.local_get(result_offset);
 
         let func = generator.func_by_name(&format!("stdlib.{type_prefix}-to-string"));
 
@@ -136,7 +138,9 @@ impl SimpleWord for IntToUtf8 {
             }
         };
 
-        generator.create_call_stack_local(builder, return_type, false, true);
+        let (result_offset, _) =
+            generator.create_call_stack_local(builder, return_type, false, true);
+        builder.local_get(result_offset);
 
         let func = generator.func_by_name(&format!("stdlib.{type_prefix}-to-utf8"));
 

--- a/clar2wasm/tests/oom-checker/unit_tests.rs
+++ b/clar2wasm/tests/oom-checker/unit_tests.rs
@@ -70,22 +70,6 @@ fn concat_oom() {
     );
 }
 
-#[cfg(not(feature = "test-clarity-v1"))]
-#[test]
-fn replace_at_oom() {
-    crosscheck_oom_with_non_literal_args(
-        "(replace-at? (list 1 2 3) u0 42)",
-        &[list_of(TypeSignature::IntType, 3)],
-        Ok(Some(
-            Value::some(
-                Value::cons_list_unsanitized(vec![Value::Int(42), Value::Int(2), Value::Int(3)])
-                    .unwrap(),
-            )
-            .unwrap(),
-        )),
-    );
-}
-
 #[test]
 fn map_oom() {
     crosscheck_oom_with_non_literal_args(
@@ -244,26 +228,6 @@ fn get_burn_block_info_pox_addrs_oom() {
 }
 
 #[test]
-#[ignore = "issue #592"]
-fn int_to_ascii_oom() {
-    crosscheck_oom(
-        "(int-to-ascii 42)",
-        Ok(Some(
-            Value::string_ascii_from_bytes(b"42".to_vec()).unwrap(),
-        )),
-    );
-}
-
-#[test]
-#[ignore = "issue #592"]
-fn int_to_utf8_oom() {
-    crosscheck_oom(
-        "(int-to-utf8 42)",
-        Ok(Some(Value::string_utf8_from_bytes(b"42".to_vec()).unwrap())),
-    );
-}
-
-#[test]
 fn data_var_oom() {
     crosscheck_oom(
         r#"
@@ -281,4 +245,88 @@ fn secp256k1_recover_oom() {
         "(secp256k1-recover? 0xde5b9eb9e7c5592930eb2e30a01369c36586d872082ed8181ee83d2a0ec20f04 0x8738487ebe69b93d8e51583be8eee50bb4213fc49c767d329632730cc193b873554428fc936ca3569afc15f1c9365f6591d6251a89fee9c9ac661116824d3a1301)",
         Ok(Some(Value::okay(Value::buff_from(vec![3, 173, 184, 222, 75, 251, 101, 219, 44, 253, 97, 32, 213, 92, 101, 38, 174, 156, 82, 230, 117, 219, 126, 71, 48, 134, 54, 83, 75, 167, 120, 97, 16]).unwrap()).unwrap())),
     );
+}
+
+#[cfg(not(feature = "test-clarity-v1"))]
+#[cfg(test)]
+mod clarity_v2_v3 {
+    use clarity::vm::types::TypeSignature;
+    use clarity::vm::Value;
+
+    use crate::{crosscheck_oom, crosscheck_oom_with_non_literal_args, list_of};
+
+    #[test]
+    fn replace_at_oom() {
+        crosscheck_oom_with_non_literal_args(
+            "(replace-at? (list 1 2 3) u0 42)",
+            &[list_of(TypeSignature::IntType, 3)],
+            Ok(Some(
+                Value::some(
+                    Value::cons_list_unsanitized(vec![
+                        Value::Int(42),
+                        Value::Int(2),
+                        Value::Int(3),
+                    ])
+                    .unwrap(),
+                )
+                .unwrap(),
+            )),
+        );
+    }
+
+    #[test]
+    fn int_to_ascii_oom_negative() {
+        crosscheck_oom(
+            "(int-to-ascii -42)",
+            Ok(Some(
+                Value::string_ascii_from_bytes(b"-42".to_vec()).unwrap(),
+            )),
+        );
+    }
+
+    #[test]
+    fn int_to_utf8_oom_negative() {
+        crosscheck_oom(
+            "(int-to-utf8 -42)",
+            Ok(Some(
+                Value::string_utf8_from_bytes(b"-42".to_vec()).unwrap(),
+            )),
+        );
+    }
+
+    #[test]
+    fn int_to_ascii_oom() {
+        crosscheck_oom(
+            "(int-to-ascii 42)",
+            Ok(Some(
+                Value::string_ascii_from_bytes(b"42".to_vec()).unwrap(),
+            )),
+        );
+    }
+
+    #[test]
+    fn int_to_utf8_oom() {
+        crosscheck_oom(
+            "(int-to-utf8 42)",
+            Ok(Some(Value::string_utf8_from_bytes(b"42".to_vec()).unwrap())),
+        );
+    }
+
+    #[test]
+    fn unsigned_value_int_to_ascii_oom() {
+        crosscheck_oom(
+            "(int-to-ascii u42)",
+            Ok(Some(
+                Value::string_ascii_from_bytes(b"42".to_vec()).unwrap(),
+            )),
+        );
+    }
+
+    #[test]
+    fn unsigned_value_int_to_utf8_oom() {
+        crosscheck_oom(
+            "(int-to-utf8 u42)",
+            Ok(Some(Value::string_utf8_from_bytes(b"42".to_vec()).unwrap())),
+        );
+    }
 }

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -3631,15 +3631,15 @@ fn uint_to_string() {
 
         let expected = num.to_string();
 
-        // This algo needs space on the stack,
-        // we move the initial value of $stack-pointer
-        // to a random one where it wouldn't matter
-        let stack_pointer = instance.get_global(&mut store, "stack-pointer").unwrap();
-        stack_pointer.set(&mut store, Val::I32(1500)).unwrap();
+        let res_offset = 1500;
 
-        conv.call(&mut store, &[lo.into(), hi.into()], &mut result)
-            .expect("call to uint-to-string failed");
-        assert_eq!(result[0].unwrap_i32(), 1500);
+        conv.call(
+            &mut store,
+            &[lo.into(), hi.into(), res_offset.into()],
+            &mut result,
+        )
+        .expect("call to uint-to-string failed");
+        assert_eq!(result[0].unwrap_i32(), res_offset);
         assert_eq!(result[1].unwrap_i32(), expected.len() as i32);
 
         let mut buffer = vec![0u8; expected.len()];
@@ -3693,15 +3693,17 @@ fn int_to_string() {
         let lo = num as i64;
         let hi = (num >> 64) as i64;
 
-        // This algo needs space on the stack,
-        // we move the initial value of $stack-pointer
-        // to a random one where it wouldn't matter
-        let stack_pointer = instance.get_global(&mut store, "stack-pointer").unwrap();
-        stack_pointer.set(&mut store, Val::I32(1500)).unwrap();
+        // Use a safe offset in memory where we know we have space
+        let res_offset = 1500;
 
-        conv.call(&mut store, &[lo.into(), hi.into()], &mut result)
-            .expect("call to uint-to-string failed");
-        assert_eq!(result[0].unwrap_i32(), 1500);
+        conv.call(
+            &mut store,
+            &[lo.into(), hi.into(), res_offset.into()],
+            &mut result,
+        )
+        .expect("call to int-to-string failed");
+
+        assert_eq!(result[0].unwrap_i32(), res_offset); // Should return the same offset
         assert_eq!(result[1].unwrap_i32(), expected.len() as i32);
 
         let mut buffer = vec![0u8; expected.len()];
@@ -3758,15 +3760,15 @@ fn uint_to_utf8() {
         let expected = num.to_string();
         let expected_len = 4 * expected.len();
 
-        // This algo needs space on the stack,
-        // we move the initial value of $stack-pointer
-        // to a random one where it wouldn't matter
-        let stack_pointer = instance.get_global(&mut store, "stack-pointer").unwrap();
-        stack_pointer.set(&mut store, Val::I32(1500)).unwrap();
+        let res_offset = 1500;
 
-        conv.call(&mut store, &[lo.into(), hi.into()], &mut result)
-            .expect("call to uint-to-string failed");
-        assert_eq!(result[0].unwrap_i32(), 1500);
+        conv.call(
+            &mut store,
+            &[lo.into(), hi.into(), res_offset.into()],
+            &mut result,
+        )
+        .expect("call to uint-to-string failed");
+        assert_eq!(result[0].unwrap_i32(), res_offset);
         assert_eq!(result[1].unwrap_i32(), expected_len as i32);
 
         let mut buffer = vec![0u8; expected_len];
@@ -3825,15 +3827,15 @@ fn int_to_utf8() {
         let lo = num as i64;
         let hi = (num >> 64) as i64;
 
-        // This algo needs space on the stack,
-        // we move the initial value of $stack-pointer
-        // to a random one where it wouldn't matter
-        let stack_pointer = instance.get_global(&mut store, "stack-pointer").unwrap();
-        stack_pointer.set(&mut store, Val::I32(1500)).unwrap();
+        let res_offset = 1500;
 
-        conv.call(&mut store, &[lo.into(), hi.into()], &mut result)
-            .expect("call to uint-to-string failed");
-        assert_eq!(result[0].unwrap_i32(), 1500);
+        conv.call(
+            &mut store,
+            &[lo.into(), hi.into(), res_offset.into()],
+            &mut result,
+        )
+        .expect("call to uint-to-string failed");
+        assert_eq!(result[0].unwrap_i32(), res_offset);
         assert_eq!(result[1].unwrap_i32(), expected_len as i32);
 
         let mut buffer = vec![0u8; expected_len];


### PR DESCRIPTION
This PR addresses an out-of-memory access issue occurring in the `int-to-ascii` and `int-to-utf8` functions.

Fixes: #592 