### PR TITLE
Add `Word` trait

### DIFF
--- a/clar2wasm/src/words/arithmetic.rs
+++ b/clar2wasm/src/words/arithmetic.rs
@@ -2,7 +2,7 @@ use clarity::vm::types::TypeSignature;
 use clarity::vm::ClarityName;
 use walrus::ValType;
 
-use super::SimpleWord;
+use super::{SimpleWord, Word};
 use crate::error_mapping::ErrorMap;
 use crate::wasm_generator::{GeneratorError, WasmGenerator};
 
@@ -32,11 +32,13 @@ fn simple_typed_one_call(
 #[derive(Debug)]
 pub struct Add;
 
-impl SimpleWord for Add {
+impl Word for Add {
     fn name(&self) -> ClarityName {
         "+".into()
     }
+}
 
+impl SimpleWord for Add {
     fn visit(
         &self,
         generator: &mut WasmGenerator,
@@ -64,11 +66,13 @@ impl SimpleWord for Add {
 #[derive(Debug)]
 pub struct Sub;
 
-impl SimpleWord for Sub {
+impl Word for Sub {
     fn name(&self) -> ClarityName {
         "-".into()
     }
+}
 
+impl SimpleWord for Sub {
     fn visit(
         &self,
         generator: &mut WasmGenerator,
@@ -120,11 +124,13 @@ impl SimpleWord for Sub {
 #[derive(Debug)]
 pub struct Mul;
 
-impl SimpleWord for Mul {
+impl Word for Mul {
     fn name(&self) -> ClarityName {
         "*".into()
     }
+}
 
+impl SimpleWord for Mul {
     fn visit(
         &self,
         generator: &mut WasmGenerator,
@@ -152,11 +158,13 @@ impl SimpleWord for Mul {
 #[derive(Debug)]
 pub struct Div;
 
-impl SimpleWord for Div {
+impl Word for Div {
     fn name(&self) -> ClarityName {
         "/".into()
     }
+}
 
+impl SimpleWord for Div {
     fn visit(
         &self,
         generator: &mut WasmGenerator,
@@ -184,11 +192,13 @@ impl SimpleWord for Div {
 #[derive(Debug)]
 pub struct Modulo;
 
-impl SimpleWord for Modulo {
+impl Word for Modulo {
     fn name(&self) -> ClarityName {
         "mod".into()
     }
+}
 
+impl SimpleWord for Modulo {
     fn visit(
         &self,
         generator: &mut WasmGenerator,
@@ -203,11 +213,13 @@ impl SimpleWord for Modulo {
 #[derive(Debug)]
 pub struct Log2;
 
-impl SimpleWord for Log2 {
+impl Word for Log2 {
     fn name(&self) -> ClarityName {
         "log2".into()
     }
+}
 
+impl SimpleWord for Log2 {
     fn visit<'b>(
         &self,
         generator: &mut WasmGenerator,
@@ -222,11 +234,13 @@ impl SimpleWord for Log2 {
 #[derive(Debug)]
 pub struct Power;
 
-impl SimpleWord for Power {
+impl Word for Power {
     fn name(&self) -> ClarityName {
         "pow".into()
     }
+}
 
+impl SimpleWord for Power {
     fn visit(
         &self,
         generator: &mut WasmGenerator,
@@ -241,11 +255,13 @@ impl SimpleWord for Power {
 #[derive(Debug)]
 pub struct Sqrti;
 
-impl SimpleWord for Sqrti {
+impl Word for Sqrti {
     fn name(&self) -> ClarityName {
         "sqrti".into()
     }
+}
 
+impl SimpleWord for Sqrti {
     fn visit(
         &self,
         generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/bindings.rs
+++ b/clar2wasm/src/words/bindings.rs
@@ -3,16 +3,18 @@ use clarity::vm::{ClarityName, SymbolicExpression};
 use crate::check_args;
 use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
-use crate::words::ComplexWord;
+use crate::words::{ComplexWord, Word};
 
 #[derive(Debug)]
 pub struct Let;
 
-impl ComplexWord for Let {
+impl Word for Let {
     fn name(&self) -> ClarityName {
         "let".into()
     }
+}
 
+impl ComplexWord for Let {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/bitwise.rs
+++ b/clar2wasm/src/words/bitwise.rs
@@ -2,17 +2,19 @@ use clarity::vm::types::TypeSignature;
 use clarity::vm::ClarityName;
 use walrus::InstrSeqBuilder;
 
-use super::SimpleWord;
+use super::{SimpleWord, Word};
 use crate::wasm_generator::{GeneratorError, WasmGenerator};
 
 #[derive(Debug)]
 pub struct BitwiseNot;
 
-impl SimpleWord for BitwiseNot {
+impl Word for BitwiseNot {
     fn name(&self) -> ClarityName {
         "bit-not".into()
     }
+}
 
+impl SimpleWord for BitwiseNot {
     fn visit(
         &self,
         generator: &mut WasmGenerator,
@@ -45,11 +47,13 @@ fn traverse_bitwise(
 #[derive(Debug)]
 pub struct BitwiseOr;
 
-impl SimpleWord for BitwiseOr {
+impl Word for BitwiseOr {
     fn name(&self) -> ClarityName {
         "bit-or".into()
     }
+}
 
+impl SimpleWord for BitwiseOr {
     fn visit(
         &self,
         generator: &mut WasmGenerator,
@@ -64,11 +68,13 @@ impl SimpleWord for BitwiseOr {
 #[derive(Debug)]
 pub struct BitwiseAnd;
 
-impl SimpleWord for BitwiseAnd {
+impl Word for BitwiseAnd {
     fn name(&self) -> ClarityName {
         "bit-and".into()
     }
+}
 
+impl SimpleWord for BitwiseAnd {
     fn visit(
         &self,
         generator: &mut WasmGenerator,
@@ -83,11 +89,13 @@ impl SimpleWord for BitwiseAnd {
 #[derive(Debug)]
 pub struct BitwiseXor;
 
-impl SimpleWord for BitwiseXor {
+impl Word for BitwiseXor {
     fn name(&self) -> ClarityName {
         "bit-xor".into()
     }
+}
 
+impl SimpleWord for BitwiseXor {
     fn visit(
         &self,
         generator: &mut WasmGenerator,
@@ -102,11 +110,13 @@ impl SimpleWord for BitwiseXor {
 #[derive(Debug)]
 pub struct BitwiseLShift;
 
-impl SimpleWord for BitwiseLShift {
+impl Word for BitwiseLShift {
     fn name(&self) -> ClarityName {
         "bit-shift-left".into()
     }
+}
 
+impl SimpleWord for BitwiseLShift {
     fn visit(
         &self,
         generator: &mut WasmGenerator,
@@ -123,11 +133,13 @@ impl SimpleWord for BitwiseLShift {
 #[derive(Debug)]
 pub struct BitwiseRShift;
 
-impl SimpleWord for BitwiseRShift {
+impl Word for BitwiseRShift {
     fn name(&self) -> ClarityName {
         "bit-shift-right".into()
     }
+}
 
+impl SimpleWord for BitwiseRShift {
     fn visit(
         &self,
         generator: &mut WasmGenerator,
@@ -156,11 +168,13 @@ impl SimpleWord for BitwiseRShift {
 #[derive(Debug)]
 pub struct Xor;
 
-impl SimpleWord for Xor {
+impl Word for Xor {
     fn name(&self) -> ClarityName {
         "xor".into()
     }
+}
 
+impl SimpleWord for Xor {
     fn visit(
         &self,
         generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/blockinfo.rs
+++ b/clar2wasm/src/words/blockinfo.rs
@@ -1,6 +1,6 @@
 use clarity::vm::{ClarityName, SymbolicExpression};
 
-use super::ComplexWord;
+use super::{ComplexWord, Word};
 use crate::check_args;
 use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
@@ -8,11 +8,13 @@ use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
 #[derive(Debug)]
 pub struct GetBlockInfo;
 
-impl ComplexWord for GetBlockInfo {
+impl Word for GetBlockInfo {
     fn name(&self) -> ClarityName {
         "get-block-info?".into()
     }
+}
 
+impl ComplexWord for GetBlockInfo {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -93,11 +95,13 @@ impl ComplexWord for GetBlockInfo {
 #[derive(Debug)]
 pub struct GetBurnBlockInfo;
 
-impl ComplexWord for GetBurnBlockInfo {
+impl Word for GetBurnBlockInfo {
     fn name(&self) -> ClarityName {
         "get-burn-block-info?".into()
     }
+}
 
+impl ComplexWord for GetBurnBlockInfo {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -158,11 +162,13 @@ impl ComplexWord for GetBurnBlockInfo {
 #[derive(Debug)]
 pub struct AtBlock;
 
-impl ComplexWord for AtBlock {
+impl Word for AtBlock {
     fn name(&self) -> ClarityName {
         "at-block".into()
     }
+}
 
+impl ComplexWord for AtBlock {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -194,11 +200,13 @@ impl ComplexWord for AtBlock {
 #[derive(Debug)]
 pub struct GetStacksBlockInfo;
 
-impl ComplexWord for GetStacksBlockInfo {
+impl Word for GetStacksBlockInfo {
     fn name(&self) -> ClarityName {
         "get-stacks-block-info?".into()
     }
+}
 
+impl ComplexWord for GetStacksBlockInfo {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -262,11 +270,13 @@ impl ComplexWord for GetStacksBlockInfo {
 #[derive(Debug)]
 pub struct GetTenureInfo;
 
-impl ComplexWord for GetTenureInfo {
+impl Word for GetTenureInfo {
     fn name(&self) -> ClarityName {
         "get-tenure-info?".into()
     }
+}
 
+impl ComplexWord for GetTenureInfo {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/buff_to_integer.rs
+++ b/clar2wasm/src/words/buff_to_integer.rs
@@ -1,7 +1,7 @@
 use clarity::vm::types::TypeSignature;
 
 use crate::wasm_generator::{GeneratorError, WasmGenerator};
-use crate::words::SimpleWord;
+use crate::words::{SimpleWord, Word};
 
 fn traverse_buffer_to_integer(
     name: &str,
@@ -20,11 +20,13 @@ fn traverse_buffer_to_integer(
 #[derive(Debug)]
 pub struct BuffToUintBe;
 
-impl SimpleWord for BuffToUintBe {
+impl Word for BuffToUintBe {
     fn name(&self) -> clarity::vm::ClarityName {
         "buff-to-uint-be".into()
     }
+}
 
+impl SimpleWord for BuffToUintBe {
     fn visit(
         &self,
         generator: &mut crate::wasm_generator::WasmGenerator,
@@ -39,11 +41,13 @@ impl SimpleWord for BuffToUintBe {
 #[derive(Debug)]
 pub struct BuffToIntBe;
 
-impl SimpleWord for BuffToIntBe {
+impl Word for BuffToIntBe {
     fn name(&self) -> clarity::vm::ClarityName {
         "buff-to-int-be".into()
     }
+}
 
+impl SimpleWord for BuffToIntBe {
     fn visit(
         &self,
         generator: &mut crate::wasm_generator::WasmGenerator,
@@ -60,11 +64,13 @@ impl SimpleWord for BuffToIntBe {
 #[derive(Debug)]
 pub struct BuffToUintLe;
 
-impl SimpleWord for BuffToUintLe {
+impl Word for BuffToUintLe {
     fn name(&self) -> clarity::vm::ClarityName {
         "buff-to-uint-le".into()
     }
+}
 
+impl SimpleWord for BuffToUintLe {
     fn visit(
         &self,
         generator: &mut crate::wasm_generator::WasmGenerator,
@@ -79,11 +85,13 @@ impl SimpleWord for BuffToUintLe {
 #[derive(Debug)]
 pub struct BuffToIntLe;
 
-impl SimpleWord for BuffToIntLe {
+impl Word for BuffToIntLe {
     fn name(&self) -> clarity::vm::ClarityName {
         "buff-to-int-le".into()
     }
+}
 
+impl SimpleWord for BuffToIntLe {
     fn visit(
         &self,
         generator: &mut crate::wasm_generator::WasmGenerator,

--- a/clar2wasm/src/words/comparison.rs
+++ b/clar2wasm/src/words/comparison.rs
@@ -1,7 +1,7 @@
 use clarity::vm::types::{SequenceSubtype, StringSubtype, TypeSignature};
 use clarity::vm::ClarityName;
 
-use super::SimpleWord;
+use super::{SimpleWord, Word};
 use crate::wasm_generator::{GeneratorError, WasmGenerator};
 
 fn traverse_comparison(
@@ -48,11 +48,13 @@ fn traverse_comparison(
 #[derive(Debug)]
 pub struct CmpLess;
 
-impl SimpleWord for CmpLess {
+impl Word for CmpLess {
     fn name(&self) -> ClarityName {
         "<".into()
     }
+}
 
+impl SimpleWord for CmpLess {
     fn visit(
         &self,
         generator: &mut WasmGenerator,
@@ -67,11 +69,13 @@ impl SimpleWord for CmpLess {
 #[derive(Debug)]
 pub struct CmpLeq;
 
-impl SimpleWord for CmpLeq {
+impl Word for CmpLeq {
     fn name(&self) -> ClarityName {
         "<=".into()
     }
+}
 
+impl SimpleWord for CmpLeq {
     fn visit(
         &self,
         generator: &mut WasmGenerator,
@@ -86,11 +90,13 @@ impl SimpleWord for CmpLeq {
 #[derive(Debug)]
 pub struct CmpGreater;
 
-impl SimpleWord for CmpGreater {
+impl Word for CmpGreater {
     fn name(&self) -> ClarityName {
         ">".into()
     }
+}
 
+impl SimpleWord for CmpGreater {
     fn visit(
         &self,
         generator: &mut WasmGenerator,
@@ -105,11 +111,13 @@ impl SimpleWord for CmpGreater {
 #[derive(Debug)]
 pub struct CmpGeq;
 
-impl SimpleWord for CmpGeq {
+impl Word for CmpGeq {
     fn name(&self) -> ClarityName {
         ">=".into()
     }
+}
 
+impl SimpleWord for CmpGeq {
     fn visit(
         &self,
         generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/conditionals.rs
+++ b/clar2wasm/src/words/conditionals.rs
@@ -3,7 +3,7 @@ use clarity::vm::{ClarityName, SymbolicExpression};
 use walrus::ir::{self, InstrSeqType, Loop};
 use walrus::ValType;
 
-use super::{ComplexWord, SimpleWord};
+use super::{ComplexWord, SimpleWord, Word};
 use crate::error_mapping::ErrorMap;
 use crate::wasm_generator::{
     add_placeholder_for_clarity_type, clar2wasm_ty, drop_value, ArgumentsExt, GeneratorError,
@@ -15,11 +15,13 @@ use crate::{check_args, words};
 #[derive(Debug)]
 pub struct If;
 
-impl ComplexWord for If {
+impl Word for If {
     fn name(&self) -> ClarityName {
         "if".into()
     }
+}
 
+impl ComplexWord for If {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -58,11 +60,13 @@ impl ComplexWord for If {
 #[derive(Debug)]
 pub struct Match;
 
-impl ComplexWord for Match {
+impl Word for Match {
     fn name(&self) -> ClarityName {
         "match".into()
     }
+}
 
+impl ComplexWord for Match {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -181,11 +185,13 @@ impl ComplexWord for Match {
 #[derive(Debug)]
 pub struct Filter;
 
-impl ComplexWord for Filter {
+impl Word for Filter {
     fn name(&self) -> ClarityName {
         "filter".into()
     }
+}
 
+impl ComplexWord for Filter {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -406,11 +412,13 @@ fn traverse_short_circuiting_list(
 #[derive(Debug)]
 pub struct And;
 
-impl ComplexWord for And {
+impl Word for And {
     fn name(&self) -> ClarityName {
         "and".into()
     }
+}
 
+impl ComplexWord for And {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -433,11 +441,13 @@ impl ComplexWord for And {
 #[derive(Debug)]
 pub struct SimpleAnd;
 
-impl SimpleWord for SimpleAnd {
+impl Word for SimpleAnd {
     fn name(&self) -> ClarityName {
         "and".into()
     }
+}
 
+impl SimpleWord for SimpleAnd {
     fn visit(
         &self,
         _generator: &mut WasmGenerator,
@@ -455,11 +465,13 @@ impl SimpleWord for SimpleAnd {
 #[derive(Debug)]
 pub struct Or;
 
-impl ComplexWord for Or {
+impl Word for Or {
     fn name(&self) -> ClarityName {
         "or".into()
     }
+}
 
+impl ComplexWord for Or {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -482,11 +494,13 @@ impl ComplexWord for Or {
 #[derive(Debug)]
 pub struct SimpleOr;
 
-impl SimpleWord for SimpleOr {
+impl Word for SimpleOr {
     fn name(&self) -> ClarityName {
         "or".into()
     }
+}
 
+impl SimpleWord for SimpleOr {
     fn visit(
         &self,
         _generator: &mut WasmGenerator,
@@ -504,11 +518,13 @@ impl SimpleWord for SimpleOr {
 #[derive(Debug)]
 pub struct Unwrap;
 
-impl ComplexWord for Unwrap {
+impl Word for Unwrap {
     fn name(&self) -> ClarityName {
         "unwrap!".into()
     }
+}
 
+impl ComplexWord for Unwrap {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -587,11 +603,13 @@ impl ComplexWord for Unwrap {
 #[derive(Debug)]
 pub struct UnwrapErr;
 
-impl ComplexWord for UnwrapErr {
+impl Word for UnwrapErr {
     fn name(&self) -> ClarityName {
         "unwrap-err!".into()
     }
+}
 
+impl ComplexWord for UnwrapErr {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -678,11 +696,13 @@ impl ComplexWord for UnwrapErr {
 #[derive(Debug)]
 pub struct Asserts;
 
-impl ComplexWord for Asserts {
+impl Word for Asserts {
     fn name(&self) -> ClarityName {
         "asserts!".into()
     }
+}
 
+impl ComplexWord for Asserts {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -755,11 +775,13 @@ impl ComplexWord for Asserts {
 #[derive(Debug)]
 pub struct Try;
 
-impl ComplexWord for Try {
+impl Word for Try {
     fn name(&self) -> ClarityName {
         "try!".into()
     }
+}
 
+impl ComplexWord for Try {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/consensus_buff.rs
+++ b/clar2wasm/src/words/consensus_buff.rs
@@ -1,7 +1,7 @@
 use clarity::vm::types::{TypeSignature, MAX_VALUE_SIZE};
 use walrus::ir::{BinaryOp, InstrSeqType};
 
-use super::ComplexWord;
+use super::{ComplexWord, Word};
 use crate::check_args;
 use crate::wasm_generator::{
     add_placeholder_for_clarity_type, clar2wasm_ty, drop_value, ArgumentsExt, GeneratorError,
@@ -12,11 +12,13 @@ use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
 #[derive(Debug)]
 pub struct ToConsensusBuff;
 
-impl ComplexWord for ToConsensusBuff {
+impl Word for ToConsensusBuff {
     fn name(&self) -> clarity::vm::ClarityName {
         "to-consensus-buff?".into()
     }
+}
 
+impl ComplexWord for ToConsensusBuff {
     fn traverse(
         &self,
         generator: &mut crate::wasm_generator::WasmGenerator,
@@ -89,11 +91,13 @@ impl ComplexWord for ToConsensusBuff {
 #[derive(Debug)]
 pub struct FromConsensusBuff;
 
-impl ComplexWord for FromConsensusBuff {
+impl Word for FromConsensusBuff {
     fn name(&self) -> clarity::vm::ClarityName {
         "from-consensus-buff?".into()
     }
+}
 
+impl ComplexWord for FromConsensusBuff {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/constants.rs
+++ b/clar2wasm/src/words/constants.rs
@@ -1,7 +1,7 @@
 use clarity::vm::{ClarityName, SymbolicExpression, SymbolicExpressionType};
 use walrus::{ActiveData, DataKind, ValType};
 
-use super::ComplexWord;
+use super::{ComplexWord, Word};
 use crate::check_args;
 use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 use crate::wasm_utils::{
@@ -11,11 +11,13 @@ use crate::wasm_utils::{
 #[derive(Debug)]
 pub struct DefineConstant;
 
-impl ComplexWord for DefineConstant {
+impl Word for DefineConstant {
     fn name(&self) -> ClarityName {
         "define-constant".into()
     }
+}
 
+impl ComplexWord for DefineConstant {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/contract.rs
+++ b/clar2wasm/src/words/contract.rs
@@ -5,7 +5,7 @@ use clarity::vm::{ClarityName, SymbolicExpression, SymbolicExpressionType, Value
 use walrus::ir::BinaryOp;
 use walrus::ValType;
 
-use super::ComplexWord;
+use super::{ComplexWord, Word};
 use crate::check_args;
 use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
@@ -13,11 +13,13 @@ use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
 #[derive(Debug)]
 pub struct AsContract;
 
-impl ComplexWord for AsContract {
+impl Word for AsContract {
     fn name(&self) -> ClarityName {
         "as-contract".into()
     }
+}
 
+impl ComplexWord for AsContract {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -45,11 +47,13 @@ impl ComplexWord for AsContract {
 #[derive(Debug)]
 pub struct ContractCall;
 
-impl ComplexWord for ContractCall {
+impl Word for ContractCall {
     fn name(&self) -> ClarityName {
         "contract-call?".into()
     }
+}
 
+impl ComplexWord for ContractCall {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/control_flow.rs
+++ b/clar2wasm/src/words/control_flow.rs
@@ -2,7 +2,7 @@ use clarity::vm::types::TypeSignature;
 use clarity::vm::{ClarityName, SymbolicExpression};
 use walrus::ir::{IfElse, UnaryOp};
 
-use super::ComplexWord;
+use super::{ComplexWord, Word};
 use crate::check_args;
 use crate::error_mapping::ErrorMap;
 use crate::wasm_generator::{drop_value, ArgumentsExt, GeneratorError, WasmGenerator};
@@ -11,11 +11,13 @@ use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
 #[derive(Debug)]
 pub struct Begin;
 
-impl ComplexWord for Begin {
+impl Word for Begin {
     fn name(&self) -> ClarityName {
         "begin".into()
     }
+}
 
+impl ComplexWord for Begin {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -47,11 +49,13 @@ impl ComplexWord for Begin {
 #[derive(Debug)]
 pub struct UnwrapPanic;
 
-impl ComplexWord for UnwrapPanic {
+impl Word for UnwrapPanic {
     fn name(&self) -> ClarityName {
         "unwrap-panic".into()
     }
+}
 
+impl ComplexWord for UnwrapPanic {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -185,11 +189,13 @@ impl ComplexWord for UnwrapPanic {
 #[derive(Debug)]
 pub struct UnwrapErrPanic;
 
-impl ComplexWord for UnwrapErrPanic {
+impl Word for UnwrapErrPanic {
     fn name(&self) -> ClarityName {
         "unwrap-err-panic".into()
     }
+}
 
+impl ComplexWord for UnwrapErrPanic {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/conversion.rs
+++ b/clar2wasm/src/words/conversion.rs
@@ -1,16 +1,18 @@
 use clarity::vm::types::{SequenceSubtype, StringSubtype, TypeSignature};
 
-use super::SimpleWord;
+use super::{SimpleWord, Word};
 use crate::wasm_generator::GeneratorError;
 
 #[derive(Debug)]
 pub struct StringToInt;
 
-impl SimpleWord for StringToInt {
+impl Word for StringToInt {
     fn name(&self) -> clarity::vm::ClarityName {
         "string-to-int?".into()
     }
+}
 
+impl SimpleWord for StringToInt {
     fn visit(
         &self,
         generator: &mut crate::wasm_generator::WasmGenerator,
@@ -42,11 +44,13 @@ impl SimpleWord for StringToInt {
 #[derive(Debug)]
 pub struct StringToUint;
 
-impl SimpleWord for StringToUint {
+impl Word for StringToUint {
     fn name(&self) -> clarity::vm::ClarityName {
         "string-to-uint?".into()
     }
+}
 
+impl SimpleWord for StringToUint {
     fn visit(
         &self,
         generator: &mut crate::wasm_generator::WasmGenerator,
@@ -79,11 +83,13 @@ impl SimpleWord for StringToUint {
 #[derive(Debug)]
 pub struct IntToAscii;
 
-impl SimpleWord for IntToAscii {
+impl Word for IntToAscii {
     fn name(&self) -> clarity::vm::ClarityName {
         "int-to-ascii".into()
     }
+}
 
+impl SimpleWord for IntToAscii {
     fn visit(
         &self,
         generator: &mut crate::wasm_generator::WasmGenerator,
@@ -116,11 +122,13 @@ impl SimpleWord for IntToAscii {
 #[derive(Debug)]
 pub struct IntToUtf8;
 
-impl SimpleWord for IntToUtf8 {
+impl Word for IntToUtf8 {
     fn name(&self) -> clarity::vm::ClarityName {
         "int-to-utf8".into()
     }
+}
 
+impl SimpleWord for IntToUtf8 {
     fn visit(
         &self,
         generator: &mut crate::wasm_generator::WasmGenerator,

--- a/clar2wasm/src/words/data_vars.rs
+++ b/clar2wasm/src/words/data_vars.rs
@@ -2,7 +2,7 @@ use clarity::vm::types::TypeSignature;
 use clarity::vm::{ClarityName, SymbolicExpression};
 use walrus::ValType;
 
-use super::ComplexWord;
+use super::{ComplexWord, Word};
 use crate::check_args;
 use crate::wasm_generator::{ArgumentsExt, GeneratorError, LiteralMemoryEntry, WasmGenerator};
 use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
@@ -10,11 +10,13 @@ use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
 #[derive(Debug)]
 pub struct DefineDataVar;
 
-impl ComplexWord for DefineDataVar {
+impl Word for DefineDataVar {
     fn name(&self) -> ClarityName {
         "define-data-var".into()
     }
+}
 
+impl ComplexWord for DefineDataVar {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -100,11 +102,13 @@ impl ComplexWord for DefineDataVar {
 #[derive(Debug)]
 pub struct SetDataVar;
 
-impl ComplexWord for SetDataVar {
+impl Word for SetDataVar {
     fn name(&self) -> ClarityName {
         "var-set".into()
     }
+}
 
+impl ComplexWord for SetDataVar {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -173,11 +177,13 @@ impl ComplexWord for SetDataVar {
 #[derive(Debug)]
 pub struct GetDataVar;
 
-impl ComplexWord for GetDataVar {
+impl Word for GetDataVar {
     fn name(&self) -> ClarityName {
         "var-get".into()
     }
+}
 
+impl ComplexWord for GetDataVar {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/default_to.rs
+++ b/clar2wasm/src/words/default_to.rs
@@ -2,7 +2,7 @@ use clarity::vm::types::TypeSignature;
 use clarity::vm::{ClarityName, SymbolicExpression};
 use walrus::ir::InstrSeqType;
 
-use super::ComplexWord;
+use super::{ComplexWord, Word};
 use crate::check_args;
 use crate::wasm_generator::{
     clar2wasm_ty, drop_value, ArgumentsExt, GeneratorError, WasmGenerator,
@@ -12,11 +12,13 @@ use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
 #[derive(Debug)]
 pub struct DefaultTo;
 
-impl ComplexWord for DefaultTo {
+impl Word for DefaultTo {
     fn name(&self) -> ClarityName {
         "default-to".into()
     }
+}
 
+impl ComplexWord for DefaultTo {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/enums.rs
+++ b/clar2wasm/src/words/enums.rs
@@ -1,7 +1,7 @@
 use clarity::vm::types::TypeSignature;
 use clarity::vm::{ClarityName, SymbolicExpression};
 
-use super::ComplexWord;
+use super::{ComplexWord, Word};
 use crate::check_args;
 use crate::wasm_generator::{
     add_placeholder_for_type, clar2wasm_ty, ArgumentsExt, GeneratorError, WasmGenerator,
@@ -11,11 +11,13 @@ use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
 #[derive(Debug)]
 pub struct ClaritySome;
 
-impl ComplexWord for ClaritySome {
+impl Word for ClaritySome {
     fn name(&self) -> ClarityName {
         "some".into()
     }
+}
 
+impl ComplexWord for ClaritySome {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -48,11 +50,13 @@ impl ComplexWord for ClaritySome {
 #[derive(Debug)]
 pub struct ClarityOk;
 
-impl ComplexWord for ClarityOk {
+impl Word for ClarityOk {
     fn name(&self) -> ClarityName {
         "ok".into()
     }
+}
 
+impl ComplexWord for ClarityOk {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -95,11 +99,13 @@ impl ComplexWord for ClarityOk {
 #[derive(Debug)]
 pub struct ClarityErr;
 
-impl ComplexWord for ClarityErr {
+impl Word for ClarityErr {
     fn name(&self) -> ClarityName {
         "err".into()
     }
+}
 
+impl ComplexWord for ClarityErr {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -4,7 +4,7 @@ use clarity::vm::{ClarityName, SymbolicExpression};
 use walrus::ir::{BinaryOp, IfElse, InstrSeqType, Loop, UnaryOp};
 use walrus::{InstrSeqBuilder, LocalId, ValType};
 
-use super::ComplexWord;
+use super::{ComplexWord, Word};
 use crate::check_args;
 use crate::wasm_generator::{
     clar2wasm_ty, drop_value, ArgumentsExt, GeneratorError, SequenceElementType, WasmGenerator,
@@ -14,11 +14,13 @@ use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
 #[derive(Debug)]
 pub struct IsEq;
 
-impl ComplexWord for IsEq {
+impl Word for IsEq {
     fn name(&self) -> ClarityName {
         "is-eq".into()
     }
+}
 
+impl ComplexWord for IsEq {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -108,14 +110,16 @@ pub enum IndexOf {
     Alias,
 }
 
-impl ComplexWord for IndexOf {
+impl Word for IndexOf {
     fn name(&self) -> ClarityName {
         match self {
             IndexOf::Original => "index-of".into(),
             IndexOf::Alias => "index-of?".into(),
         }
     }
+}
 
+impl ComplexWord for IndexOf {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/functions.rs
+++ b/clar2wasm/src/words/functions.rs
@@ -1,7 +1,7 @@
 use clarity::vm::types::{ASCIIData, CharType};
 use clarity::vm::{ClarityName, SymbolicExpression};
 
-use super::ComplexWord;
+use super::{ComplexWord, Word};
 use crate::check_args;
 use crate::error_mapping::ErrorMap;
 use crate::wasm_generator::{
@@ -12,11 +12,13 @@ use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
 #[derive(Debug)]
 pub struct DefinePrivateFunction;
 
-impl ComplexWord for DefinePrivateFunction {
+impl Word for DefinePrivateFunction {
     fn name(&self) -> ClarityName {
         "define-private".into()
     }
+}
 
+impl ComplexWord for DefinePrivateFunction {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -48,11 +50,13 @@ impl ComplexWord for DefinePrivateFunction {
 #[derive(Debug)]
 pub struct DefineReadonlyFunction;
 
-impl ComplexWord for DefineReadonlyFunction {
+impl Word for DefineReadonlyFunction {
     fn name(&self) -> ClarityName {
         "define-read-only".into()
     }
+}
 
+impl ComplexWord for DefineReadonlyFunction {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -107,11 +111,13 @@ impl ComplexWord for DefineReadonlyFunction {
 #[derive(Debug)]
 pub struct DefinePublicFunction;
 
-impl ComplexWord for DefinePublicFunction {
+impl Word for DefinePublicFunction {
     fn name(&self) -> ClarityName {
         "define-public".into()
     }
+}
 
+impl ComplexWord for DefinePublicFunction {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/hashing.rs
+++ b/clar2wasm/src/words/hashing.rs
@@ -1,7 +1,7 @@
 use clarity::vm::types::{BufferLength, SequenceSubtype, TypeSignature, BUFF_32};
 use clarity::vm::ClarityName;
 
-use super::SimpleWord;
+use super::{SimpleWord, Word};
 use crate::wasm_generator::{GeneratorError, WasmGenerator};
 
 pub fn traverse_hash(
@@ -56,11 +56,13 @@ pub fn traverse_hash(
 #[derive(Debug)]
 pub struct Hash160;
 
-impl SimpleWord for Hash160 {
+impl Word for Hash160 {
     fn name(&self) -> ClarityName {
         "hash160".into()
     }
+}
 
+impl SimpleWord for Hash160 {
     fn visit(
         &self,
         generator: &mut WasmGenerator,
@@ -76,11 +78,13 @@ impl SimpleWord for Hash160 {
 #[derive(Debug)]
 pub struct Sha256;
 
-impl SimpleWord for Sha256 {
+impl Word for Sha256 {
     fn name(&self) -> ClarityName {
         "sha256".into()
     }
+}
 
+impl SimpleWord for Sha256 {
     fn visit(
         &self,
         generator: &mut WasmGenerator,
@@ -96,11 +100,13 @@ impl SimpleWord for Sha256 {
 #[derive(Debug)]
 pub struct Keccak256;
 
-impl SimpleWord for Keccak256 {
+impl Word for Keccak256 {
     fn name(&self) -> ClarityName {
         "keccak256".into()
     }
+}
 
+impl SimpleWord for Keccak256 {
     fn visit(
         &self,
         generator: &mut WasmGenerator,
@@ -151,11 +157,13 @@ impl SimpleWord for Keccak256 {
 #[derive(Debug)]
 pub struct Sha512;
 
-impl SimpleWord for Sha512 {
+impl Word for Sha512 {
     fn name(&self) -> ClarityName {
         "sha512".into()
     }
+}
 
+impl SimpleWord for Sha512 {
     fn visit(
         &self,
         generator: &mut WasmGenerator,
@@ -171,11 +179,13 @@ impl SimpleWord for Sha512 {
 #[derive(Debug)]
 pub struct Sha512_256;
 
-impl SimpleWord for Sha512_256 {
+impl Word for Sha512_256 {
     fn name(&self) -> ClarityName {
         "sha512/256".into()
     }
+}
 
+impl SimpleWord for Sha512_256 {
     fn visit(
         &self,
         generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/logical.rs
+++ b/clar2wasm/src/words/logical.rs
@@ -1,17 +1,19 @@
 use clarity::vm::types::TypeSignature;
 use clarity::vm::ClarityName;
 
-use super::SimpleWord;
+use super::{SimpleWord, Word};
 use crate::wasm_generator::{GeneratorError, WasmGenerator};
 
 #[derive(Debug)]
 pub struct Not;
 
-impl SimpleWord for Not {
+impl Word for Not {
     fn name(&self) -> ClarityName {
         "not".into()
     }
+}
 
+impl SimpleWord for Not {
     fn visit(
         &self,
         generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/maps.rs
+++ b/clar2wasm/src/words/maps.rs
@@ -1,7 +1,7 @@
 use clarity::vm::types::TypeSignature;
 use clarity::vm::{ClarityName, SymbolicExpression};
 
-use super::ComplexWord;
+use super::{ComplexWord, Word};
 use crate::check_args;
 use crate::wasm_generator::{ArgumentsExt, GeneratorError, LiteralMemoryEntry, WasmGenerator};
 use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
@@ -9,11 +9,13 @@ use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
 #[derive(Debug)]
 pub struct MapDefinition;
 
-impl ComplexWord for MapDefinition {
+impl Word for MapDefinition {
     fn name(&self) -> ClarityName {
         "define-map".into()
     }
+}
 
+impl ComplexWord for MapDefinition {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -71,11 +73,13 @@ impl ComplexWord for MapDefinition {
 #[derive(Debug)]
 pub struct MapGet;
 
-impl ComplexWord for MapGet {
+impl Word for MapGet {
     fn name(&self) -> ClarityName {
         "map-get?".into()
     }
+}
 
+impl ComplexWord for MapGet {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -150,11 +154,13 @@ impl ComplexWord for MapGet {
 #[derive(Debug)]
 pub struct MapSet;
 
-impl ComplexWord for MapSet {
+impl Word for MapSet {
     fn name(&self) -> ClarityName {
         "map-set".into()
     }
+}
 
+impl ComplexWord for MapSet {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -232,11 +238,13 @@ impl ComplexWord for MapSet {
 #[derive(Debug)]
 pub struct MapInsert;
 
-impl ComplexWord for MapInsert {
+impl Word for MapInsert {
     fn name(&self) -> ClarityName {
         "map-insert".into()
     }
+}
 
+impl ComplexWord for MapInsert {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -314,11 +322,13 @@ impl ComplexWord for MapInsert {
 #[derive(Debug)]
 pub struct MapDelete;
 
-impl ComplexWord for MapDelete {
+impl Word for MapDelete {
     fn name(&self) -> ClarityName {
         "map-delete".into()
     }
+}
 
+impl ComplexWord for MapDelete {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/mod.rs
+++ b/clar2wasm/src/words/mod.rs
@@ -39,9 +39,11 @@ pub mod tokens;
 pub mod traits;
 pub mod tuples;
 
-pub trait ComplexWord: Sync + core::fmt::Debug {
+pub trait Word: Sync + core::fmt::Debug {
     fn name(&self) -> ClarityName;
+}
 
+pub trait ComplexWord: Word {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -135,9 +137,7 @@ pub(crate) static COMPLEX_WORDS: &[&'static dyn ComplexWord] = &[
     &tuples::TupleMerge,
 ];
 
-pub trait SimpleWord: Sync + core::fmt::Debug {
-    fn name(&self) -> ClarityName;
-
+pub trait SimpleWord: Word {
     fn visit(
         &self,
         generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/noop.rs
+++ b/clar2wasm/src/words/noop.rs
@@ -1,7 +1,7 @@
 use clarity::vm::types::TypeSignature;
 use clarity::vm::{ClarityName, SymbolicExpression};
 
-use super::{ComplexWord, SimpleWord};
+use super::{ComplexWord, SimpleWord, Word};
 use crate::check_args;
 use crate::wasm_generator::{GeneratorError, WasmGenerator};
 use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
@@ -13,11 +13,13 @@ use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
 #[derive(Debug)]
 pub struct ToInt;
 
-impl SimpleWord for ToInt {
+impl Word for ToInt {
     fn name(&self) -> ClarityName {
         "to-int".into()
     }
+}
 
+impl SimpleWord for ToInt {
     fn visit(
         &self,
         generator: &mut WasmGenerator,
@@ -35,11 +37,13 @@ impl SimpleWord for ToInt {
 #[derive(Debug)]
 pub struct ToUint;
 
-impl SimpleWord for ToUint {
+impl Word for ToUint {
     fn name(&self) -> ClarityName {
         "to-uint".into()
     }
+}
 
+impl SimpleWord for ToUint {
     fn visit(
         &self,
         generator: &mut WasmGenerator,
@@ -57,11 +61,13 @@ impl SimpleWord for ToUint {
 #[derive(Debug)]
 pub struct ContractOf;
 
-impl ComplexWord for ContractOf {
+impl Word for ContractOf {
     fn name(&self) -> ClarityName {
         "contract-of".into()
     }
+}
 
+impl ComplexWord for ContractOf {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/options.rs
+++ b/clar2wasm/src/words/options.rs
@@ -2,7 +2,7 @@ use clarity::vm::types::TypeSignature;
 use clarity::vm::{ClarityName, SymbolicExpression};
 use walrus::ir::BinaryOp;
 
-use super::ComplexWord;
+use super::{ComplexWord, Word};
 use crate::check_args;
 use crate::wasm_generator::{drop_value, ArgumentsExt, GeneratorError, WasmGenerator};
 use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
@@ -40,11 +40,13 @@ pub fn traverse_optional(
 #[derive(Debug)]
 pub struct IsSome;
 
-impl ComplexWord for IsSome {
+impl Word for IsSome {
     fn name(&self) -> ClarityName {
         "is-some".into()
     }
+}
 
+impl ComplexWord for IsSome {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -61,11 +63,13 @@ impl ComplexWord for IsSome {
 #[derive(Debug)]
 pub struct IsNone;
 
-impl ComplexWord for IsNone {
+impl Word for IsNone {
     fn name(&self) -> ClarityName {
         "is-none".into()
     }
+}
 
+impl ComplexWord for IsNone {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/principal.rs
+++ b/clar2wasm/src/words/principal.rs
@@ -9,7 +9,7 @@ use clarity::{
 use walrus::ir::{BinaryOp, ExtendedLoad, InstrSeqType, LoadKind, MemArg};
 use walrus::{LocalId, ValType};
 
-use super::{ComplexWord, SimpleWord};
+use super::{ComplexWord, SimpleWord, Word};
 use crate::check_args;
 use crate::wasm_generator::{
     add_placeholder_for_clarity_type, clar2wasm_ty, ArgumentsExt, GeneratorError, WasmGenerator,
@@ -19,11 +19,13 @@ use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
 #[derive(Debug)]
 pub struct IsStandard;
 
-impl SimpleWord for IsStandard {
+impl Word for IsStandard {
     fn name(&self) -> ClarityName {
         "is-standard".into()
     }
+}
 
+impl SimpleWord for IsStandard {
     fn visit(
         &self,
         generator: &mut WasmGenerator,
@@ -88,11 +90,13 @@ impl SimpleWord for IsStandard {
 #[derive(Debug)]
 pub struct Construct;
 
-impl ComplexWord for Construct {
+impl Word for Construct {
     fn name(&self) -> ClarityName {
         "principal-construct?".into()
     }
+}
 
+impl ComplexWord for Construct {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -192,11 +196,13 @@ fn generate_tuple(
     builder.i32_const(1);
 }
 
-impl SimpleWord for Destruct {
+impl Word for Destruct {
     fn name(&self) -> ClarityName {
         "principal-destruct?".into()
     }
+}
 
+impl SimpleWord for Destruct {
     fn visit(
         &self,
         generator: &mut WasmGenerator,
@@ -277,11 +283,13 @@ impl SimpleWord for Destruct {
 #[derive(Debug)]
 pub struct PrincipalOf;
 
-impl ComplexWord for PrincipalOf {
+impl Word for PrincipalOf {
     fn name(&self) -> ClarityName {
         "principal-of?".into()
     }
+}
 
+impl ComplexWord for PrincipalOf {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/print.rs
+++ b/clar2wasm/src/words/print.rs
@@ -1,7 +1,7 @@
 use clarity::vm::types::{ASCIIData, CharType};
 use clarity::vm::{ClarityName, SymbolicExpression};
 
-use super::ComplexWord;
+use super::{ComplexWord, Word};
 use crate::check_args;
 use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 use crate::wasm_utils::{check_argument_count, signature_from_string, ArgumentCountCheck};
@@ -9,11 +9,13 @@ use crate::wasm_utils::{check_argument_count, signature_from_string, ArgumentCou
 #[derive(Debug)]
 pub struct Print;
 
-impl ComplexWord for Print {
+impl Word for Print {
     fn name(&self) -> ClarityName {
         "print".into()
     }
+}
 
+impl ComplexWord for Print {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/responses.rs
+++ b/clar2wasm/src/words/responses.rs
@@ -2,10 +2,11 @@ use clarity::vm::types::TypeSignature;
 use clarity::vm::{ClarityName, SymbolicExpression};
 use walrus::ir::BinaryOp;
 
-use super::ComplexWord;
+use super::{ComplexWord, Word};
 use crate::check_args;
 use crate::wasm_generator::{drop_value, ArgumentsExt, GeneratorError, WasmGenerator};
 use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
+
 pub fn traverse_response(
     generator: &mut WasmGenerator,
     builder: &mut walrus::InstrSeqBuilder,
@@ -42,11 +43,13 @@ pub fn traverse_response(
 #[derive(Debug)]
 pub struct IsOk;
 
-impl ComplexWord for IsOk {
+impl Word for IsOk {
     fn name(&self) -> ClarityName {
         "is-ok".into()
     }
+}
 
+impl ComplexWord for IsOk {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -63,11 +66,13 @@ impl ComplexWord for IsOk {
 #[derive(Debug)]
 pub struct IsErr;
 
-impl ComplexWord for IsErr {
+impl Word for IsErr {
     fn name(&self) -> ClarityName {
         "is-err".into()
     }
+}
 
+impl ComplexWord for IsErr {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/secp256k1.rs
+++ b/clar2wasm/src/words/secp256k1.rs
@@ -1,6 +1,6 @@
 use clarity::vm::{ClarityName, SymbolicExpression};
 
-use super::ComplexWord;
+use super::{ComplexWord, Word};
 use crate::check_args;
 use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
@@ -8,11 +8,13 @@ use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
 #[derive(Debug)]
 pub struct Recover;
 
-impl ComplexWord for Recover {
+impl Word for Recover {
     fn name(&self) -> ClarityName {
         "secp256k1-recover?".into()
     }
+}
 
+impl ComplexWord for Recover {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -57,11 +59,13 @@ impl ComplexWord for Recover {
 #[derive(Debug)]
 pub struct Verify;
 
-impl ComplexWord for Verify {
+impl Word for Verify {
     fn name(&self) -> ClarityName {
         "secp256k1-verify".into()
     }
+}
 
+impl ComplexWord for Verify {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -13,16 +13,18 @@ use crate::wasm_generator::{
     ArgumentsExt, GeneratorError, SequenceElementType, WasmGenerator,
 };
 use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
-use crate::words::{self, ComplexWord};
+use crate::words::{self, ComplexWord, Word};
 
 #[derive(Debug)]
 pub struct ListCons;
 
-impl ComplexWord for ListCons {
+impl Word for ListCons {
     fn name(&self) -> ClarityName {
         "list".into()
     }
+}
 
+impl ComplexWord for ListCons {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -74,11 +76,13 @@ impl ComplexWord for ListCons {
 #[derive(Debug)]
 pub struct Fold;
 
-impl ComplexWord for Fold {
+impl Word for Fold {
     fn name(&self) -> ClarityName {
         "fold".into()
     }
+}
 
+impl ComplexWord for Fold {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -260,11 +264,13 @@ impl ComplexWord for Fold {
 #[derive(Debug)]
 pub struct Append;
 
-impl ComplexWord for Append {
+impl Word for Append {
     fn name(&self) -> ClarityName {
         "append".into()
     }
+}
 
+impl ComplexWord for Append {
     fn traverse(
         &self,
         generator: &mut crate::wasm_generator::WasmGenerator,
@@ -349,11 +355,13 @@ impl ComplexWord for Append {
 #[derive(Debug)]
 pub struct AsMaxLen;
 
-impl ComplexWord for AsMaxLen {
+impl Word for AsMaxLen {
     fn name(&self) -> ClarityName {
         "as-max-len?".into()
     }
+}
 
+impl ComplexWord for AsMaxLen {
     fn traverse(
         &self,
         generator: &mut crate::wasm_generator::WasmGenerator,
@@ -452,11 +460,13 @@ impl ComplexWord for AsMaxLen {
 #[derive(Debug)]
 pub struct Concat;
 
-impl ComplexWord for Concat {
+impl Word for Concat {
     fn name(&self) -> ClarityName {
         "concat".into()
     }
+}
 
+impl ComplexWord for Concat {
     fn traverse(
         &self,
         generator: &mut crate::wasm_generator::WasmGenerator,
@@ -525,11 +535,13 @@ impl ComplexWord for Concat {
 #[derive(Debug)]
 pub struct Map;
 
-impl ComplexWord for Map {
+impl Word for Map {
     fn name(&self) -> ClarityName {
         "map".into()
     }
+}
 
+impl ComplexWord for Map {
     fn traverse(
         &self,
         generator: &mut crate::wasm_generator::WasmGenerator,
@@ -813,11 +825,13 @@ impl ComplexWord for Map {
 #[derive(Debug)]
 pub struct Len;
 
-impl ComplexWord for Len {
+impl Word for Len {
     fn name(&self) -> ClarityName {
         "len".into()
     }
+}
 
+impl ComplexWord for Len {
     fn traverse(
         &self,
         generator: &mut crate::wasm_generator::WasmGenerator,
@@ -895,14 +909,16 @@ pub enum ElementAt {
     Alias,
 }
 
-impl ComplexWord for ElementAt {
+impl Word for ElementAt {
     fn name(&self) -> ClarityName {
         match self {
             ElementAt::Original => "element-at".into(),
             ElementAt::Alias => "element-at?".into(),
         }
     }
+}
 
+impl ComplexWord for ElementAt {
     fn traverse(
         &self,
         generator: &mut crate::wasm_generator::WasmGenerator,
@@ -1081,11 +1097,13 @@ impl ComplexWord for ElementAt {
 #[derive(Debug)]
 pub struct ReplaceAt;
 
-impl ComplexWord for ReplaceAt {
+impl Word for ReplaceAt {
     fn name(&self) -> ClarityName {
         "replace-at?".into()
     }
+}
 
+impl ComplexWord for ReplaceAt {
     fn traverse(
         &self,
         generator: &mut crate::wasm_generator::WasmGenerator,
@@ -1334,11 +1352,13 @@ impl ComplexWord for ReplaceAt {
 #[derive(Debug)]
 pub struct Slice;
 
-impl ComplexWord for Slice {
+impl Word for Slice {
     fn name(&self) -> ClarityName {
         "slice?".into()
     }
+}
 
+impl ComplexWord for Slice {
     fn traverse(
         &self,
         generator: &mut crate::wasm_generator::WasmGenerator,

--- a/clar2wasm/src/words/stx.rs
+++ b/clar2wasm/src/words/stx.rs
@@ -1,7 +1,7 @@
 use clarity::vm::types::TypeSignature;
 use clarity::vm::{ClarityName, SymbolicExpression};
 
-use super::{ComplexWord, SimpleWord};
+use super::{ComplexWord, SimpleWord, Word};
 use crate::check_args;
 use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
@@ -9,11 +9,13 @@ use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
 #[derive(Debug)]
 pub struct StxBurn;
 
-impl SimpleWord for StxBurn {
+impl Word for StxBurn {
     fn name(&self) -> ClarityName {
         "stx-burn?".into()
     }
+}
 
+impl SimpleWord for StxBurn {
     fn visit(
         &self,
         generator: &mut WasmGenerator,
@@ -32,11 +34,13 @@ impl SimpleWord for StxBurn {
 #[derive(Debug)]
 pub struct StxGetBalance;
 
-impl SimpleWord for StxGetBalance {
+impl Word for StxGetBalance {
     fn name(&self) -> ClarityName {
         "stx-get-balance".into()
     }
+}
 
+impl SimpleWord for StxGetBalance {
     fn visit(
         &self,
         generator: &mut WasmGenerator,
@@ -52,11 +56,13 @@ impl SimpleWord for StxGetBalance {
 #[derive(Debug)]
 pub struct StxTransfer;
 
-impl ComplexWord for StxTransfer {
+impl Word for StxTransfer {
     fn name(&self) -> ClarityName {
         "stx-transfer?".into()
     }
+}
 
+impl ComplexWord for StxTransfer {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -84,11 +90,13 @@ impl ComplexWord for StxTransfer {
 #[derive(Debug)]
 pub struct StxTransferMemo;
 
-impl ComplexWord for StxTransferMemo {
+impl Word for StxTransferMemo {
     fn name(&self) -> ClarityName {
         "stx-transfer-memo?".into()
     }
+}
 
+impl ComplexWord for StxTransferMemo {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -116,11 +124,13 @@ impl ComplexWord for StxTransferMemo {
 #[derive(Debug)]
 pub struct StxGetAccount;
 
-impl SimpleWord for StxGetAccount {
+impl Word for StxGetAccount {
     fn name(&self) -> ClarityName {
         "stx-account".into()
     }
+}
 
+impl SimpleWord for StxGetAccount {
     fn visit(
         &self,
         generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/tokens.rs
+++ b/clar2wasm/src/words/tokens.rs
@@ -1,7 +1,7 @@
 use clarity::vm::types::TypeSignature;
 use clarity::vm::{ClarityName, SymbolicExpression};
 
-use super::ComplexWord;
+use super::{ComplexWord, Word};
 use crate::check_args;
 use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
@@ -9,11 +9,13 @@ use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
 #[derive(Debug)]
 pub struct DefineFungibleToken;
 
-impl ComplexWord for DefineFungibleToken {
+impl Word for DefineFungibleToken {
     fn name(&self) -> ClarityName {
         "define-fungible-token".into()
     }
+}
 
+impl ComplexWord for DefineFungibleToken {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -72,11 +74,13 @@ impl ComplexWord for DefineFungibleToken {
 #[derive(Debug)]
 pub struct BurnFungibleToken;
 
-impl ComplexWord for BurnFungibleToken {
+impl Word for BurnFungibleToken {
     fn name(&self) -> ClarityName {
         "ft-burn?".into()
     }
+}
 
+impl ComplexWord for BurnFungibleToken {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -110,11 +114,13 @@ impl ComplexWord for BurnFungibleToken {
 #[derive(Debug)]
 pub struct TransferFungibleToken;
 
-impl ComplexWord for TransferFungibleToken {
+impl Word for TransferFungibleToken {
     fn name(&self) -> ClarityName {
         "ft-transfer?".into()
     }
+}
 
+impl ComplexWord for TransferFungibleToken {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -150,11 +156,13 @@ impl ComplexWord for TransferFungibleToken {
 #[derive(Debug)]
 pub struct MintFungibleToken;
 
-impl ComplexWord for MintFungibleToken {
+impl Word for MintFungibleToken {
     fn name(&self) -> ClarityName {
         "ft-mint?".into()
     }
+}
 
+impl ComplexWord for MintFungibleToken {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -187,11 +195,13 @@ impl ComplexWord for MintFungibleToken {
 #[derive(Debug)]
 pub struct GetSupplyOfFungibleToken;
 
-impl ComplexWord for GetSupplyOfFungibleToken {
+impl Word for GetSupplyOfFungibleToken {
     fn name(&self) -> ClarityName {
         "ft-get-supply".into()
     }
+}
 
+impl ComplexWord for GetSupplyOfFungibleToken {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -217,11 +227,13 @@ impl ComplexWord for GetSupplyOfFungibleToken {
 #[derive(Debug)]
 pub struct GetBalanceOfFungibleToken;
 
-impl ComplexWord for GetBalanceOfFungibleToken {
+impl Word for GetBalanceOfFungibleToken {
     fn name(&self) -> ClarityName {
         "ft-get-balance".into()
     }
+}
 
+impl ComplexWord for GetBalanceOfFungibleToken {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -255,11 +267,13 @@ impl ComplexWord for GetBalanceOfFungibleToken {
 #[derive(Debug)]
 pub struct DefineNonFungibleToken;
 
-impl ComplexWord for DefineNonFungibleToken {
+impl Word for DefineNonFungibleToken {
     fn name(&self) -> ClarityName {
         "define-non-fungible-token".into()
     }
+}
 
+impl ComplexWord for DefineNonFungibleToken {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -313,11 +327,13 @@ impl ComplexWord for DefineNonFungibleToken {
 #[derive(Debug)]
 pub struct BurnNonFungibleToken;
 
-impl ComplexWord for BurnNonFungibleToken {
+impl Word for BurnNonFungibleToken {
     fn name(&self) -> ClarityName {
         "nft-burn?".into()
     }
+}
 
+impl ComplexWord for BurnNonFungibleToken {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -367,11 +383,13 @@ impl ComplexWord for BurnNonFungibleToken {
 #[derive(Debug)]
 pub struct TransferNonFungibleToken;
 
-impl ComplexWord for TransferNonFungibleToken {
+impl Word for TransferNonFungibleToken {
     fn name(&self) -> ClarityName {
         "nft-transfer?".into()
     }
+}
 
+impl ComplexWord for TransferNonFungibleToken {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -425,11 +443,13 @@ impl ComplexWord for TransferNonFungibleToken {
 #[derive(Debug)]
 pub struct MintNonFungibleToken;
 
-impl ComplexWord for MintNonFungibleToken {
+impl Word for MintNonFungibleToken {
     fn name(&self) -> ClarityName {
         "nft-mint?".into()
     }
+}
 
+impl ComplexWord for MintNonFungibleToken {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -479,11 +499,13 @@ impl ComplexWord for MintNonFungibleToken {
 #[derive(Debug)]
 pub struct GetOwnerOfNonFungibleToken;
 
-impl ComplexWord for GetOwnerOfNonFungibleToken {
+impl Word for GetOwnerOfNonFungibleToken {
     fn name(&self) -> ClarityName {
         "nft-get-owner?".into()
     }
+}
 
+impl ComplexWord for GetOwnerOfNonFungibleToken {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/traits.rs
+++ b/clar2wasm/src/words/traits.rs
@@ -1,6 +1,6 @@
 use clarity::vm::{ClarityName, SymbolicExpression, SymbolicExpressionType};
 
-use super::ComplexWord;
+use super::{ComplexWord, Word};
 use crate::check_args;
 use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
@@ -8,11 +8,13 @@ use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
 #[derive(Debug)]
 pub struct DefineTrait;
 
-impl ComplexWord for DefineTrait {
+impl Word for DefineTrait {
     fn name(&self) -> ClarityName {
         "define-trait".into()
     }
+}
 
+impl ComplexWord for DefineTrait {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -55,11 +57,13 @@ impl ComplexWord for DefineTrait {
 #[derive(Debug)]
 pub struct UseTrait;
 
-impl ComplexWord for UseTrait {
+impl Word for UseTrait {
     fn name(&self) -> ClarityName {
         "use-trait".into()
     }
+}
 
+impl ComplexWord for UseTrait {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -89,11 +93,13 @@ impl ComplexWord for UseTrait {
 #[derive(Debug)]
 pub struct ImplTrait;
 
-impl ComplexWord for ImplTrait {
+impl Word for ImplTrait {
     fn name(&self) -> ClarityName {
         "impl-trait".into()
     }
+}
 
+impl ComplexWord for ImplTrait {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,

--- a/clar2wasm/src/words/tuples.rs
+++ b/clar2wasm/src/words/tuples.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use clarity::vm::types::TypeSignature;
 use clarity::vm::{ClarityName, SymbolicExpression};
 
-use super::ComplexWord;
+use super::{ComplexWord, Word};
 use crate::check_args;
 use crate::wasm_generator::{clar2wasm_ty, drop_value, GeneratorError, WasmGenerator};
 use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
@@ -11,11 +11,13 @@ use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
 #[derive(Debug)]
 pub struct TupleCons;
 
-impl ComplexWord for TupleCons {
+impl Word for TupleCons {
     fn name(&self) -> ClarityName {
         "tuple".into()
     }
+}
 
+impl ComplexWord for TupleCons {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -100,11 +102,13 @@ impl ComplexWord for TupleCons {
 #[derive(Debug)]
 pub struct TupleGet;
 
-impl ComplexWord for TupleGet {
+impl Word for TupleGet {
     fn name(&self) -> ClarityName {
         "get".into()
     }
+}
 
+impl ComplexWord for TupleGet {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,
@@ -174,11 +178,13 @@ impl ComplexWord for TupleGet {
 #[derive(Debug)]
 pub struct TupleMerge;
 
-impl ComplexWord for TupleMerge {
+impl Word for TupleMerge {
     fn name(&self) -> ClarityName {
         "merge".into()
     }
+}
 
+impl ComplexWord for TupleMerge {
     fn traverse(
         &self,
         generator: &mut WasmGenerator,


### PR DESCRIPTION
The `Word` trait separates `ComplexWord::name` and `SimpleWord::name` into a separate trait, allowing for functionality to be implemented only based on a word's name, without having to bring in `SimpleWord::visit` or `ComplexWord::traverse` with it.

This is useful for any case where the above is required, and since we already have a case for it in cost-tracking, this is the time to introduce it.

See-also: #616