### PR TITLE
fix default test environment

### DIFF
--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -366,7 +366,7 @@ impl TestEnvironment {
 
 impl Default for TestEnvironment {
     fn default() -> Self {
-        Self::new(StacksEpochId::Epoch25, ClarityVersion::Clarity2)
+        Self::new(StacksEpochId::latest(), ClarityVersion::latest())
     }
 }
 

--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -366,7 +366,7 @@ impl TestEnvironment {
 
 impl Default for TestEnvironment {
     fn default() -> Self {
-        Self::new(StacksEpochId::latest(), ClarityVersion::latest())
+        Self::new(StacksEpochId::Epoch31, ClarityVersion::Clarity3)
     }
 }
 

--- a/clar2wasm/src/words/blockinfo.rs
+++ b/clar2wasm/src/words/blockinfo.rs
@@ -402,7 +402,10 @@ mod tests {
 
         #[test]
         fn get_block_info_less_than_two_args() {
-            let mut env = TestEnvironment::default();
+            let mut env = TestEnvironment::new(
+                clarity::types::StacksEpochId::Epoch25,
+                clarity::vm::ClarityVersion::Clarity2,
+            );
             env.advance_chain_tip(1);
             let result = env.evaluate("(get-block-info? id-header-hash)");
             assert!(result.is_err());

--- a/clar2wasm/src/words/blockinfo.rs
+++ b/clar2wasm/src/words/blockinfo.rs
@@ -613,7 +613,10 @@ mod tests {
 
     #[test]
     fn get_block_info_burnchain_header_hash() {
-        let mut env = TestEnvironment::default();
+        let mut env = TestEnvironment::new(
+            clarity::types::StacksEpochId::Epoch25,
+            clarity::vm::ClarityVersion::Clarity2
+        );
         env.advance_chain_tip(1);
         let result = env
             .evaluate("(get-block-info? burnchain-header-hash u0)")
@@ -626,7 +629,10 @@ mod tests {
 
     #[test]
     fn get_block_info_id_header_hash() {
-        let mut env = TestEnvironment::default();
+        let mut env = TestEnvironment::new(
+            clarity::types::StacksEpochId::Epoch25,
+            clarity::vm::ClarityVersion::Clarity2
+        );
         env.advance_chain_tip(1);
         let result = env
             .evaluate("(get-block-info? id-header-hash u0)")
@@ -645,7 +651,10 @@ mod tests {
 
     #[test]
     fn get_block_info_header_hash() {
-        let mut env = TestEnvironment::default();
+        let mut env = TestEnvironment::new(
+            clarity::types::StacksEpochId::Epoch25,
+            clarity::vm::ClarityVersion::Clarity2
+        );
         env.advance_chain_tip(1);
         let result = env
             .evaluate("(get-block-info? header-hash u0)")
@@ -658,7 +667,10 @@ mod tests {
 
     #[test]
     fn get_block_info_miner_address() {
-        let mut env = TestEnvironment::default();
+        let mut env = TestEnvironment::new(
+            clarity::types::StacksEpochId::Epoch25,
+            clarity::vm::ClarityVersion::Clarity2
+        );
         env.advance_chain_tip(1);
         let result = env
             .evaluate("(get-block-info? miner-address u0)")
@@ -676,7 +688,10 @@ mod tests {
 
     #[test]
     fn get_block_info_time() {
-        let mut env = TestEnvironment::default();
+        let mut env = TestEnvironment::new(
+            clarity::types::StacksEpochId::Epoch25,
+            clarity::vm::ClarityVersion::Clarity2
+        );
         env.advance_chain_tip(1);
         let result = env
             .evaluate("(get-block-info? time u0)")
@@ -709,7 +724,10 @@ mod tests {
 
     #[test]
     fn get_block_info_miner_spend_total() {
-        let mut env = TestEnvironment::default();
+        let mut env = TestEnvironment::new(
+            clarity::types::StacksEpochId::Epoch25,
+            clarity::vm::ClarityVersion::Clarity2
+        );
         env.advance_chain_tip(1);
         let result = env
             .evaluate("(get-block-info? miner-spend-total u0)")
@@ -719,7 +737,10 @@ mod tests {
 
     #[test]
     fn get_block_info_miner_spend_winner() {
-        let mut env = TestEnvironment::default();
+        let mut env = TestEnvironment::new(
+            clarity::types::StacksEpochId::Epoch25,
+            clarity::vm::ClarityVersion::Clarity2
+        );
         env.advance_chain_tip(1);
         let result = env
             .evaluate("(get-block-info? miner-spend-winner u0)")

--- a/clar2wasm/src/words/blockinfo.rs
+++ b/clar2wasm/src/words/blockinfo.rs
@@ -342,9 +342,10 @@ impl ComplexWord for GetTenureInfo {
 
 #[cfg(test)]
 mod tests {
+    use clarity::types::StacksEpochId;
     use clarity::vm::errors::{CheckErrors, Error};
     use clarity::vm::types::{OptionalData, PrincipalData, TupleData};
-    use clarity::vm::Value;
+    use clarity::vm::{ClarityVersion, Value};
 
     use crate::tools::{evaluate, TestEnvironment};
 
@@ -355,7 +356,7 @@ mod tests {
     #[cfg(any(feature = "test-clarity-v1", feature = "test-clarity-v2"))]
     #[cfg(test)]
     mod clarity_v1_v2 {
-        use clarity::types::StacksEpochId;
+        use clarity::{types::{StacksEpochId}, vm::ClarityVersion};
 
         use super::*;
         use crate::tools::crosscheck_with_epoch;
@@ -402,10 +403,17 @@ mod tests {
 
         #[test]
         fn get_block_info_less_than_two_args() {
+            let epoch = if cfg!(feature = "test-clarity-v1") {
+                StacksEpochId::Epoch2_05
+            } else {
+                StacksEpochId::Epoch25
+            };
+
             let mut env = TestEnvironment::new(
-                clarity::types::StacksEpochId::Epoch25,
-                clarity::vm::ClarityVersion::Clarity2,
+                epoch,
+                ClarityVersion::default_for_epoch(epoch)
             );
+
             env.advance_chain_tip(1);
             let result = env.evaluate("(get-block-info? id-header-hash)");
             assert!(result.is_err());
@@ -616,9 +624,15 @@ mod tests {
 
     #[test]
     fn get_block_info_burnchain_header_hash() {
+        let epoch = if cfg!(feature = "test-clarity-v1") {
+            StacksEpochId::Epoch2_05
+        } else {
+            StacksEpochId::Epoch25
+        };
+
         let mut env = TestEnvironment::new(
-            clarity::types::StacksEpochId::Epoch25,
-            clarity::vm::ClarityVersion::Clarity2,
+            epoch,
+            ClarityVersion::default_for_epoch(epoch)
         );
         env.advance_chain_tip(1);
         let result = env
@@ -632,10 +646,17 @@ mod tests {
 
     #[test]
     fn get_block_info_id_header_hash() {
+        let epoch = if cfg!(feature = "test-clarity-v1") {
+            StacksEpochId::Epoch2_05
+        } else {
+            StacksEpochId::Epoch25
+        };
+
         let mut env = TestEnvironment::new(
-            clarity::types::StacksEpochId::Epoch25,
-            clarity::vm::ClarityVersion::Clarity2,
+            epoch,
+            ClarityVersion::default_for_epoch(epoch)
         );
+
         env.advance_chain_tip(1);
         let result = env
             .evaluate("(get-block-info? id-header-hash u0)")
@@ -654,10 +675,17 @@ mod tests {
 
     #[test]
     fn get_block_info_header_hash() {
+        let epoch = if cfg!(feature = "test-clarity-v1") {
+            StacksEpochId::Epoch2_05
+        } else {
+            StacksEpochId::Epoch25
+        };
+
         let mut env = TestEnvironment::new(
-            clarity::types::StacksEpochId::Epoch25,
-            clarity::vm::ClarityVersion::Clarity2,
+            epoch,
+            ClarityVersion::default_for_epoch(epoch)
         );
+
         env.advance_chain_tip(1);
         let result = env
             .evaluate("(get-block-info? header-hash u0)")
@@ -670,10 +698,17 @@ mod tests {
 
     #[test]
     fn get_block_info_miner_address() {
+        let epoch = if cfg!(feature = "test-clarity-v1") {
+            StacksEpochId::Epoch2_05
+        } else {
+            StacksEpochId::Epoch25
+        };
+
         let mut env = TestEnvironment::new(
-            clarity::types::StacksEpochId::Epoch25,
-            clarity::vm::ClarityVersion::Clarity2,
+            epoch,
+            ClarityVersion::default_for_epoch(epoch)
         );
+
         env.advance_chain_tip(1);
         let result = env
             .evaluate("(get-block-info? miner-address u0)")
@@ -691,10 +726,17 @@ mod tests {
 
     #[test]
     fn get_block_info_time() {
+        let epoch = if cfg!(feature = "test-clarity-v1") {
+            StacksEpochId::Epoch2_05
+        } else {
+            StacksEpochId::Epoch25
+        };
+
         let mut env = TestEnvironment::new(
-            clarity::types::StacksEpochId::Epoch25,
-            clarity::vm::ClarityVersion::Clarity2,
+            epoch,
+            ClarityVersion::default_for_epoch(epoch)
         );
+
         env.advance_chain_tip(1);
         let result = env
             .evaluate("(get-block-info? time u0)")
@@ -731,6 +773,7 @@ mod tests {
             clarity::types::StacksEpochId::Epoch25,
             clarity::vm::ClarityVersion::Clarity2,
         );
+
         env.advance_chain_tip(1);
         let result = env
             .evaluate("(get-block-info? miner-spend-total u0)")
@@ -744,6 +787,7 @@ mod tests {
             clarity::types::StacksEpochId::Epoch25,
             clarity::vm::ClarityVersion::Clarity2,
         );
+
         env.advance_chain_tip(1);
         let result = env
             .evaluate("(get-block-info? miner-spend-winner u0)")

--- a/clar2wasm/src/words/blockinfo.rs
+++ b/clar2wasm/src/words/blockinfo.rs
@@ -356,7 +356,8 @@ mod tests {
     #[cfg(any(feature = "test-clarity-v1", feature = "test-clarity-v2"))]
     #[cfg(test)]
     mod clarity_v1_v2 {
-        use clarity::{types::{StacksEpochId}, vm::ClarityVersion};
+        use clarity::types::StacksEpochId;
+        use clarity::vm::ClarityVersion;
 
         use super::*;
         use crate::tools::crosscheck_with_epoch;
@@ -409,10 +410,7 @@ mod tests {
                 StacksEpochId::Epoch25
             };
 
-            let mut env = TestEnvironment::new(
-                epoch,
-                ClarityVersion::default_for_epoch(epoch)
-            );
+            let mut env = TestEnvironment::new(epoch, ClarityVersion::default_for_epoch(epoch));
 
             env.advance_chain_tip(1);
             let result = env.evaluate("(get-block-info? id-header-hash)");
@@ -630,10 +628,7 @@ mod tests {
             StacksEpochId::Epoch25
         };
 
-        let mut env = TestEnvironment::new(
-            epoch,
-            ClarityVersion::default_for_epoch(epoch)
-        );
+        let mut env = TestEnvironment::new(epoch, ClarityVersion::default_for_epoch(epoch));
         env.advance_chain_tip(1);
         let result = env
             .evaluate("(get-block-info? burnchain-header-hash u0)")
@@ -652,10 +647,7 @@ mod tests {
             StacksEpochId::Epoch25
         };
 
-        let mut env = TestEnvironment::new(
-            epoch,
-            ClarityVersion::default_for_epoch(epoch)
-        );
+        let mut env = TestEnvironment::new(epoch, ClarityVersion::default_for_epoch(epoch));
 
         env.advance_chain_tip(1);
         let result = env
@@ -681,10 +673,7 @@ mod tests {
             StacksEpochId::Epoch25
         };
 
-        let mut env = TestEnvironment::new(
-            epoch,
-            ClarityVersion::default_for_epoch(epoch)
-        );
+        let mut env = TestEnvironment::new(epoch, ClarityVersion::default_for_epoch(epoch));
 
         env.advance_chain_tip(1);
         let result = env
@@ -704,10 +693,7 @@ mod tests {
             StacksEpochId::Epoch25
         };
 
-        let mut env = TestEnvironment::new(
-            epoch,
-            ClarityVersion::default_for_epoch(epoch)
-        );
+        let mut env = TestEnvironment::new(epoch, ClarityVersion::default_for_epoch(epoch));
 
         env.advance_chain_tip(1);
         let result = env
@@ -732,10 +718,7 @@ mod tests {
             StacksEpochId::Epoch25
         };
 
-        let mut env = TestEnvironment::new(
-            epoch,
-            ClarityVersion::default_for_epoch(epoch)
-        );
+        let mut env = TestEnvironment::new(epoch, ClarityVersion::default_for_epoch(epoch));
 
         env.advance_chain_tip(1);
         let result = env

--- a/clar2wasm/src/words/blockinfo.rs
+++ b/clar2wasm/src/words/blockinfo.rs
@@ -615,7 +615,7 @@ mod tests {
     fn get_block_info_burnchain_header_hash() {
         let mut env = TestEnvironment::new(
             clarity::types::StacksEpochId::Epoch25,
-            clarity::vm::ClarityVersion::Clarity2
+            clarity::vm::ClarityVersion::Clarity2,
         );
         env.advance_chain_tip(1);
         let result = env
@@ -631,7 +631,7 @@ mod tests {
     fn get_block_info_id_header_hash() {
         let mut env = TestEnvironment::new(
             clarity::types::StacksEpochId::Epoch25,
-            clarity::vm::ClarityVersion::Clarity2
+            clarity::vm::ClarityVersion::Clarity2,
         );
         env.advance_chain_tip(1);
         let result = env
@@ -653,7 +653,7 @@ mod tests {
     fn get_block_info_header_hash() {
         let mut env = TestEnvironment::new(
             clarity::types::StacksEpochId::Epoch25,
-            clarity::vm::ClarityVersion::Clarity2
+            clarity::vm::ClarityVersion::Clarity2,
         );
         env.advance_chain_tip(1);
         let result = env
@@ -669,7 +669,7 @@ mod tests {
     fn get_block_info_miner_address() {
         let mut env = TestEnvironment::new(
             clarity::types::StacksEpochId::Epoch25,
-            clarity::vm::ClarityVersion::Clarity2
+            clarity::vm::ClarityVersion::Clarity2,
         );
         env.advance_chain_tip(1);
         let result = env
@@ -690,7 +690,7 @@ mod tests {
     fn get_block_info_time() {
         let mut env = TestEnvironment::new(
             clarity::types::StacksEpochId::Epoch25,
-            clarity::vm::ClarityVersion::Clarity2
+            clarity::vm::ClarityVersion::Clarity2,
         );
         env.advance_chain_tip(1);
         let result = env
@@ -726,7 +726,7 @@ mod tests {
     fn get_block_info_miner_spend_total() {
         let mut env = TestEnvironment::new(
             clarity::types::StacksEpochId::Epoch25,
-            clarity::vm::ClarityVersion::Clarity2
+            clarity::vm::ClarityVersion::Clarity2,
         );
         env.advance_chain_tip(1);
         let result = env
@@ -739,7 +739,7 @@ mod tests {
     fn get_block_info_miner_spend_winner() {
         let mut env = TestEnvironment::new(
             clarity::types::StacksEpochId::Epoch25,
-            clarity::vm::ClarityVersion::Clarity2
+            clarity::vm::ClarityVersion::Clarity2,
         );
         env.advance_chain_tip(1);
         let result = env


### PR DESCRIPTION
update Test environment default to latest epoch and latest Clarity version

fix #613 