### PR TITLE
benches: improve resolution of `add_prices`

### DIFF
--- a/clar2wasm/benches/comparison.rs
+++ b/clar2wasm/benches/comparison.rs
@@ -337,7 +337,7 @@ decl_benches! {
     ),
     (
         "add_prices",
-        (1..401).step_by(50),
+        (1..51).step_by(2),
         |_i| r"
         (define-map oracle_data
             { source: uint, symbol: uint }


### PR DESCRIPTION
The range of values the `add_prices` benchmark is performed under doesn't showcase the important of the behavior that we want to capture very well - meaning the transition from the "interpreter better" to "webassembly better" regimes. This commit improves that by changing this range to a more representative value.