### PR TITLE
Chore: clippy 1.86 fixes

### DIFF
--- a/clar2wasm/src/deserialize.rs
+++ b/clar2wasm/src/deserialize.rs
@@ -1043,7 +1043,7 @@ impl WasmGenerator {
 
         // bitset which will indicate if a field was defined or not
         let result_len = tm.len();
-        let bitset: Vec<LocalId> = (0..(result_len + 31) / 32)
+        let bitset: Vec<LocalId> = (0..result_len.div_ceil(32))
             .map(|_| self.module.locals.add(ValType::I32))
             .collect();
 

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -640,9 +640,9 @@ impl WasmGenerator {
     /// # Arguments
     ///
     /// * `builder` - A mutable reference to the `InstrSeqBuilder`, used to construct
-    ///               the WebAssembly instruction sequence.
+    ///   the WebAssembly instruction sequence.
     /// * `expr` - A reference to the `SymbolicExpression` representing the expression
-    ///            that triggered the early return.
+    ///   that triggered the early return.
     /// * `runtime_error` - The `ErrorMap` variant indicating the type of runtime error.
     ///
     /// # Returns

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -591,7 +591,7 @@ fn prop_buff_to_uint_be() {
         PropInt::new({
             let mut b = b.to_vec();
             let offset = 16 - b.len();
-            b.extend(std::iter::repeat(0).take(offset));
+            b.extend(std::iter::repeat_n(0, offset));
             b.rotate_right(offset);
             u128::from_be_bytes(b.try_into().unwrap())
         })
@@ -603,7 +603,7 @@ fn prop_buff_to_uint_le() {
     test_buff_to_uint("stdlib.buff-to-uint-le", 1500, |b| {
         PropInt::new({
             let mut b = b.to_vec();
-            b.extend(std::iter::repeat(0).take(16 - b.len()));
+            b.extend(std::iter::repeat_n(0, 16 - b.len()));
             u128::from_le_bytes(b.try_into().unwrap())
         })
     })


### PR DESCRIPTION
There are a few new Clippy lints triggered with the new version of Rust.