### PR TITLE
Chore: fix new clippy 1.85 warnings

### DIFF
--- a/clar2wasm/src/linker.rs
+++ b/clar2wasm/src/linker.rs
@@ -751,12 +751,13 @@ fn link_set_variable_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), E
                 // env.add_memory(value.get_memory_use())?;
 
                 // Store the variable in the global context
-                caller
-                    .data_mut()
-                    .global_context
-                    .database
-                    .set_variable(&contract, var_name.as_str(), value, &data_types, &epoch)
-                    .map_err(Error::from)?;
+                caller.data_mut().global_context.database.set_variable(
+                    &contract,
+                    var_name.as_str(),
+                    value,
+                    &data_types,
+                    &epoch,
+                )?;
 
                 Ok(())
             },
@@ -1293,7 +1294,7 @@ fn link_stx_burn_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error
              amount_hi: i64,
              principal_offset: i32,
              principal_length: i32| {
-                let amount = (amount_hi as u128) << 64 | ((amount_lo as u64) as u128);
+                let amount = ((amount_hi as u128) << 64) | ((amount_lo as u64) as u128);
 
                 // Get the memory from the caller
                 let memory = caller
@@ -1391,7 +1392,7 @@ fn link_stx_transfer_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), E
              recipient_length: i32,
              memo_offset: i32,
              memo_length: i32| {
-                let amount = (amount_hi as u128) << 64 | ((amount_lo as u64) as u128);
+                let amount = ((amount_hi as u128) << 64) | ((amount_lo as u64) as u128);
 
                 // Get the memory from the caller
                 let memory = caller
@@ -1655,7 +1656,7 @@ fn link_ft_burn_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error>
                 let token_name = ClarityName::try_from(name.clone())?;
 
                 // Compute the amount
-                let amount = (amount_hi as u128) << 64 | ((amount_lo as u64) as u128);
+                let amount = ((amount_hi as u128) << 64) | ((amount_lo as u64) as u128);
 
                 // Read the sender principal from the Wasm memory
                 let value = read_from_wasm(
@@ -1783,7 +1784,7 @@ fn link_ft_mint_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error>
                 let token_name = ClarityName::try_from(name.clone())?;
 
                 // Compute the amount
-                let amount = (amount_hi as u128) << 64 | ((amount_lo as u64) as u128);
+                let amount = ((amount_hi as u128) << 64) | ((amount_lo as u64) as u128);
 
                 // Read the sender principal from the Wasm memory
                 let value = read_from_wasm(
@@ -1909,7 +1910,7 @@ fn link_ft_transfer_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Er
                 let token_name = ClarityName::try_from(name.clone())?;
 
                 // Compute the amount
-                let amount = (amount_hi as u128) << 64 | ((amount_lo as u64) as u128);
+                let amount = ((amount_hi as u128) << 64) | ((amount_lo as u64) as u128);
 
                 // Read the sender principal from the Wasm memory
                 let value = read_from_wasm(
@@ -3004,7 +3005,7 @@ fn check_height_valid(
     height_hi: i64,
     return_offset: i32,
 ) -> Result<Option<u32>, Error> {
-    let height = (height_hi as u128) << 64 | ((height_lo as u64) as u128);
+    let height = ((height_hi as u128) << 64) | ((height_lo as u64) as u128);
 
     let height_value = match u32::try_from(height) {
         Ok(result) => result,
@@ -3577,7 +3578,7 @@ fn link_get_burn_block_info_header_hash_property_fn(
                     .get_export("memory")
                     .and_then(|export| export.into_memory())
                     .ok_or(Error::Wasm(WasmError::MemoryNotFound))?;
-                let height = (height_hi as u128) << 64 | ((height_lo as u64) as u128);
+                let height = ((height_hi as u128) << 64) | ((height_lo as u64) as u128);
 
                 // Note: we assume that we will not have a height bigger than u32::MAX.
                 let height_value = match u32::try_from(height) {
@@ -3653,7 +3654,7 @@ fn link_get_burn_block_info_pox_addrs_property_fn(
                     .and_then(|export| export.into_memory())
                     .ok_or(Error::Wasm(WasmError::MemoryNotFound))?;
 
-                let height = (height_hi as u128) << 64 | ((height_lo as u64) as u128);
+                let height = ((height_hi as u128) << 64) | ((height_lo as u64) as u128);
 
                 // Note: we assume that we will not have a height bigger than u32::MAX.
                 let height_value = match u32::try_from(height) {

--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -433,7 +433,7 @@ impl KnownBug {
         if let Error::Wasm(WasmError::WasmGeneratorError(message)) = err {
             RGX.captures(message).is_some_and(|caps| {
                 caps.get(1)
-                    .map_or(true, |cap1| cap1.as_str() == caps.get(2).unwrap().as_str())
+                    .is_none_or(|cap1| cap1.as_str() == caps.get(2).unwrap().as_str())
             })
         } else {
             false

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -3461,7 +3461,7 @@ fn principal_construct() {
             assert_eq!(&buffer, expected_principal);
         }
 
-        let err = (result[4].unwrap_i64() as u128) << 64 | result[3].unwrap_i64() as u128;
+        let err = ((result[4].unwrap_i64() as u128) << 64) | result[3].unwrap_i64() as u128;
         assert_eq!(err, expected_err);
     };
 
@@ -4165,18 +4165,18 @@ fn utf8_to_string_utf8_invalid() {
                 *a = code as u8;
             }
             (2, [a, b, ..]) => {
-                *a = (code >> 6 & 0x1F) as u8 | 0b1100_0000;
+                *a = ((code >> 6) & 0x1F) as u8 | 0b1100_0000;
                 *b = (code & 0x3F) as u8 | 0b1000_0000;
             }
             (3, [a, b, c, ..]) => {
-                *a = (code >> 12 & 0x0F) as u8 | 0b1110_0000;
-                *b = (code >> 6 & 0x3F) as u8 | 0b1000_0000;
+                *a = ((code >> 12) & 0x0F) as u8 | 0b1110_0000;
+                *b = ((code >> 6) & 0x3F) as u8 | 0b1000_0000;
                 *c = (code & 0x3F) as u8 | 0b1000_0000;
             }
             (4, [a, b, c, d]) => {
-                *a = (code >> 18 & 0x07) as u8 | 0b1111_0000;
-                *b = (code >> 12 & 0x3F) as u8 | 0b1000_0000;
-                *c = (code >> 6 & 0x3F) as u8 | 0b1000_0000;
+                *a = ((code >> 18) & 0x07) as u8 | 0b1111_0000;
+                *b = ((code >> 12) & 0x3F) as u8 | 0b1000_0000;
+                *c = ((code >> 6) & 0x3F) as u8 | 0b1000_0000;
                 *d = (code & 0x3F) as u8 | 0b1000_0000;
             }
             _ => unreachable!("Cannot create a utf8 with more than 4 bytes"),

--- a/clar2wasm/tests/standard/utils.rs
+++ b/clar2wasm/tests/standard/utils.rs
@@ -54,7 +54,7 @@ pub(crate) trait FromWasmResult {
 impl FromWasmResult for u128 {
     fn from_wasm_result(v: &[Val]) -> Self {
         match v {
-            &[Val::I64(lo), Val::I64(hi)] => ((lo as u64) as u128) | ((hi as u64) as u128) << 64,
+            &[Val::I64(lo), Val::I64(hi)] => ((lo as u64) as u128) | (((hi as u64) as u128) << 64),
             _ => panic!("invalid wasm result"),
         }
     }


### PR DESCRIPTION
Fix the new clippy warnings. Most of them were due to the [precedence lint](https://rust-lang.github.io/rust-clippy/master/index.html#precedence).