### PR TITLE
cost-tracking: scaffold compiler and runtime code

### DIFF
--- a/clar2wasm/benches/comparison.rs
+++ b/clar2wasm/benches/comparison.rs
@@ -152,6 +152,7 @@ where
         ClarityVersion::latest(),
         StacksEpochId::latest(),
         &mut analysis_db,
+        false,
     )
     .expect("Failed compiling clarity to WASM");
 

--- a/clar2wasm/build.rs
+++ b/clar2wasm/build.rs
@@ -1,6 +1,8 @@
 /// Generate the standard library as a Wasm binary from the WAT source.
 #[allow(clippy::expect_used)]
 fn main() {
+    println!("cargo:rerun-if-changed=src/standard/standard.wat");
+
     match wat::parse_file("src/standard/standard.wat") {
         Ok(binary) => {
             std::fs::write("src/standard/standard.wasm", binary)
@@ -10,5 +12,4 @@ fn main() {
             panic!("Failed to parse standard library: {error}");
         }
     };
-    println!("cargo:rerun-if-changed=src/standard/standard.wat");
 }

--- a/clar2wasm/src/bin/main.rs
+++ b/clar2wasm/src/bin/main.rs
@@ -23,6 +23,9 @@ struct Args {
     /// Output file to write compiled WebAssembly to
     #[arg(short, long)]
     output: Option<String>,
+    /// Whether to emit cost-tracking code.
+    #[arg(long, default_value_t = false)]
+    cost_tracking: bool,
 }
 
 fn main() {
@@ -60,6 +63,7 @@ fn main() {
         clarity_version,
         epoch,
         &mut datastore.as_analysis_db(),
+        args.cost_tracking,
     )
     .unwrap_or_else(|err| match err {
         CompileError::Generic {

--- a/clar2wasm/src/cost.rs
+++ b/clar2wasm/src/cost.rs
@@ -1,0 +1,805 @@
+//! Functionality to track the costs of running Clarity.
+//!
+//! The cost computations in this module are meant to be a full match with the interpreter
+//! implementation of the Clarity runtime.
+
+mod clar3;
+
+use std::fmt;
+
+use clarity::vm::ClarityName;
+use walrus::ir::{BinaryOp, Instr, UnaryOp, Unop};
+use walrus::{FunctionId, GlobalId, InstrSeqBuilder, LocalId, Module};
+use wasmtime::{AsContextMut, Extern, Global, Mutability, Val, ValType};
+
+use crate::error_mapping::ErrorMap;
+use crate::wasm_generator::{GeneratorError, WasmGenerator};
+use crate::words::Word;
+
+type Result<T, E = GeneratorError> = std::result::Result<T, E>;
+
+/// Values of the cost globals
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CostMeter {
+    pub runtime: u64,
+    pub read_count: u64,
+    pub read_length: u64,
+    pub write_count: u64,
+    pub write_length: u64,
+}
+
+/// Globals used for cost tracking
+#[derive(Debug, Clone, Copy)]
+pub struct CostGlobals {
+    pub runtime: Global,
+    pub read_count: Global,
+    pub read_length: Global,
+    pub write_count: Global,
+    pub write_length: Global,
+}
+
+/// Trait for a `Linker` that can be used to retrieve the cost globals.
+pub trait CostLinker<T> {
+    /// Get the cost globals.
+    fn get_cost_globals(&self, store: impl AsContextMut<Data = T>)
+        -> wasmtime::Result<CostGlobals>;
+    /// Define the cost globals.
+    fn define_cost_globals(&mut self, store: impl AsContextMut<Data = T>) -> wasmtime::Result<()>;
+}
+
+/// Convenience to use the same error string in multiple places
+#[derive(Debug)]
+enum GetCostGlobalsError {
+    Runtime,
+    ReadCount,
+    ReadLength,
+    WriteCount,
+    WriteLength,
+}
+
+impl fmt::Display for GetCostGlobalsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use GetCostGlobalsError::*;
+
+        match self {
+            Runtime => write!(f, "missing `cost-runtime` global"),
+            ReadCount => write!(f, "missing `cost-read-count` global"),
+            ReadLength => write!(f, "missing `cost-read-length` global"),
+            WriteCount => write!(f, "missing `cost-write-count` global"),
+            WriteLength => write!(f, "missing `cost-write-length` global"),
+        }
+    }
+}
+
+impl std::error::Error for GetCostGlobalsError {}
+
+impl<T> CostLinker<T> for wasmtime::Linker<T> {
+    fn get_cost_globals(
+        &self,
+        mut store: impl AsContextMut<Data = T>,
+    ) -> wasmtime::Result<CostGlobals> {
+        let mut store = store.as_context_mut();
+
+        let runtime = self.get(&mut store, "clarity", "cost-runtime");
+        let read_count = self.get(&mut store, "clarity", "cost-read-count");
+        let read_length = self.get(&mut store, "clarity", "cost-read-length");
+        let write_count = self.get(&mut store, "clarity", "cost-write-count");
+        let write_length = self.get(&mut store, "clarity", "cost-write-length");
+
+        use GetCostGlobalsError::*;
+
+        fn unwrap_global_or(
+            ext: Option<Extern>,
+            err: GetCostGlobalsError,
+        ) -> Result<Global, GetCostGlobalsError> {
+            match ext {
+                Some(Extern::Global(global)) => Ok(global),
+                _ => Err(err),
+            }
+        }
+
+        Ok(CostGlobals {
+            runtime: unwrap_global_or(runtime, Runtime)?,
+            read_count: unwrap_global_or(read_count, ReadCount)?,
+            read_length: unwrap_global_or(read_length, ReadLength)?,
+            write_count: unwrap_global_or(write_count, WriteCount)?,
+            write_length: unwrap_global_or(write_length, WriteLength)?,
+        })
+    }
+
+    fn define_cost_globals(
+        &mut self,
+        mut store: impl AsContextMut<Data = T>,
+    ) -> wasmtime::Result<()> {
+        let mut store = store.as_context_mut();
+
+        define_cost_global_import(self, &mut store, "cost-runtime", 0)?;
+        define_cost_global_import(self, &mut store, "cost-read-count", 0)?;
+        define_cost_global_import(self, &mut store, "cost-read-length", 0)?;
+        define_cost_global_import(self, &mut store, "cost-write-count", 0)?;
+        define_cost_global_import(self, &mut store, "cost-write-length", 0)?;
+
+        Ok(())
+    }
+}
+
+fn define_cost_global_import<T>(
+    linker: &mut wasmtime::Linker<T>,
+    mut store: impl AsContextMut<Data = T>,
+    name: &str,
+    value: u64,
+) -> wasmtime::Result<()> {
+    use wasmtime::{Global, GlobalType};
+
+    let mut store = store.as_context_mut();
+
+    let global = Global::new(
+        &mut store,
+        GlobalType::new(ValType::I64, Mutability::Var),
+        Val::I64(value as _),
+    )?;
+
+    linker.define(&mut store, "clarity", name, global)?;
+
+    Ok(())
+}
+
+/// Trait to manipulate the values of a cost meter.
+pub trait AccessCostMeter<T>: CostLinker<T> {
+    /// Get the current value of the cost meter.
+    fn get_cost_meter(
+        &self,
+        mut store: impl AsContextMut<Data = T>,
+    ) -> wasmtime::Result<CostMeter> {
+        let mut store = store.as_context_mut();
+
+        let globals = self.get_cost_globals(&mut store)?;
+
+        use GetCostGlobalsError::*;
+
+        Ok(CostMeter {
+            runtime: globals.runtime.get(&mut store).i64().ok_or(Runtime)? as _,
+            read_count: globals.read_count.get(&mut store).i64().ok_or(ReadCount)? as _,
+            read_length: globals
+                .read_length
+                .get(&mut store)
+                .i64()
+                .ok_or(ReadLength)? as _,
+            write_count: globals
+                .write_count
+                .get(&mut store)
+                .i64()
+                .ok_or(WriteCount)? as _,
+            write_length: globals
+                .write_length
+                .get(&mut store)
+                .i64()
+                .ok_or(WriteLength)? as _,
+        })
+    }
+
+    /// Set the value of the cost meter.
+    fn set_cost_meter(
+        &self,
+        mut store: impl AsContextMut<Data = T>,
+        meter: CostMeter,
+    ) -> wasmtime::Result<()> {
+        let mut store = store.as_context_mut();
+
+        let globals = self.get_cost_globals(&mut store)?;
+
+        globals
+            .runtime
+            .set(&mut store, Val::I64(meter.runtime as _))?;
+        globals
+            .read_count
+            .set(&mut store, Val::I64(meter.read_count as _))?;
+        globals
+            .read_length
+            .set(&mut store, Val::I64(meter.read_length as _))?;
+        globals
+            .write_count
+            .set(&mut store, Val::I64(meter.write_count as _))?;
+        globals
+            .write_length
+            .set(&mut store, Val::I64(meter.write_length as _))?;
+
+        Ok(())
+    }
+}
+
+impl<D, T: CostLinker<D>> AccessCostMeter<D> for T {}
+
+/// Extension trait allowing for words to generate cost tracking code
+/// during traversal.
+// TODO: use this in word traversal
+#[allow(dead_code)]
+pub trait WordCharge {
+    /// Generate cost tracking code for this word.
+    ///
+    /// See [`ChargeGenerator::charge`] for more details.
+    fn charge<C: ChargeGenerator>(
+        &self,
+        generator: &C,
+        instrs: &mut InstrSeqBuilder,
+        n: impl Into<Scalar>,
+    ) -> Result<()>;
+}
+
+impl<W: ?Sized + Word> WordCharge for W {
+    fn charge<C: ChargeGenerator>(
+        &self,
+        generator: &C,
+        instrs: &mut InstrSeqBuilder,
+        n: impl Into<Scalar>,
+    ) -> Result<()> {
+        generator.charge(instrs, self.name(), n)
+    }
+}
+
+/// Generators of cost tracking code.
+pub trait ChargeGenerator {
+    /// The cost tracking context. Only present if charging code should be emitted.
+    fn cost_context(&self) -> Option<(&ChargeContext, &Module)>;
+
+    /// Generate code that charges the appropriate cost for the given word.
+    ///
+    /// `n` is a scaling factor that depends on the word being charged, but can only be known
+    /// during traversal. The value *must* be either a `u32` or a `LocalId` representing a local
+    /// with type `I32`.
+    /// If the word has a constant cost, the value will be ignored. This is useful in words where
+    /// the cost is known to be constant during traversal.
+    ///
+    /// Code will be generated iff [`cost_context`] returns `Some`.
+    fn charge(
+        &self,
+        instrs: &mut InstrSeqBuilder,
+        word_name: ClarityName,
+        n: impl Into<Scalar>,
+    ) -> Result<()> {
+        let n = n.into();
+
+        if let Some((ctx, module)) = self.cost_context() {
+            match clar3::WORD_COSTS.get(&word_name) {
+                Some(cost) => ctx.emit(instrs, module, cost, n)?,
+                None => {
+                    return Err(GeneratorError::InternalError(format!(
+                        "expected '{word_name}' to be in costs table"
+                    )))
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl ChargeGenerator for WasmGenerator {
+    fn cost_context(&self) -> Option<(&ChargeContext, &Module)> {
+        self.cost_context.as_ref().map(|ctx| (ctx, &self.module))
+    }
+}
+
+/// A 32-bit unsigned integer to be resolved at either compile-time or run-time.
+#[derive(Clone, Copy)]
+pub enum Scalar {
+    Compile(u32),
+    Run(LocalId),
+}
+
+impl From<u32> for Scalar {
+    fn from(n: u32) -> Self {
+        Self::Compile(n)
+    }
+}
+
+impl From<LocalId> for Scalar {
+    fn from(n: LocalId) -> Self {
+        Self::Run(n)
+    }
+}
+
+/// Trait for allowing us to not repeat ourselves in resolving a scalar.
+trait ScalarGet {
+    fn scalar_get(&mut self, module: &Module, scalar: Scalar) -> Result<&mut Self>;
+}
+
+impl ScalarGet for InstrSeqBuilder<'_> {
+    fn scalar_get(&mut self, module: &Module, scalar: Scalar) -> Result<&mut Self> {
+        Ok(match scalar {
+            Scalar::Compile(c) => self.i64_const(c as _),
+            Scalar::Run(l) => {
+                let local = module.locals.get(l);
+
+                match local.ty() {
+                    walrus::ValType::I32 => {}
+                    ty => {
+                        return Err(GeneratorError::InternalError(format!(
+                            "cost local should be of type i32 but is of type {ty}"
+                        )))
+                    }
+                }
+
+                self.local_get(l)
+                    // this is so we don't have to repeat this code in the `caf` functions
+                    .instr(Instr::Unop(Unop {
+                        op: UnaryOp::I64ExtendUI32,
+                    }))
+            }
+        })
+    }
+}
+
+/// Context required from a generator to emit cost tracking code.
+pub struct ChargeContext {
+    pub runtime: GlobalId,
+    pub read_count: GlobalId,
+    pub read_length: GlobalId,
+    pub write_count: GlobalId,
+    pub write_length: GlobalId,
+    pub runtime_error: FunctionId,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct WordCost {
+    runtime: Caf,
+    read_count: Caf,
+    read_length: Caf,
+    write_count: Caf,
+    write_length: Caf,
+}
+
+/// Cost assessment function
+#[derive(Debug, Clone, Copy)]
+enum Caf {
+    /// Constant cost
+    Constant(u32),
+    /// Linear cost, scaling with `n`
+    ///
+    /// a * n + b
+    Linear { a: u64, b: u64 },
+    /// Linear logarithmic cost, scaling with `n`
+    ///
+    /// a * n * log2(n) + b
+    NLogN { a: u64, b: u64 },
+    /// Zero cost - equivalent to `Constant(0)`
+    None,
+}
+
+impl ChargeContext {
+    fn emit(
+        &self,
+        instrs: &mut InstrSeqBuilder,
+        module: &Module,
+        cost: &WordCost,
+        n: Scalar,
+    ) -> Result<()> {
+        self.emit_with_caf(
+            instrs,
+            module,
+            cost.runtime,
+            self.runtime,
+            ErrorMap::CostOverrunRuntime as _,
+            n,
+        )?;
+        self.emit_with_caf(
+            instrs,
+            module,
+            cost.read_count,
+            self.read_count,
+            ErrorMap::CostOverrunReadCount as _,
+            n,
+        )?;
+        self.emit_with_caf(
+            instrs,
+            module,
+            cost.read_length,
+            self.read_length,
+            ErrorMap::CostOverrunReadLength as _,
+            n,
+        )?;
+        self.emit_with_caf(
+            instrs,
+            module,
+            cost.write_count,
+            self.write_count,
+            ErrorMap::CostOverrunWriteCount as _,
+            n,
+        )?;
+        self.emit_with_caf(
+            instrs,
+            module,
+            cost.write_length,
+            self.write_length,
+            ErrorMap::CostOverrunWriteLength as _,
+            n,
+        )?;
+
+        Ok(())
+    }
+
+    fn emit_with_caf(
+        &self,
+        instrs: &mut InstrSeqBuilder,
+        module: &Module,
+        params: Caf,
+        global: GlobalId,
+        err_code: i32,
+        n: impl Into<Scalar>,
+    ) -> Result<()> {
+        match params {
+            Caf::Constant(cost) => {
+                caf_const(instrs, module, global, self.runtime_error, err_code, cost)
+            }
+            Caf::Linear { a, b } => caf_linear(
+                instrs,
+                module,
+                global,
+                self.runtime_error,
+                err_code,
+                n,
+                a,
+                b,
+            ),
+            Caf::NLogN { a, b } => caf_nlogn(
+                instrs,
+                module,
+                global,
+                self.runtime_error,
+                err_code,
+                n,
+                a,
+                b,
+            ),
+            Caf::None => Ok(()),
+        }
+    }
+}
+
+fn caf_const(
+    instrs: &mut InstrSeqBuilder,
+    module: &Module,
+    global: GlobalId,
+    error: FunctionId,
+    err_code: i32,
+    cost: impl Into<Scalar>,
+) -> Result<()> {
+    let cost = cost.into();
+
+    // global pushed onto the stack to subtract from later
+    instrs.global_get(global);
+
+    // cost
+    instrs.scalar_get(module, cost)?;
+
+    // global -= cost
+    instrs
+        .binop(BinaryOp::I64Sub)
+        .global_set(global)
+        .global_get(global)
+        .i64_const(0)
+        .binop(BinaryOp::I64LtS)
+        .if_else(
+            None,
+            |builder| {
+                builder.i32_const(err_code);
+                builder.call(error);
+            },
+            |_| {},
+        );
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn caf_linear(
+    instrs: &mut InstrSeqBuilder,
+    module: &Module,
+    global: GlobalId,
+    error: FunctionId,
+    err_code: i32,
+    n: impl Into<Scalar>,
+    a: u64,
+    b: u64,
+) -> Result<()> {
+    let n = n.into();
+
+    // global pushed onto the stack to subtract from later
+    instrs.global_get(global);
+
+    // cost = a * n + b
+    instrs
+        // n
+        .scalar_get(module, n)?
+        // a *
+        .i64_const(a as _)
+        .binop(BinaryOp::I64Mul)
+        // b +
+        .i64_const(b as _)
+        .binop(BinaryOp::I64Add);
+
+    // global -= cost
+    instrs
+        .binop(BinaryOp::I64Sub)
+        .global_set(global)
+        .global_get(global)
+        .i64_const(0)
+        .binop(BinaryOp::I64LtS)
+        .if_else(
+            None,
+            |builder| {
+                builder.i32_const(err_code);
+                builder.call(error);
+            },
+            |_| {},
+        );
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn caf_nlogn(
+    instrs: &mut InstrSeqBuilder,
+    module: &Module,
+    global: GlobalId,
+    error: FunctionId,
+    err_code: i32,
+    n: impl Into<Scalar>,
+    a: u64,
+    b: u64,
+) -> Result<()> {
+    let n = n.into();
+
+    // global pushed onto the stack to subtract from later
+    instrs.global_get(global);
+
+    // cost = a * n * log2(n) + b
+    instrs
+        // log2(n)
+        // 63 minus leading zeros in `n`
+        // n *must* be larger than 0
+        .i64_const(63)
+        .scalar_get(module, n)?
+        .unop(UnaryOp::I64Clz)
+        .binop(BinaryOp::I64Sub)
+        // n *
+        .scalar_get(module, n)?
+        .binop(BinaryOp::I64Mul)
+        // a *
+        .i64_const(a as _)
+        .binop(BinaryOp::I64Mul)
+        // b +
+        .i64_const(b as _)
+        .binop(BinaryOp::I64Add);
+
+    // global -= cost
+    instrs
+        .binop(BinaryOp::I64Sub)
+        .global_set(global)
+        .global_get(global)
+        .i64_const(0)
+        .binop(BinaryOp::I64LtS)
+        .if_else(
+            None,
+            |builder| {
+                builder.i32_const(err_code);
+                builder.call(error);
+            },
+            |_| {},
+        );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod test_caf {
+    //! The code in this module tests that the code generation in the `caf_*` functions is correct,
+    //! *not* that the code generation of each word is correct.
+
+    use super::*;
+
+    #[test]
+    fn constant() {
+        let initial_cost_val = 1000000;
+
+        for cost in 1..100 {
+            let final_cost_val =
+                execute_with_caf(0, initial_cost_val, |local| (Caf::Constant(cost), local))
+                    .expect("execution with enough fuel should succeed");
+
+            assert_eq!(
+                final_cost_val,
+                initial_cost_val - cost as u64,
+                "should decrement accurately"
+            );
+        }
+    }
+
+    #[test]
+    fn linear() {
+        let initial_val = 1000000;
+
+        let a = 2;
+        let b = 3;
+
+        for n in 0..100 {
+            let cost = a * n + b;
+
+            let final_val = execute_with_caf(n, initial_val, |local| {
+                (
+                    Caf::Linear {
+                        a: a as _,
+                        b: b as _,
+                    },
+                    local,
+                )
+            })
+            .expect("execution with enough fuel should succeed");
+
+            assert_eq!(
+                final_val,
+                initial_val - cost as u64,
+                "should decrement accurately"
+            );
+        }
+    }
+
+    #[test]
+    fn nlogn() {
+        let initial_val = 1000000;
+
+        let a = 2;
+        let b = 3;
+
+        // cost = (+ (* a (* n (log2 n))) b))
+
+        for n in 1..100u32 {
+            let cost = a * n * n.ilog2() + b;
+
+            let final_val = execute_with_caf(n as _, initial_val, |local| {
+                (
+                    Caf::NLogN {
+                        a: a as _,
+                        b: b as _,
+                    },
+                    local,
+                )
+            })
+            .expect("execution with enough fuel should succeed");
+
+            assert_eq!(
+                final_val,
+                initial_val - cost as u64,
+                "should decrement accurately"
+            );
+        }
+    }
+
+    #[test]
+    fn none() {
+        let initial_val = 2;
+        let fn_arg = 0;
+
+        let final_val = execute_with_caf(fn_arg, initial_val, |local| (Caf::None, local))
+            .expect("execution with enough fuel should succeed");
+
+        assert_eq!(final_val, initial_val, "none caf should not cost");
+    }
+
+    const ERR_CODE: i32 = -42;
+
+    fn execute_with_caf<S: Into<Scalar>>(
+        arg: i32,
+        initial: u64,
+        caf: impl FnOnce(LocalId) -> (Caf, S),
+    ) -> Result<u64, i64> {
+        use wasmtime::{Engine, Linker, Module, Store};
+
+        let engine = Engine::default();
+        let binary = module_with_caf(caf);
+        let module = Module::from_binary(&engine, &binary).unwrap();
+
+        let mut linker = Linker::<()>::new(&engine);
+        let mut store = Store::new(&engine, ());
+
+        linker.define_cost_globals(&mut store).unwrap();
+        linker
+            .set_cost_meter(
+                &mut store,
+                CostMeter {
+                    runtime: initial,
+                    read_count: 0,
+                    read_length: 0,
+                    write_count: 0,
+                    write_length: 0,
+                },
+            )
+            .unwrap();
+
+        let instance = linker.instantiate(&mut store, &module).unwrap();
+
+        let func = instance
+            .get_typed_func::<i32, i32>(&mut store, "identity")
+            .unwrap();
+        let err_code = instance.get_global(&mut store, "err-code").unwrap();
+
+        match func.call(&mut store, arg) {
+            Ok(_) => Ok(linker.get_cost_meter(&mut store).unwrap().runtime),
+            Err(_) => Err(err_code.get(&mut store).unwrap_i64()),
+        }
+    }
+
+    // The functions generated here is extremely simple (a: i32) -> a, but still allows for
+    // understanding the runtime characteristics of any `Caf`.
+    fn module_with_caf<S: Into<Scalar>>(caf: impl FnOnce(LocalId) -> (Caf, S)) -> Vec<u8> {
+        use walrus::ir::Value;
+        use walrus::{FunctionBuilder, InitExpr, Module, ValType};
+
+        let mut module = Module::default();
+
+        // we put in all the globals, but we only use `cost-runtime`
+        let (cost_global, _) =
+            module.add_import_global("clarity", "cost-runtime", ValType::I64, true);
+        module.add_import_global("clarity", "cost-read-count", ValType::I64, true);
+        module.add_import_global("clarity", "cost-read-length", ValType::I64, true);
+        module.add_import_global("clarity", "cost-write-count", ValType::I64, true);
+        module.add_import_global("clarity", "cost-write-length", ValType::I64, true);
+
+        let error_global =
+            module
+                .globals
+                .add_local(ValType::I32, true, InitExpr::Value(Value::I32(0)));
+
+        let arg = module.locals.add(ValType::I32);
+
+        // runtime error that takes an I32 and traps, similar to the stdlib
+        let mut error = FunctionBuilder::new(&mut module.types, &[ValType::I32], &[]);
+        let mut body = error.func_body();
+        body.local_get(arg);
+        body.global_set(error_global);
+        body.unreachable();
+        let error = error.finish(vec![arg], &mut module.funcs);
+
+        let mut identity =
+            FunctionBuilder::new(&mut module.types, &[ValType::I32], &[ValType::I32]);
+
+        let mut body = identity.func_body();
+
+        let (caf, scalar) = caf(arg);
+        match caf {
+            Caf::Constant(n) => {
+                caf_const(&mut body, &module, cost_global, error, ERR_CODE, n).unwrap()
+            }
+            Caf::Linear { a, b } => caf_linear(
+                &mut body,
+                &module,
+                cost_global,
+                error,
+                ERR_CODE,
+                scalar,
+                a,
+                b,
+            )
+            .unwrap(),
+            Caf::NLogN { a, b } => caf_nlogn(
+                &mut body,
+                &module,
+                cost_global,
+                error,
+                ERR_CODE,
+                scalar,
+                a,
+                b,
+            )
+            .unwrap(),
+            Caf::None => {}
+        }
+        body.local_get(arg);
+        let identity = identity.finish(vec![arg], &mut module.funcs);
+
+        module.exports.add("identity", identity);
+        module.exports.add("err-code", error_global);
+
+        module.emit_wasm()
+    }
+}

--- a/clar2wasm/src/cost/clar3.rs
+++ b/clar2wasm/src/cost/clar3.rs
@@ -1,0 +1,1170 @@
+use std::collections::HashMap;
+
+use clarity::vm::ClarityName;
+use lazy_static::lazy_static;
+
+use super::{Caf, WordCost};
+use crate::words::arithmetic::{Add, Div, Log2, Modulo, Mul, Power, Sqrti, Sub};
+use crate::words::bindings::Let;
+use crate::words::bitwise::{
+    BitwiseAnd, BitwiseLShift, BitwiseNot, BitwiseOr, BitwiseRShift, BitwiseXor,
+};
+use crate::words::blockinfo::{
+    AtBlock, GetBlockInfo, GetBurnBlockInfo, GetStacksBlockInfo, GetTenureInfo,
+};
+use crate::words::buff_to_integer::{BuffToIntBe, BuffToIntLe, BuffToUintBe, BuffToUintLe};
+use crate::words::comparison::{CmpGeq, CmpGreater, CmpLeq, CmpLess};
+use crate::words::conditionals::{And, Asserts, Filter, If, Match, Or, Try, Unwrap, UnwrapErr};
+use crate::words::consensus_buff::{FromConsensusBuff, ToConsensusBuff};
+use crate::words::contract::{AsContract, ContractCall};
+use crate::words::control_flow::{Begin, UnwrapErrPanic, UnwrapPanic};
+use crate::words::conversion::{IntToAscii, IntToUtf8, StringToInt, StringToUint};
+use crate::words::data_vars::{GetDataVar, SetDataVar};
+use crate::words::default_to::DefaultTo;
+use crate::words::enums::{ClarityErr, ClarityOk, ClaritySome};
+use crate::words::equal::{IndexOf, IsEq};
+use crate::words::hashing::{Hash160, Keccak256, Sha256, Sha512, Sha512_256};
+use crate::words::logical::Not;
+use crate::words::maps::{MapDelete, MapGet, MapInsert, MapSet};
+use crate::words::noop::{ContractOf, ToInt, ToUint};
+use crate::words::options::{IsNone, IsSome};
+use crate::words::principal::{Construct, Destruct, IsStandard, PrincipalOf};
+use crate::words::print::Print;
+use crate::words::responses::{IsErr, IsOk};
+use crate::words::secp256k1::{Recover, Verify};
+use crate::words::sequences::{
+    Append, AsMaxLen, Concat, ElementAt, Fold, Len, ListCons, Map, ReplaceAt, Slice,
+};
+use crate::words::stx::{StxBurn, StxGetAccount, StxGetBalance, StxTransfer, StxTransferMemo};
+use crate::words::tokens::{
+    BurnFungibleToken, BurnNonFungibleToken, GetBalanceOfFungibleToken, GetOwnerOfNonFungibleToken,
+    GetSupplyOfFungibleToken, MintFungibleToken, MintNonFungibleToken, TransferFungibleToken,
+    TransferNonFungibleToken,
+};
+use crate::words::tuples::{TupleCons, TupleGet, TupleMerge};
+use crate::words::Word;
+
+lazy_static! {
+    pub(super) static ref WORD_COSTS: HashMap<ClarityName, WordCost> = {
+        use Caf::*;
+
+        let mut map = HashMap::new();
+
+        // simple variadic words
+
+        map.insert(
+            Add.name(),
+            WordCost {
+                runtime: Linear { a: 11, b: 125 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Sub.name(),
+            WordCost {
+                runtime: Linear { a: 11, b: 125 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Mul.name(),
+            WordCost {
+                runtime: Linear { a: 13, b: 125 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Div.name(),
+            WordCost {
+                runtime: Linear { a: 13, b: 125 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+
+        // simple words
+
+        map.insert(
+            Log2.name(),
+            WordCost {
+                runtime: Constant(133),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Modulo.name(),
+            WordCost {
+                runtime: Constant(141),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Power.name(),
+            WordCost {
+                runtime: Constant(143),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Sqrti.name(),
+            WordCost {
+                runtime: Constant(142),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            BitwiseAnd.name(),
+            WordCost {
+                runtime: Linear { a: 15, b: 129 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            BitwiseOr.name(),
+            WordCost {
+                runtime: Linear { a: 15, b: 129 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            BitwiseXor.name(),
+            WordCost {
+                runtime: Linear { a: 15, b: 129 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            BitwiseNot.name(),
+            WordCost {
+                runtime: Constant(147),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            BitwiseLShift.name(),
+            WordCost {
+                runtime: Constant(167),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            BitwiseRShift.name(),
+            WordCost {
+                runtime: Constant(167),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            BuffToIntLe.name(),
+            WordCost {
+                runtime: Constant(141),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            BuffToIntBe.name(),
+            WordCost {
+                runtime: Constant(141),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            BuffToUintLe.name(),
+            WordCost {
+                runtime: Constant(141),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            BuffToUintBe.name(),
+            WordCost {
+                runtime: Constant(141),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            CmpGreater.name(),
+            WordCost {
+                runtime: Linear { a: 7, b: 128 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            CmpGeq.name(),
+            WordCost {
+                runtime: Linear { a: 7, b: 128 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            CmpLess.name(),
+            WordCost {
+                runtime: Linear { a: 7, b: 128 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            CmpLeq.name(),
+            WordCost {
+                runtime: Linear { a: 7, b: 128 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Or.name(),
+            WordCost {
+                runtime: Linear { a: 3, b: 120 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            And.name(),
+            WordCost {
+                runtime: Linear { a: 3, b: 120 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Not.name(),
+            WordCost {
+                runtime: Constant(138),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            IntToAscii.name(),
+            WordCost {
+                runtime: Constant(147),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            IntToUtf8.name(),
+            WordCost {
+                runtime: Constant(181),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            StringToInt.name(),
+            WordCost {
+                runtime: Constant(168),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            StringToUint.name(),
+            WordCost {
+                runtime: Constant(168),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            ToInt.name(),
+            WordCost {
+                runtime: Constant(135),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            ToUint.name(),
+            WordCost {
+                runtime: Constant(135),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Hash160.name(),
+            WordCost {
+                runtime: Linear {  a: 1, b: 188 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Keccak256.name(),
+            WordCost {
+                runtime: Linear {  a: 1, b: 127 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Sha256.name(),
+            WordCost {
+                runtime: Linear {  a: 1, b: 100 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Sha512.name(),
+            WordCost {
+                runtime: Linear {  a: 1, b: 176 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Sha512_256.name(),
+            WordCost {
+                runtime: Linear {  a: 1, b: 56 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Destruct.name(),
+            WordCost {
+                runtime: Constant(314),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            IsStandard.name(),
+            WordCost {
+                runtime: Constant(127),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        // TODO: check if this indeed costs nothing (SUSPICIOUS)
+        map.insert(
+            StxBurn.name(),
+            WordCost {
+                runtime: None,
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            StxGetAccount.name(),
+            WordCost {
+                runtime: Constant(4654),
+                read_count: Constant(1),
+                read_length: Constant(1),
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            StxGetBalance.name(),
+            WordCost {
+                runtime: Constant(4294),
+                read_count: Constant(1),
+                read_length: Constant(1),
+                write_count: None,
+                write_length: None,
+            },
+        );
+
+        // complex words
+
+        map.insert(
+            Let.name(),
+            WordCost {
+                runtime: Linear { a: 117, b: 178 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            }
+        );
+        map.insert(
+            AtBlock.name(),
+            WordCost {
+                runtime: Constant(1327),
+                read_count: Constant(1),
+                read_length: Constant(1),
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            GetBlockInfo.name(),
+            WordCost {
+                runtime: Constant(6321),
+                read_count: Constant(1),
+                read_length: Constant(1),
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            GetBurnBlockInfo.name(),
+            WordCost {
+                runtime: Constant(96479),
+                read_count: Constant(1),
+                read_length: Constant(1),
+                write_count: None,
+                write_length: None,
+            },
+        );
+        // TODO: check if this indeed costs the same as `get_block_info`
+        map.insert(
+            GetStacksBlockInfo.name(),
+            WordCost {
+                runtime: Constant(6321),
+                read_count: Constant(1),
+                read_length: Constant(1),
+                write_count: None,
+                write_length: None,
+            },
+        );
+        // TODO: check if this indeed costs nothing (SUSPICIOUS)
+        map.insert(
+            GetTenureInfo.name(),
+            WordCost {
+                runtime: None,
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Asserts.name(),
+            WordCost {
+                runtime: Constant(128),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Filter.name(),
+            WordCost {
+                runtime: Constant(407),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            If.name(),
+            WordCost {
+                runtime: Constant(168),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Match.name(),
+            WordCost {
+                runtime: Constant(264),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Try.name(),
+            WordCost {
+                runtime: Constant(240),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Unwrap.name(),
+            WordCost {
+                runtime: Constant(252),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            UnwrapErr.name(),
+            WordCost {
+                runtime: Constant(248),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            UnwrapErrPanic.name(),
+            WordCost {
+                runtime: Constant(302),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            UnwrapPanic.name(),
+            WordCost {
+                runtime: Constant(274),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            FromConsensusBuff.name(),
+            WordCost {
+                runtime: NLogN { a: 3, b: 185 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            ToConsensusBuff.name(),
+            WordCost {
+                runtime: Linear { a: 1, b: 233 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            AsContract.name(),
+            WordCost {
+                runtime: Constant(138),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            ContractCall.name(),
+            WordCost {
+                runtime: Constant(134),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Begin.name(),
+            WordCost {
+                runtime: Constant(151),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            GetDataVar.name(),
+            WordCost {
+                runtime: Linear { a: 1, b: 151 },
+                read_count: Constant(1),
+                read_length: Linear { a: 1, b: 1 },
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            SetDataVar.name(),
+            WordCost {
+                runtime: Linear { a: 5, b: 655 },
+                read_count: None,
+                read_length: None,
+                write_count: Constant(1),
+                write_length: Linear { a: 1, b: 1 },
+            },
+        );
+        map.insert(
+            DefaultTo.name(),
+            WordCost {
+                runtime: Constant(268),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            ClarityOk.name(),
+            WordCost {
+                runtime: Constant(199),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            ClarityErr.name(),
+            WordCost {
+                runtime: Constant(199),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            ClaritySome.name(),
+            WordCost {
+                runtime: Constant(199),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            IndexOf::Alias.name(),
+            WordCost {
+                runtime: Linear { a: 1, b: 211 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            IndexOf::Original.name(),
+            WordCost {
+                runtime: Linear { a: 1, b: 211 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            IsEq.name(),
+            WordCost {
+                runtime: Linear { a: 1, b: 151 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            MapGet.name(),
+            WordCost {
+                runtime: Linear { a: 1, b: 1025 },
+                read_count: Constant(1),
+                read_length: Linear { a: 1, b: 1},
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            MapSet.name(),
+            WordCost {
+                runtime: Linear { a: 4, b: 1899 },
+                read_count: Constant(1),
+                read_length: None,
+                write_count: Constant(1),
+                write_length: Linear { a: 1, b: 1},
+            },
+        );
+        // TODO: check if this indeed costs the same as `map-set`
+        map.insert(
+            MapInsert.name(),
+            WordCost {
+                runtime: Linear { a: 4, b: 1899 },
+                read_count: Constant(1),
+                read_length: None,
+                write_count: Constant(1),
+                write_length: Linear { a: 1, b: 1},
+            },
+        );
+        // TODO: check if this indeed costs the same as `map-set`
+        map.insert(
+            MapDelete.name(),
+            WordCost {
+                runtime: Linear { a: 4, b: 1899 },
+                read_count: Constant(1),
+                read_length: None,
+                write_count: Constant(1),
+                write_length: Linear { a: 1, b: 1},
+            },
+        );
+        map.insert(
+            ContractOf.name(),
+            WordCost {
+                runtime: Constant(13400),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            IsNone.name(),
+            WordCost {
+                runtime: Constant(214),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            IsSome.name(),
+            WordCost {
+                runtime: Constant(195),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Construct.name(),
+            WordCost {
+                runtime: Constant(398),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            PrincipalOf.name(),
+            WordCost {
+                runtime: Constant(984),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Print.name(),
+            WordCost {
+                runtime: Linear { a:15, b: 1458 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            IsOk.name(),
+            WordCost {
+                runtime: Constant(258),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            IsErr.name(),
+            WordCost {
+                runtime: Constant(245),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Recover.name(),
+            WordCost {
+                runtime: Constant(8655),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Verify.name(),
+            WordCost {
+                runtime: Constant(8349),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Append.name(),
+            WordCost {
+                runtime: Linear { a: 73, b: 285 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            AsMaxLen.name(),
+            WordCost {
+                runtime: Constant(475),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Concat.name(),
+            WordCost {
+                runtime: Linear { a: 37, b: 220 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            ElementAt::Original.name(),
+            WordCost {
+                runtime: Constant(498),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            ElementAt::Alias.name(),
+            WordCost {
+                runtime: Constant(498),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Fold.name(),
+            WordCost {
+                runtime: Constant(460),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Len.name(),
+            WordCost {
+                runtime: Constant(429),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            ListCons.name(),
+            WordCost {
+                runtime: Linear { a: 14, b: 164 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Map.name(),
+            WordCost {
+                runtime: Linear { a: 1198, b: 3067 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            ReplaceAt.name(),
+            WordCost {
+                runtime: Linear { a: 1, b: 561 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            Slice.name(),
+            WordCost {
+                runtime: Constant(498),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            StxTransfer.name(),
+            WordCost {
+                runtime: Constant(4640),
+                read_count: Constant(1),
+                read_length: Constant(1),
+                write_count: Constant(1),
+                write_length: Constant(1),
+            },
+        );
+        map.insert(
+            StxTransferMemo.name(),
+            WordCost {
+                runtime: Constant(4709),
+                read_count: Constant(1),
+                read_length: Constant(1),
+                write_count: Constant(1),
+                write_length: Constant(1),
+            },
+        );
+        map.insert(
+            MintFungibleToken.name(),
+            WordCost {
+                runtime: Constant(1479),
+                read_count: Constant(2),
+                read_length: Constant(1),
+                write_count: Constant(2),
+                write_length: Constant(1),
+            },
+        );
+        map.insert(
+            BurnFungibleToken.name(),
+            WordCost {
+                runtime: Constant(549),
+                read_count: Constant(2),
+                read_length: Constant(1),
+                write_count: Constant(2),
+                write_length: Constant(1),
+            },
+        );
+        map.insert(
+            TransferFungibleToken.name(),
+            WordCost {
+                runtime: Constant(549),
+                read_count: Constant(2),
+                read_length: Constant(1),
+                write_count: Constant(2),
+                write_length: Constant(1),
+            },
+        );
+        map.insert(
+            GetSupplyOfFungibleToken.name(),
+            WordCost {
+                runtime: Constant(420),
+                read_count: Constant(1),
+                read_length: Constant(1),
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            GetBalanceOfFungibleToken.name(),
+            WordCost {
+                runtime: Constant(479),
+                read_count: Constant(1),
+                read_length: Constant(1),
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            MintNonFungibleToken.name(),
+            WordCost {
+                runtime: Linear { a: 9, b: 575 },
+                read_count: Constant(1),
+                read_length: Constant(1),
+                write_count: Constant(1),
+                write_length: Constant(1),
+            },
+        );
+        map.insert(
+            BurnNonFungibleToken.name(),
+            WordCost {
+                runtime: Linear { a: 9, b: 572 },
+                read_count: Constant(1),
+                read_length: Constant(1),
+                write_count: Constant(1),
+                write_length: Constant(1),
+            },
+        );
+        map.insert(
+            TransferNonFungibleToken.name(),
+            WordCost {
+                runtime: Linear { a: 9, b: 572 },
+                read_count: Constant(1),
+                read_length: Constant(1),
+                write_count: Constant(1),
+                write_length: Constant(1),
+            },
+        );
+        map.insert(
+            GetOwnerOfNonFungibleToken.name(),
+            WordCost {
+                runtime: Linear { a: 9, b: 795 },
+                read_count: Constant(1),
+                read_length: Constant(1),
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            TupleCons.name(),
+            WordCost {
+                runtime: NLogN { a: 10, b: 1876 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            TupleGet.name(),
+            WordCost {
+                runtime: NLogN { a: 4, b: 1736 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            TupleMerge.name(),
+            WordCost {
+                runtime: Linear { a: 4, b: 408 },
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+
+        // TODO: check if these are indeed only relevant during analysis
+        //
+        // DefineConstant
+        // DefineDataVar
+        // DefinePrivateFunction
+        // DefinePublicFunction
+        // DefineReadOnlyFunction
+        // DefineFungibleToken
+        // DefineNonFungibleToken
+        // DefineTrait
+
+        map
+    };
+}

--- a/clar2wasm/src/error_mapping.rs
+++ b/clar2wasm/src/error_mapping.rs
@@ -78,6 +78,21 @@ pub enum ErrorMap {
     /// Indicates an attempt to use a function with too many arguments
     ArgumentCountAtMost = 15,
 
+    /// Indicates a runtime cost overrun
+    CostOverrunRuntime = 100,
+
+    /// Indicates a read count cost overrun
+    CostOverrunReadCount = 101,
+
+    /// Indicates a read length cost overrun
+    CostOverrunReadLength = 102,
+
+    /// Indicates a write count cost overrun
+    CostOverrunWriteCount = 103,
+
+    /// Indicates a write length cost overrun
+    CostOverrunWriteLength = 104,
+
     /// A catch-all for errors that are not mapped to specific error codes.
     /// This might be used for unexpected or unclassified errors.
     NotMapped = 99,
@@ -103,6 +118,11 @@ impl From<i32> for ErrorMap {
             13 => ErrorMap::ArgumentCountMismatch,
             14 => ErrorMap::ArgumentCountAtLeast,
             15 => ErrorMap::ArgumentCountAtMost,
+            100 => ErrorMap::CostOverrunRuntime,
+            101 => ErrorMap::CostOverrunReadCount,
+            102 => ErrorMap::CostOverrunReadLength,
+            103 => ErrorMap::CostOverrunWriteCount,
+            104 => ErrorMap::CostOverrunWriteLength,
             _ => ErrorMap::NotMapped,
         }
     }

--- a/clar2wasm/src/lib.rs
+++ b/clar2wasm/src/lib.rs
@@ -12,6 +12,9 @@ use clarity::vm::ClarityVersion;
 pub use walrus::Module;
 use wasm_generator::{GeneratorError, WasmGenerator};
 
+mod cost;
+pub use cost::{AccessCostMeter, CostGlobals, CostLinker, CostMeter};
+
 mod deserialize;
 pub mod initialize;
 pub mod linker;
@@ -60,6 +63,7 @@ pub fn compile(
     clarity_version: ClarityVersion,
     epoch: StacksEpochId,
     analysis_db: &mut AnalysisDatabase,
+    emit_cost_code: bool,
 ) -> Result<CompileResult, CompileError> {
     // Parse the contract
     let (ast, mut diagnostics, success) = build_ast_with_diagnostics(
@@ -120,7 +124,12 @@ pub fn compile(
     }
 
     #[allow(clippy::expect_used)]
-    match WasmGenerator::new(contract_analysis.clone()).and_then(WasmGenerator::generate) {
+    let generator = match emit_cost_code {
+        false => WasmGenerator::new(contract_analysis.clone()),
+        true => WasmGenerator::with_cost_code(contract_analysis.clone()),
+    };
+
+    match generator.and_then(WasmGenerator::generate) {
         Ok(module) => Ok(CompileResult {
             ast,
             diagnostics,
@@ -132,6 +141,7 @@ pub fn compile(
             Err(CompileError::Generic {
                 ast: Box::new(ast),
                 diagnostics,
+                #[allow(clippy::expect_used)]
                 cost_tracker: Box::new(
                     contract_analysis
                         .cost_track

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -327,7 +327,17 @@
     ;; Useful for debugging, just prints a message
     (import "" "debug_msg" (func $debug_msg (param $value i32)))
 
+    ;; TODO: These are not defined, but instead during compilation, because otherwise we *must* link
+    ;;       them in, and the test suite will fail due to some of the runtime code being in
+    ;;      `stacks-core`
     ;;
+    ;; ;; Cost tracking globals
+    ;; (import "clarity" "cost-runtime" (global $cost-runtime (mut i64)))
+    ;; (import "clarity" "cost-read-count" (global $cost-read-count (mut i64)))
+    ;; (import "clarity" "cost-read-length" (global $cost-read-length (mut i64)))
+    ;; (import "clarity" "cost-write-count" (global $cost-write-count (mut i64)))
+    ;; (import "clarity" "cost-write-length" (global $cost-write-length (mut i64)))
+
     ;; Global definitions
     (global $stack-pointer (mut i32) (i32.const 0))
     (global $runtime-error-code (mut i32) (i32.const -1))
@@ -385,6 +395,11 @@
         ;; 5: buffer to integer expects a buffer length <= 16
         ;; 6: panic
         ;; 7: short return
+        ;; 100: runtime cost overrun
+        ;; 101: read count cost overrun
+        ;; 102: read length cost overrun
+        ;; 103: write count cost overrun
+        ;; 104: write length cost overrun
     (func $stdlib.runtime-error (param $error_code i32)
         (global.set $runtime-error-code (local.get $error_code))
 

--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -174,6 +174,7 @@ impl TestEnvironment {
                     self.version,
                     self.epoch,
                     analysis_db,
+                    false,
                 )
                 .map_err(|e| CheckErrors::Expects(format!("Compilation failure {:?}", e)))
             })

--- a/clar2wasm/src/wasm_utils.rs
+++ b/clar2wasm/src/wasm_utils.rs
@@ -19,6 +19,7 @@ use crate::error_mapping::{self, ErrorMap};
 use crate::initialize::ClarityWasmContext;
 use crate::linker::link_host_functions;
 use crate::wasm_generator::{GeneratorError, WasmGenerator};
+use crate::CostLinker;
 
 #[allow(non_snake_case)]
 pub enum MintAssetErrorCodes {
@@ -1273,6 +1274,9 @@ pub fn call_function<'a>(
 
     // Link in the host interface functions.
     link_host_functions(&mut linker)?;
+    linker
+        .define_cost_globals(&mut store)
+        .map_err(|e| Error::Wasm(WasmError::UnableToLoadModule(e)))?;
 
     let instance = linker
         .instantiate(&mut store, &module)

--- a/clar2wasm/tests/lib_tests.rs
+++ b/clar2wasm/tests/lib_tests.rs
@@ -74,6 +74,7 @@ macro_rules! test_multi_contract_init {
                             ClarityVersion::Clarity2,
                             StacksEpochId::latest(),
                             analysis_db,
+                            false,
                         )
                         .map_err(|_| CheckErrors::Expects("Compilation failure".to_string()))
                     })

--- a/clar2wasm/tests/oom-checker/main.rs
+++ b/clar2wasm/tests/oom-checker/main.rs
@@ -43,6 +43,7 @@ fn as_oom_check_snippet(
                 version,
                 epoch,
                 analysis_db,
+                false,
             )
             .map_err(|e| CheckErrors::Expects(format!("Compilation failure {e:?}")))
         })


### PR DESCRIPTION
This commit introduces the scaffold necessary to implement cost-tracking code generation.

The runtime gets access to three new items: the `AccessCostMeter` and `CostLinker` traits, and the `CostMeter` struct, which together allow for setting and retrieving the cost limits when running a module. The runtime also gets a choice of whether to compile Clarity with or without the cost tracking code.

The binaries - `clar2wasm` and `crosscheck` - can now receive a new `--cost-tracking` flag, to optionally generate cost tracking code.

To facilitate further implementation, implementers of `SimpleWord` and `ComplexWord` are extended with the `SimpleWordCharge` and `ComplexWordCharge` traits, respectively. These allow the implementer to simply call `fn charge(n: Scalar)` on the word, to generate the appropriate cost-tracking code for that word. The scaling factor `n` is word-dependant, and may be either a constant 32-bit integer or a `LocalId` which resolves into a 32-bit integer.

See-also: #616