### PR TITLE
Fix as-contract cost tracking

### DIFF
--- a/clar2wasm/src/cost.rs
+++ b/clar2wasm/src/cost.rs
@@ -270,7 +270,8 @@ pub trait ChargeGenerator {
                 Some(cost) => ctx.emit(instrs, module, cost, n)?,
                 None => {
                     return Err(GeneratorError::InternalError(format!(
-                        "expected '{word_name}' to be in costs table"
+                        "'{}' do not exists in costs table for {}",
+                        word_name, ctx.clarity_version
                     )))
                 }
             }

--- a/clar2wasm/src/cost/clar1.rs
+++ b/clar2wasm/src/cost/clar1.rs
@@ -9,7 +9,7 @@ use crate::words::bindings::Let;
 use crate::words::blockinfo::{AtBlock, GetBlockInfo, GetStacksBlockInfo, GetTenureInfo};
 use crate::words::comparison::{CmpGeq, CmpGreater, CmpLeq, CmpLess};
 use crate::words::conditionals::{And, Asserts, Filter, If, Match, Or, Try, Unwrap, UnwrapErr};
-use crate::words::contract::ContractCall;
+use crate::words::contract::{AsContract, ContractCall};
 use crate::words::control_flow::{Begin, UnwrapErrPanic, UnwrapPanic};
 use crate::words::data_vars::{GetDataVar, SetDataVar};
 use crate::words::default_to::DefaultTo;
@@ -425,6 +425,16 @@ lazy_static! {
             UnwrapPanic.name(),
             WordCost {
                 runtime: Constant(1000),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            AsContract.name(),
+            WordCost {
+                runtime: Constant(138),
                 read_count: None,
                 read_length: None,
                 write_count: None,

--- a/clar2wasm/src/cost/clar2.rs
+++ b/clar2wasm/src/cost/clar2.rs
@@ -9,7 +9,7 @@ use crate::words::bindings::Let;
 use crate::words::blockinfo::{AtBlock, GetBlockInfo, GetStacksBlockInfo, GetTenureInfo};
 use crate::words::comparison::{CmpGeq, CmpGreater, CmpLeq, CmpLess};
 use crate::words::conditionals::{And, Asserts, Filter, If, Match, Or, Try, Unwrap, UnwrapErr};
-use crate::words::contract::ContractCall;
+use crate::words::contract::{AsContract, ContractCall};
 use crate::words::control_flow::{Begin, UnwrapErrPanic, UnwrapPanic};
 use crate::words::data_vars::{GetDataVar, SetDataVar};
 use crate::words::default_to::DefaultTo;
@@ -425,6 +425,16 @@ lazy_static! {
             UnwrapPanic.name(),
             WordCost {
                 runtime: Constant(339),
+                read_count: None,
+                read_length: None,
+                write_count: None,
+                write_length: None,
+            },
+        );
+        map.insert(
+            AsContract.name(),
+            WordCost {
+                runtime: Constant(138),
                 read_count: None,
                 read_length: None,
                 write_count: None,


### PR DESCRIPTION
`as-contract` costs are missing for Clarity::V1 and Clarity::V2.