### PR TITLE
Allocate space for hashing functions workspaces

### DIFF
--- a/clar2wasm/Cargo.toml
+++ b/clar2wasm/Cargo.toml
@@ -13,6 +13,7 @@ wasmtime = "15.0.0"
 sha2 = { version = "0.10.7" }
 chrono = { version = "0.4.20" }
 rusqlite = { version = "0.31.0" }
+once_cell = "1.19.0"
 
 clarity = { git="https://github.com/stacks-network/stacks-core", branch="feat/clarity-wasm-develop", features = ["testing"] }
 stacks-common = { git="https://github.com/stacks-network/stacks-core", branch="feat/clarity-wasm-develop" }

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -1549,17 +1549,17 @@
         )
     )
 
-    (func $stdlib.sha256-buf (param $offset i32) (param $length i32) (param $offset-result i32) (result i32 i32)
+    (func $stdlib.sha256-buf (param $offset i32) (param $length i32) (param $offset-result i32) (param $workspace-offset i32) (result i32 i32)
         (local $i i32)
         ;; see this for an explanation: https://sha256algorithm.com/
 
-        (call $extend-data (local.get $offset) (local.get $length))
+        (call $extend-data (local.get $offset) (local.get $length) (local.get $workspace-offset))
         (local.set $length)
 
         (local.set $i (i32.const 0))
         (loop
-            (call $block64 (local.get $i))
-            (call $working-vars)
+            (call $block64 (local.get $i) (local.get $workspace-offset))
+            (call $working-vars local.get $workspace-offset)
             (br_if 0
                 (i32.lt_u
                     (local.tee $i (i32.add (local.get $i) (i32.const 64)))
@@ -1572,14 +1572,14 @@
         (v128.store
             (local.get $offset-result)
             (i8x16.swizzle
-                (v128.load (global.get $stack-pointer))
+                (v128.load (local.get $workspace-offset))
                 (v128.const i8x16 3 2 1 0 7 6 5 4 11 10 9 8 15 14 13 12)
             )
         )
         (v128.store offset=16
             (local.get $offset-result)
             (i8x16.swizzle
-                (v128.load offset=16 (global.get $stack-pointer))
+                (v128.load offset=16 (local.get $workspace-offset))
                 (v128.const i8x16 3 2 1 0 7 6 5 4 11 10 9 8 15 14 13 12)
             )
         )
@@ -1587,33 +1587,33 @@
         (local.get $offset-result) (i32.const 32)
     )
 
-    (func $stdlib.sha256-int (param $lo i64) (param $hi i64) (param $offset-result i32) (result i32 i32)
+    (func $stdlib.sha256-int (param $lo i64) (param $hi i64) (param $offset-result i32) (param $workspace-offset i32) (result i32 i32)
         ;; Copy data to the working stack, so that it has this relative configuration:
         ;;   0..32 -> Initial hash vals (will be the result hash in the end)
         ;;   32..288 -> Space to store W
         ;;   288..352 -> extended int
-        (memory.copy (global.get $stack-pointer) (i32.const 0) (i32.const 32))
+        (memory.copy (local.get $workspace-offset) (i32.const 0) (i32.const 32))
 
-        (i64.store offset=288 (global.get $stack-pointer) (local.get $lo))
-        (i64.store offset=296 (global.get $stack-pointer) (local.get $hi)) ;; offset = 288 + 8
-        (i32.store offset=304 (global.get $stack-pointer) (i32.const 0x80)) ;; offset = 288+16
-        (memory.fill (i32.add (global.get $stack-pointer) (i32.const 308)) (i32.const 0) (i32.const 46)) ;; offset = 288+20
-        (i32.store8 offset=351 (global.get $stack-pointer) (i32.const 0x80)) ;; offset = 288+63
+        (i64.store offset=288 (local.get $workspace-offset) (local.get $lo))
+        (i64.store offset=296 (local.get $workspace-offset) (local.get $hi)) ;; offset = 288 + 8
+        (i32.store offset=304 (local.get $workspace-offset) (i32.const 0x80)) ;; offset = 288+16
+        (memory.fill (i32.add (local.get $workspace-offset) (i32.const 308)) (i32.const 0) (i32.const 46)) ;; offset = 288+20
+        (i32.store8 offset=351 (local.get $workspace-offset) (i32.const 0x80)) ;; offset = 288+63
 
-        (call $block64 (i32.const 0))
-        (call $working-vars)
+        (call $block64 (i32.const 0) (local.get $workspace-offset))
+        (call $working-vars (local.get $workspace-offset))
 
         (v128.store
             (local.get $offset-result)
             (i8x16.swizzle
-                (v128.load (global.get $stack-pointer))
+                (v128.load (local.get $workspace-offset))
                 (v128.const i8x16 3 2 1 0 7 6 5 4 11 10 9 8 15 14 13 12)
             )
         )
         (v128.store offset=16
             (local.get $offset-result)
             (i8x16.swizzle
-                (v128.load offset=16 (global.get $stack-pointer))
+                (v128.load offset=16 (local.get $workspace-offset))
                 (v128.const i8x16 3 2 1 0 7 6 5 4 11 10 9 8 15 14 13 12)
             )
         )
@@ -1621,15 +1621,15 @@
         (local.get $offset-result) (i32.const 32)
     )
 
-    (func $extend-data (param $offset i32) (param $length i32) (result i32)
+    (func $extend-data (param $offset i32) (param $length i32) (param $workspace-offset i32) (result i32)
         (local $res_len i32) (local $len64 i64)
 
         ;; Move data to the working stack, so that it has this relative configuration:
         ;;   0..32 -> Initial hash vals (will be the result hash in the end)
         ;;   32..288 -> Space to store W (result of $block64)
         ;;   288..$length+288 -> shifted data
-        (memory.copy (global.get $stack-pointer) (i32.const 0) (i32.const 32))
-        (memory.copy (i32.add (global.get $stack-pointer) (i32.const 288)) (local.get $offset) (local.get $length))
+        (memory.copy (local.get $workspace-offset) (i32.const 0) (i32.const 32))
+        (memory.copy (i32.add (local.get $workspace-offset) (i32.const 288)) (local.get $offset) (local.get $length))
 
         (local.set $res_len ;; total size of data with expansion
             (i32.add
@@ -1644,20 +1644,20 @@
 
         ;; Add "1" at the end of the data
         (i32.store offset=288
-            (i32.add (global.get $stack-pointer) (local.get $length))
+            (i32.add (local.get $workspace-offset) (local.get $length))
             (i32.const 0x80)
         )
 
         ;; Fill the remaining part before the size with 0s
         (memory.fill
-            (i32.add (i32.add (global.get $stack-pointer) (local.get $length)) (i32.const 289))
+            (i32.add (i32.add (local.get $workspace-offset) (local.get $length)) (i32.const 289))
             (i32.const 0)
             (i32.sub (i32.sub (local.get $res_len) (local.get $length)) (i32.const 8))
         )
 
         ;; Add the size, as a 64bits big-endian integer
         (local.set $len64 (i64.extend_i32_u (i32.shl (local.get $length) (i32.const 3))))
-        (i32.sub (i32.add (global.get $stack-pointer) (local.get $res_len)) (i32.const 8))
+        (i32.sub (i32.add (local.get $workspace-offset) (local.get $res_len)) (i32.const 8))
         (i64.or
             (i64.or
                 (i64.or
@@ -1685,11 +1685,11 @@
         (local.get $res_len)
     )
 
-    (func $block64 (param $data i32)
+    (func $block64 (param $data i32) (param $workspace-offset i32)
         (local $origin i32)
         (local $i i32) (local $tmp i32)
 
-        (local.set $origin (global.get $stack-pointer))
+        (local.set $origin (local.get $workspace-offset))
         (local.set $data (i32.add (local.get $origin) (local.get $data)))
 
         (local.set $i (i32.const 0))
@@ -1745,13 +1745,13 @@
         )
     )
 
-    (func $working-vars
+    (func $working-vars (param $workspace-offset i32)
         (local $origin i32)
         (local $a i32) (local $b i32) (local $c i32) (local $d i32)
         (local $e i32) (local $f i32) (local $g i32) (local $h i32)
         (local $temp1 i32) (local $temp2 i32) (local $i i32)
 
-        (local.set $origin (global.get $stack-pointer))
+        (local.set $origin (local.get $workspace-offset))
 
         (local.set $a (i32.load offset=0 (local.get $origin)))
         (local.set $b (i32.load offset=4 (local.get $origin)))
@@ -1821,56 +1821,56 @@
         (i32.store offset=28 (local.get $origin) (i32.add (i32.load offset=28 (local.get $origin)) (local.get $h)))
     )
 
-    (func $stdlib.hash160-buf (param $offset i32) (param $length i32) (param $offset-result i32) (result i32 i32)
+    (func $stdlib.hash160-buf (param $offset i32) (param $length i32) (param $offset-result i32) (param $workspace-offset i32) (result i32 i32)
         (local $i i32)
         ;; ripemd-160 article: https://www.esat.kuleuven.be/cosic/publications/article-317.pdf
         ;; Here we implement a ripemd with an easier padding since inputs are results of sha256,
         ;; and thus always have the same length.
 
         ;; move $stack-pointers: current value will contain sha256 result and moved place is new stack
-        (global.set $stack-pointer (i32.add (local.tee $i (global.get $stack-pointer)) (i32.const 32)))
+        (local.set $workspace-offset (i32.add (local.tee $i (local.get $workspace-offset)) (i32.const 32)))
         ;; compute sha256
-        (call $stdlib.sha256-buf (local.get $offset) (local.get $length) (local.get $i))
+        (call $stdlib.sha256-buf (local.get $offset) (local.get $length) (local.get $i) (local.get $workspace-offset))
         drop ;; we don't need the length of sha256, it is always 32
-        (global.set $stack-pointer) ;; set $stack-pointer to its original value, aka offset of sha256 result
+        (local.set $workspace-offset) ;; set $stack-pointer to its original value, aka offset of sha256 result
 
-        (call $hash160-pad)
-        (call $hash160-compress (local.get $offset-result))
+        (call $hash160-pad (local.get $workspace-offset))
+        (call $hash160-compress (local.get $offset-result) (local.get $workspace-offset))
 
         (local.get $offset-result) (i32.const 20)
     )
 
-    (func $stdlib.hash160-int (param $lo i64) (param $hi i64) (param $offset-result i32) (result i32 i32)
+    (func $stdlib.hash160-int (param $lo i64) (param $hi i64) (param $offset-result i32) (param $workspace-offset i32) (result i32 i32)
         (local $i i32)
         ;; ripemd-160 article: https://www.esat.kuleuven.be/cosic/publications/article-317.pdf
         ;; Here we implement a ripemd with an easier padding since inputs are results of sha256,
         ;; and thus always have the same length.
 
         ;; move $stack-pointers: current value will contain sha256 result and moved place is new stack
-        (global.set $stack-pointer (i32.add (local.tee $i (global.get $stack-pointer)) (i32.const 32)))
+        (local.set $workspace-offset (i32.add (local.tee $i (local.get $workspace-offset)) (i32.const 32)))
         ;; compute sha256
-        (call $stdlib.sha256-int (local.get $lo) (local.get $hi) (local.get $i))
+        (call $stdlib.sha256-int (local.get $lo) (local.get $hi) (local.get $i) (local.get $workspace-offset))
         drop ;; we don't need the length of sha256, it is always 32
-        (global.set $stack-pointer) ;; set $stack-pointer to its original value, aka offset of sha256 result
+        (local.set $workspace-offset) ;; set $stack-pointer to its original value, aka offset of sha256 result
 
-        (call $hash160-pad)
-        (call $hash160-compress (local.get $offset-result))
+        (call $hash160-pad (local.get $workspace-offset))
+        (call $hash160-compress (local.get $offset-result) (local.get $workspace-offset))
 
         (local.get $offset-result) (i32.const 20)
     )
 
-    (func $hash160-pad
+    (func $hash160-pad (param $workspace-offset i32)
         ;; MD-padding: (already placed sha256 +) "1" + "00000..." + size as i64 big endian
-        (i64.store offset=32 (global.get $stack-pointer) (i64.const 0x80))
+        (i64.store offset=32 (local.get $workspace-offset) (i64.const 0x80))
         (memory.fill
-            (i32.add (global.get $stack-pointer) (i32.const 40))
+            (i32.add (local.get $workspace-offset) (i32.const 40))
             (i32.const 0)
             (i32.const 16)
         )
-        (i64.store offset=56 (global.get $stack-pointer) (i64.const 256))
+        (i64.store offset=56 (local.get $workspace-offset) (i64.const 256))
     )
 
-    (func $hash160-compress (param $offset-result i32)
+    (func $hash160-compress (param $offset-result i32) (param $workspace-offset i32)
         (local $h0 i32) (local $h1 i32) (local $h2 i32) (local $h3 i32) (local $h4 i32)
         (local $a1 i32) (local $b1 i32) (local $c1 i32) (local $d1 i32) (local $e1 i32)
         (local $a2 i32) (local $b2 i32) (local $c2 i32) (local $d2 i32) (local $e2 i32)
@@ -1898,7 +1898,7 @@
             ;; + word[r[i]]
             (i32.load
                 (i32.add
-                    (global.get $stack-pointer)
+                    (local.get $workspace-offset)
                     (i32.shl (i32.load8_u offset=288 (local.get $i)) (i32.const 2))
                 )
             )
@@ -1931,7 +1931,7 @@
             ;; + word[r'[i]]
             (i32.load
                 (i32.add
-                    (global.get $stack-pointer)
+                    (local.get $workspace-offset)
                     (i32.shl (i32.load8_u offset=368 (local.get $i)) (i32.const 2))
                 )
             )
@@ -2921,7 +2921,7 @@
         (local.get $hi)
     )
 
-    (func $stdlib.sha512-buf (param $offset i32) (param $length i32) (param $offset-result i32)(result i32 i32)
+    (func $stdlib.sha512-buf (param $offset i32) (param $length i32) (param $offset-result i32) (param $workspace-offset i32)(result i32 i32)
 
         ;; For binary representation, you can take a look at https://sha256algorithm.com/
         ;; Keep in mind that SHA-256 handles 4-byte words, but SHA-512 handles 8-byte words
@@ -2935,16 +2935,16 @@
         ;; Index to track all blocks
         (local $index i32)
 
-        (call $pad-sha512-data (local.get $offset) (local.get $length))
+        (call $pad-sha512-data (local.get $offset) (local.get $length) (local.get $workspace-offset))
         (local.set $length_after_padding)
 
         (local.set $index (i32.const 0))
         ;; Iterations on blocks
         (loop
             ;; Process a block
-            (call $process-sha512-block (local.get $index))
+            (call $process-sha512-block (local.get $index) (local.get $workspace-offset))
             ;; Calculate hash using initial values and k-constants (80 rounds total)
-            (call $calculate-sha512)
+            (call $calculate-sha512 (local.get $workspace-offset))
 
             (br_if 0
                 (i32.lt_u
@@ -2955,33 +2955,33 @@
         )
 
         ;; store at result position with correct endianness
-        (call $store-calculated-sha512 (local.get $offset-result))
+        (call $store-calculated-sha512 (local.get $offset-result) (local.get $workspace-offset))
         (local.get $offset-result) (i32.const 64)
     )
 
-    (func $stdlib.sha512-int (param $lo i64) (param $hi i64) (param $offset-result i32) (result i32 i32)
+    (func $stdlib.sha512-int (param $lo i64) (param $hi i64) (param $offset-result i32) (param $workspace-offset i32)(result i32 i32)
 
         ;; Copy data to the working stack, so that it has this relative configuration:
         ;;   0..64 -> Initial hash vals (will be the result hash in the end)
         ;;   64..704 -> Space to store W
         ;;   704..831 -> extended int
-        (memory.copy (global.get $stack-pointer) (i32.const 648) (i32.const 64))
-        (i64.store offset=704 (global.get $stack-pointer) (local.get $lo))
-        (i64.store offset=712 (global.get $stack-pointer) (local.get $hi)) ;; offset = 704 + 8
-        (i32.store offset=720 (global.get $stack-pointer) (i32.const 0x80)) ;; offset = 704 + 16
-        (memory.fill (i32.add (global.get $stack-pointer) (i32.const 724)) (i32.const 0) (i32.const 110)) ;; offset = 704+20
-        (i32.store8 offset=831 (global.get $stack-pointer) (i32.const 0x80)) ;; offset = 704+127
+        (memory.copy (local.get $workspace-offset) (i32.const 648) (i32.const 64))
+        (i64.store offset=704 (local.get $workspace-offset) (local.get $lo))
+        (i64.store offset=712 (local.get $workspace-offset) (local.get $hi)) ;; offset = 704 + 8
+        (i32.store offset=720 (local.get $workspace-offset) (i32.const 0x80)) ;; offset = 704 + 16
+        (memory.fill (i32.add (local.get $workspace-offset) (i32.const 724)) (i32.const 0) (i32.const 110)) ;; offset = 704+20
+        (i32.store8 offset=831 (local.get $workspace-offset) (i32.const 0x80)) ;; offset = 704+127
 
-        (call $process-sha512-block (i32.const 0))
-        (call $calculate-sha512)
+        (call $process-sha512-block (i32.const 0) (local.get $workspace-offset))
+        (call $calculate-sha512 (local.get $workspace-offset))
 
         ;; store at result position with correct endianness
-        (call $store-calculated-sha512 (local.get $offset-result))
+        (call $store-calculated-sha512 (local.get $offset-result) (local.get $workspace-offset))
 
         (local.get $offset-result) (i32.const 64)
     )
 
-    (func $pad-sha512-data (param $offset i32) (param $length i32) (result i32)
+    (func $pad-sha512-data (param $offset i32) (param $length i32) (param $workspace-offset i32) (result i32)
         ;; Length of the data after adding padding and length to it
         (local $length_after_padding i32)
 
@@ -2989,10 +2989,10 @@
         (local $message_length_64 i64)
 
         ;; Copying initial values (64 bytes) for SHA-512 from 648 index
-        (memory.copy (global.get $stack-pointer) (i32.const 648) (i32.const 64))
+        (memory.copy (local.get $workspace-offset) (i32.const 648) (i32.const 64))
 
         ;; Copying the data from the offset to isolated environment (i.e. target-index = $stack-pointer+(initial-values+(80 rounds * 8)))
-        (memory.copy (i32.add (global.get $stack-pointer) (i32.const 704)) (local.get $offset) (local.get $length))
+        (memory.copy (i32.add (local.get $workspace-offset) (i32.const 704)) (local.get $offset) (local.get $length))
 
         (local.set $length_after_padding ;; total size of data with expansion divisible by 128
             (i32.add
@@ -3007,13 +3007,13 @@
 
         ;; Add "1" at the end of the data
         (i32.store offset=704
-            (i32.add (global.get $stack-pointer) (local.get $length))
+            (i32.add (local.get $workspace-offset) (local.get $length))
             (i32.const 0x80)
         )
 
         ;; Fill the remaining part before the size with 0s
         (memory.fill
-                (i32.add (i32.add (global.get $stack-pointer) (local.get $length)) (i32.const 705))
+                (i32.add (i32.add (local.get $workspace-offset) (local.get $length)) (i32.const 705))
                 (i32.const 0)
                 ;; Leave the last 8 bytes for the length
                 ;; Not handling 16 bytes length here
@@ -3025,7 +3025,7 @@
 
         ;; Length is being handled as i64 (8 bytes), because we don't need to handle it in 16 bytes, it will be complex
         ;; This is the location where reversed length is going to be stored
-        (i32.sub (i32.add (global.get $stack-pointer) (local.get $length_after_padding)) (i32.const 8))
+        (i32.sub (i32.add (local.get $workspace-offset) (local.get $length_after_padding)) (i32.const 8))
 
         ;; i64.store values in little-endian format, so to convert the length to big-endian, we need to reverse the 8 bits of length
         (i64.or
@@ -3056,7 +3056,7 @@
 
     )
 
-    (func $process-sha512-block (param $current-block-index i32)
+    (func $process-sha512-block (param $current-block-index i32) (param $workspace-offset i32)
         ;; Basically is the $stack-pointer, but accessing global variables can be slower
         (local $origin i32)
 
@@ -3068,7 +3068,7 @@
 
         (local $index i32)
 
-        (local.set $origin (global.get $stack-pointer))
+        (local.set $origin (local.get $workspace-offset))
         (local.set $temp-block-data (i32.add (local.get $origin) (local.get $current-block-index)))
 
         (local.set $index (i32.const 0))
@@ -3122,7 +3122,7 @@
         )
     )
 
-    (func $calculate-sha512
+    (func $calculate-sha512 (param $workspace-offset i32)
 
         (local $origin i32)
         (local $index i32)
@@ -3132,7 +3132,7 @@
         (local $e i64) (local $f i64) (local $g i64) (local $h i64)
         (local $temp1 i64) (local $temp2 i64)
 
-        (local.set $origin (global.get $stack-pointer))
+        (local.set $origin (local.get $workspace-offset))
 
         ;; Calculating variables
         (local.set $a (i64.load offset=0 (local.get $origin)))
@@ -3206,32 +3206,32 @@
         (i64.store offset=56 (local.get $origin) (i64.add (i64.load offset=56 (local.get $origin)) (local.get $h)))
     )
 
-    (func $store-calculated-sha512 (param $offset-result i32)
+    (func $store-calculated-sha512 (param $offset-result i32) (param $workspace-offset i32)
         (v128.store
             (local.get $offset-result)
             (i8x16.swizzle
-                (v128.load (global.get $stack-pointer))
+                (v128.load (local.get $workspace-offset))
                 (v128.const i8x16 7 6 5 4 3 2 1 0 15 14 13 12 11 10 9 8)
             )
         )
         (v128.store offset=16
             (local.get $offset-result)
             (i8x16.swizzle
-                (v128.load offset=16 (global.get $stack-pointer))
+                (v128.load offset=16 (local.get $workspace-offset))
                 (v128.const i8x16 7 6 5 4 3 2 1 0 15 14 13 12 11 10 9 8)
             )
         )
         (v128.store offset=32
             (local.get $offset-result)
             (i8x16.swizzle
-                (v128.load offset=32 (global.get $stack-pointer))
+                (v128.load offset=32 (local.get $workspace-offset))
                 (v128.const i8x16 7 6 5 4 3 2 1 0 15 14 13 12 11 10 9 8)
             )
         )
         (v128.store offset=48
             (local.get $offset-result)
             (i8x16.swizzle
-                (v128.load offset=48 (global.get $stack-pointer))
+                (v128.load offset=48 (local.get $workspace-offset))
                 (v128.const i8x16 7 6 5 4 3 2 1 0 15 14 13 12 11 10 9 8)
             )
         )

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -1827,12 +1827,12 @@
         ;; Here we implement a ripemd with an easier padding since inputs are results of sha256,
         ;; and thus always have the same length.
 
-        ;; move $stack-pointers: current value will contain sha256 result and moved place is new stack
+        ;; move $worksapce-offset: current value will contain sha256 result and moved place is new stack
         (local.set $workspace-offset (i32.add (local.tee $i (local.get $workspace-offset)) (i32.const 32)))
         ;; compute sha256
         (call $stdlib.sha256-buf (local.get $offset) (local.get $length) (local.get $i) (local.get $workspace-offset))
         drop ;; we don't need the length of sha256, it is always 32
-        (local.set $workspace-offset) ;; set $stack-pointer to its original value, aka offset of sha256 result
+        (local.set $workspace-offset) ;; set $workspace-offset to its original value, aka offset of sha256 result
 
         (call $hash160-pad (local.get $workspace-offset))
         (call $hash160-compress (local.get $offset-result) (local.get $workspace-offset))
@@ -1846,12 +1846,12 @@
         ;; Here we implement a ripemd with an easier padding since inputs are results of sha256,
         ;; and thus always have the same length.
 
-        ;; move $stack-pointers: current value will contain sha256 result and moved place is new stack
+        ;; move $workspace-offset: current value will contain sha256 result and moved place is new stack
         (local.set $workspace-offset (i32.add (local.tee $i (local.get $workspace-offset)) (i32.const 32)))
         ;; compute sha256
         (call $stdlib.sha256-int (local.get $lo) (local.get $hi) (local.get $i) (local.get $workspace-offset))
         drop ;; we don't need the length of sha256, it is always 32
-        (local.set $workspace-offset) ;; set $stack-pointer to its original value, aka offset of sha256 result
+        (local.set $workspace-offset) ;; set $workspace-offset to its original value, aka offset of sha256 result
 
         (call $hash160-pad (local.get $workspace-offset))
         (call $hash160-compress (local.get $offset-result) (local.get $workspace-offset))
@@ -2991,7 +2991,7 @@
         ;; Copying initial values (64 bytes) for SHA-512 from 648 index
         (memory.copy (local.get $workspace-offset) (i32.const 648) (i32.const 64))
 
-        ;; Copying the data from the offset to isolated environment (i.e. target-index = $stack-pointer+(initial-values+(80 rounds * 8)))
+        ;; Copying the data from the offset to isolated environment (i.e. target-index = $workspace-offset+(initial-values+(80 rounds * 8)))
         (memory.copy (i32.add (local.get $workspace-offset) (i32.const 704)) (local.get $offset) (local.get $length))
 
         (local.set $length_after_padding ;; total size of data with expansion divisible by 128
@@ -3057,7 +3057,7 @@
     )
 
     (func $process-sha512-block (param $current-block-index i32) (param $workspace-offset i32)
-        ;; Basically is the $stack-pointer, but accessing global variables can be slower
+        ;; Basically is the $workspace-offset
         (local $origin i32)
 
         ;; Temporary block data, in an iteration

--- a/clar2wasm/src/words/hashing.rs
+++ b/clar2wasm/src/words/hashing.rs
@@ -1,10 +1,16 @@
 use clarity::vm::types::{BufferLength, SequenceSubtype, TypeSignature, BUFF_32};
 use clarity::vm::ClarityName;
+use once_cell::sync::OnceCell;
 use walrus::{LocalId, ValType};
 
 use super::{SimpleWord, Word};
 use crate::cost::WordCharge;
 use crate::wasm_generator::{GeneratorError, WasmGenerator};
+
+// Static workspaces for hash functions
+static HASH160_WORKSPACE: OnceCell<(u32, TypeSignature)> = OnceCell::new();
+static SHA256_WORKSPACE: OnceCell<(u32, TypeSignature)> = OnceCell::new();
+static SHA512_WORKSPACE: OnceCell<(u32, TypeSignature)> = OnceCell::new();
 
 pub fn traverse_hash(
     word: &impl SimpleWord,
@@ -26,7 +32,7 @@ pub fn traverse_hash(
         BufferLength::try_from(buffer_size as usize)
             .map_err(|_| GeneratorError::InternalError("buffer size too large".to_string()))?,
     ));
-    println!("it runs here");
+
     // Allocate space on the stack for the result
     let (result_local, _) = generator.create_call_stack_local(builder, &return_ty, false, true);
 
@@ -35,16 +41,6 @@ pub fn traverse_hash(
         TypeSignature::IntType | TypeSignature::UIntType => {
             // an integer is 16 bytes
             word.charge(generator, builder, 16)?;
-            // (workspace_offset, _) = generator.create_call_stack_local(
-            //     builder,
-            //     &TypeSignature::SequenceType(SequenceSubtype::BufferType(
-            //         work_space
-            //             .try_into()
-            //             .expect("Failed to convert to BufferLength"),
-            //     )),
-            //     false,
-            //     true,
-            // );
             generator.ensure_work_space(work_space);
             "int"
         }
@@ -54,16 +50,6 @@ pub fn traverse_hash(
             let buf_len = generator.module.locals.add(ValType::I32);
             builder.local_tee(buf_len);
             word.charge(generator, builder, buf_len)?;
-            // (workspace_offset, _) = generator.create_call_stack_local(
-            //     builder,
-            //     &TypeSignature::SequenceType(SequenceSubtype::BufferType(
-            //         work_space
-            //             .try_into()
-            //             .expect("Failed to convert to BufferLength"),
-            //     )),
-            //     false,
-            //     true,
-            // );
             // Input buff is also copied
             generator.ensure_work_space(u32::from(len) + work_space);
             "buf"
@@ -105,19 +91,27 @@ impl SimpleWord for Hash160 {
         arg_types: &[TypeSignature],
         _return_type: &TypeSignature,
     ) -> Result<(), GeneratorError> {
-        let work_space = 64 + 8 + 289;
-        let (workspace_offset, _) = generator.create_call_stack_local(
-            builder,
-            &TypeSignature::SequenceType(SequenceSubtype::BufferType(
+        let (work_space, workspace_type) = HASH160_WORKSPACE.get_or_init(|| {
+            let work_space = 64 + 8 + 289;
+            let ty = TypeSignature::SequenceType(SequenceSubtype::BufferType(
                 work_space
                     .try_into()
                     .expect("Failed to convert to BufferLength"),
-            )),
-            false,
-            true,
-        );
+            ));
+            (work_space, ty)
+        });
+
+        let (workspace_offset, _) =
+            generator.create_call_stack_local(builder, workspace_type, false, true);
         // work_space values from sha256, see `Sha256::visit`
-        traverse_hash(self, generator, builder, arg_types, work_space, workspace_offset)
+        traverse_hash(
+            self,
+            generator,
+            builder,
+            arg_types,
+            *work_space,
+            workspace_offset,
+        )
     }
 }
 
@@ -138,19 +132,27 @@ impl SimpleWord for Sha256 {
         arg_types: &[TypeSignature],
         _return_type: &TypeSignature,
     ) -> Result<(), GeneratorError> {
-        let work_space = 64 + 8 + 289;
-        let (workspace_offset, _) = generator.create_call_stack_local(
-            builder,
-            &TypeSignature::SequenceType(SequenceSubtype::BufferType(
+        let (work_space, workspace_type) = SHA256_WORKSPACE.get_or_init(|| {
+            let work_space = 64 + 8 + 289;
+            let ty = TypeSignature::SequenceType(SequenceSubtype::BufferType(
                 work_space
                     .try_into()
                     .expect("Failed to convert to BufferLength"),
-            )),
-            false,
-            true,
-        );
+            ));
+            (work_space, ty)
+        });
+
+        let (workspace_offset, _) =
+            generator.create_call_stack_local(builder, workspace_type, false, true);
         // work_space values from `standard.wat::$extend-data`: 64 for padding, 8 for padded size and 289 for the data shift
-        traverse_hash(self, generator, builder, arg_types, work_space, workspace_offset)
+        traverse_hash(
+            self,
+            generator,
+            builder,
+            arg_types,
+            *work_space,
+            workspace_offset,
+        )
     }
 }
 
@@ -234,19 +236,27 @@ impl SimpleWord for Sha512 {
         arg_types: &[TypeSignature],
         _return_type: &TypeSignature,
     ) -> Result<(), GeneratorError> {
-        let work_space = 128 + 16 + 705;
-        let (workspace_offset, _) = generator.create_call_stack_local(
-            builder,
-            &TypeSignature::SequenceType(SequenceSubtype::BufferType(
+        let (work_space, workspace_type) = SHA512_WORKSPACE.get_or_init(|| {
+            let work_space = 128 + 16 + 705;
+            let ty = TypeSignature::SequenceType(SequenceSubtype::BufferType(
                 work_space
                     .try_into()
                     .expect("Failed to convert to BufferLength"),
-            )),
-            false,
-            true,
-        );
+            ));
+            (work_space, ty)
+        });
+
+        let (workspace_offset, _) =
+            generator.create_call_stack_local(builder, workspace_type, false, true);
         // work_space values from `standard.wat::$pad-sha512-data`: 128 for padding, 16 for padded size and 705 for the data shift
-        traverse_hash(self, generator, builder, arg_types, work_space, workspace_offset)
+        traverse_hash(
+            self,
+            generator,
+            builder,
+            arg_types,
+            *work_space,
+            workspace_offset,
+        )
     }
 }
 
@@ -482,6 +492,47 @@ mod tests {
     }
 
     #[test]
+    fn test_hashing_function_creates_workspace_only_once() {
+        // Create a test contract that calls each hash function with different buffer sizes
+        let test_contract = r#"
+        (define-public (test-hash-functions (input1 (buff 1000)) (input2 (buff 2000)) (input3 (buff 3000)))
+            (begin
+                ;; Test hash160 with different buffer sizes
+                (hash160 input1)
+                (hash160 input2)
+                (hash160 input1)
+                ;; Test sha256 with different buffer sizes
+                (sha256 input1)
+                (sha256 input3)
+                (sha256 input2)
+                ;; Test sha512 with different buffer sizes
+                (sha512 input2)
+                (sha512 input3)
+                (sha512 input1)
+                (ok true)
+            )
+        )
+        "#;
+
+        // Create test environment and initialize contract
+        let mut env = TestEnvironment::default();
+        env.init_contract_with_snippet("test-contract", test_contract)
+            .expect("Failed to init test contract");
+
+        // Create test inputs of different sizes
+        let input1 = format!("0x{}", "aa".repeat(1000));
+        let input2 = format!("0x{}", "bb".repeat(2000));
+        let input3 = format!("0x{}", "cc".repeat(3000));
+
+        // Call the contract with different sized inputs
+        env.interpret(&format!(
+            "(contract-call? .test-contract test-hash-functions {} {} {})",
+            input1, input2, input3
+        ))
+        .expect("Failed to interpret contract call");
+    }
+
+    #[test]
     fn test_sha256_ensure_workspace_for_hashing() {
         let page_size = 65536;
 
@@ -498,12 +549,14 @@ mod tests {
         let mut env = TestEnvironment::default();
         env.init_contract_with_snippet("hasher", hasher_contract)
             .expect("Failed to init hasher contract");
+
         let expected = env
             .interpret(&format!(
                 "(contract-call? .hasher hash-large-buffer {})",
                 large_buff
             ))
             .expect("Failed to interpret contract call");
+
         let contracts = [
             ("hasher".into(), hasher_contract),
             (
@@ -520,7 +573,7 @@ mod tests {
     fn test_hash160_ensure_workspace_for_hashing() {
         let page_size = 65536;
 
-        let buffer_size = page_size - 100;
+        let buffer_size = page_size;
         let large_buff = format!("0x{}", "aa".repeat(buffer_size));
 
         let hasher_contract = r#"
@@ -533,12 +586,51 @@ mod tests {
         let mut env = TestEnvironment::default();
         env.init_contract_with_snippet("hasher", hasher_contract)
             .expect("Failed to init hasher contract");
+
         let expected = env
             .interpret(&format!(
                 "(contract-call? .hasher hash-large-buffer {})",
                 large_buff
             ))
             .expect("Failed to interpret contract call");
+
+        let contracts = [
+            ("hasher".into(), hasher_contract),
+            (
+                "caller".into(),
+                &format!("(contract-call? .hasher hash-large-buffer {})", large_buff),
+            ),
+        ];
+
+        // Compare compiled version with interpreted version
+        crosscheck_multi_contract(&contracts, Ok(expected));
+    }
+
+    #[test]
+    fn test_sha512_ensure_workspace_for_hashing() {
+        let page_size = 65536;
+
+        let buffer_size = page_size;
+        let large_buff = format!("0x{}", "aa".repeat(buffer_size));
+
+        let hasher_contract = r#"
+    (define-public (hash-large-buffer (input (buff 65537)))
+        (ok (sha512 input))
+    )
+            "#;
+
+        // First interpret the contracts to get the expected result
+        let mut env = TestEnvironment::default();
+        env.init_contract_with_snippet("hasher", hasher_contract)
+            .expect("Failed to init hasher contract");
+
+        let expected = env
+            .interpret(&format!(
+                "(contract-call? .hasher hash-large-buffer {})",
+                large_buff
+            ))
+            .expect("Failed to interpret contract call");
+
         let contracts = [
             ("hasher".into(), hasher_contract),
             (

--- a/clar2wasm/src/words/hashing.rs
+++ b/clar2wasm/src/words/hashing.rs
@@ -36,7 +36,6 @@ pub fn traverse_hash(
     // Allocate space on the stack for the result
     let (result_local, _) = generator.create_call_stack_local(builder, &return_ty, false, true);
 
-    // let workspace_offset;
     let hash_type = match arg_types[0] {
         TypeSignature::IntType | TypeSignature::UIntType => {
             // an integer is 16 bytes
@@ -92,6 +91,7 @@ impl SimpleWord for Hash160 {
         _return_type: &TypeSignature,
     ) -> Result<(), GeneratorError> {
         let (work_space, workspace_type) = HASH160_WORKSPACE.get_or_init(|| {
+            // work_space values from sha256, see `Sha256::visit`
             let work_space = 64 + 8 + 289;
             let ty = TypeSignature::SequenceType(SequenceSubtype::BufferType(
                 work_space
@@ -103,7 +103,7 @@ impl SimpleWord for Hash160 {
 
         let (workspace_offset, _) =
             generator.create_call_stack_local(builder, workspace_type, false, true);
-        // work_space values from sha256, see `Sha256::visit`
+        
         traverse_hash(
             self,
             generator,
@@ -133,6 +133,7 @@ impl SimpleWord for Sha256 {
         _return_type: &TypeSignature,
     ) -> Result<(), GeneratorError> {
         let (work_space, workspace_type) = SHA256_WORKSPACE.get_or_init(|| {
+            // work_space values from `standard.wat::$extend-data`: 64 for padding, 8 for padded size and 289 for the data shift
             let work_space = 64 + 8 + 289;
             let ty = TypeSignature::SequenceType(SequenceSubtype::BufferType(
                 work_space
@@ -144,7 +145,7 @@ impl SimpleWord for Sha256 {
 
         let (workspace_offset, _) =
             generator.create_call_stack_local(builder, workspace_type, false, true);
-        // work_space values from `standard.wat::$extend-data`: 64 for padding, 8 for padded size and 289 for the data shift
+        
         traverse_hash(
             self,
             generator,
@@ -237,6 +238,7 @@ impl SimpleWord for Sha512 {
         _return_type: &TypeSignature,
     ) -> Result<(), GeneratorError> {
         let (work_space, workspace_type) = SHA512_WORKSPACE.get_or_init(|| {
+            // work_space values from `standard.wat::$pad-sha512-data`: 128 for padding, 16 for padded size and 705 for the data shift
             let work_space = 128 + 16 + 705;
             let ty = TypeSignature::SequenceType(SequenceSubtype::BufferType(
                 work_space
@@ -248,7 +250,6 @@ impl SimpleWord for Sha512 {
 
         let (workspace_offset, _) =
             generator.create_call_stack_local(builder, workspace_type, false, true);
-        // work_space values from `standard.wat::$pad-sha512-data`: 128 for padding, 16 for padded size and 705 for the data shift
         traverse_hash(
             self,
             generator,

--- a/clar2wasm/tests/standard/property_tests.rs
+++ b/clar2wasm/tests/standard/property_tests.rs
@@ -524,6 +524,7 @@ fn prop_sha256_buff() {
         300,
         END_OF_STANDARD_DATA as i32,
         32,
+        2048,
         |buf| Sha256Sum::from_data(buf).as_bytes().to_vec(),
     )
 }
@@ -535,6 +536,7 @@ fn prop_sha256_int_on_signed() {
         2048,
         END_OF_STANDARD_DATA as i32,
         32,
+        2048,
         |n| Sha256Sum::from_data(&n.to_le_bytes()).as_bytes().to_vec(),
     )
 }
@@ -546,6 +548,7 @@ fn prop_sha256_int_on_unsigned() {
         2048,
         END_OF_STANDARD_DATA as i32,
         32,
+        2048,
         |n| Sha256Sum::from_data(&n.to_le_bytes()).as_bytes().to_vec(),
     )
 }
@@ -559,6 +562,7 @@ fn prop_hash160_buff() {
         300,
         END_OF_STANDARD_DATA as i32,
         20,
+        2048,
         |buf| Hash160::from_data(buf).as_bytes().to_vec(),
     )
 }
@@ -570,6 +574,7 @@ fn prop_hash160_int_on_signed() {
         2048,
         END_OF_STANDARD_DATA as i32,
         20,
+        2048,
         |n| Hash160::from_data(&n.to_le_bytes()).as_bytes().to_vec(),
     )
 }
@@ -581,6 +586,7 @@ fn prop_hash160_int_on_unsigned() {
         2048,
         END_OF_STANDARD_DATA as i32,
         20,
+        2048,
         |n| Hash160::from_data(&n.to_le_bytes()).as_bytes().to_vec(),
     )
 }
@@ -643,6 +649,7 @@ fn prop_sha512_buff() {
         300,
         END_OF_STANDARD_DATA as i32,
         64,
+        2048,
         |buf| Sha512Sum::from_data(buf).as_bytes().to_vec(),
     )
 }
@@ -654,6 +661,7 @@ fn prop_sha512_int_on_signed() {
         2048,
         END_OF_STANDARD_DATA as i32,
         64,
+        2048,
         |n| Sha512Sum::from_data(&n.to_le_bytes()).as_bytes().to_vec(),
     )
 }
@@ -665,6 +673,7 @@ fn prop_sha512_int_on_unsigned() {
         2048,
         END_OF_STANDARD_DATA as i32,
         64,
+        2048,
         |n| Sha512Sum::from_data(&n.to_le_bytes()).as_bytes().to_vec(),
     )
 }

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -2368,6 +2368,7 @@ fn sha256_buf() {
 
     // The offset where the result hash will be written to
     let res_offset = 3000i32;
+    let workspace_offset = 2048i32;
 
     // test with "Hello, World!", which requires only one pass
     let text = b"Hello, World!";
@@ -2382,6 +2383,7 @@ fn sha256_buf() {
                 Val::I32(END_OF_STANDARD_DATA as i32),
                 Val::I32(text.len() as i32),
                 res_offset.into(),
+                workspace_offset.into(),
             ],
             &mut result,
         )
@@ -2410,6 +2412,7 @@ fn sha256_buf() {
                 Val::I32(END_OF_STANDARD_DATA as i32),
                 Val::I32(text.len() as i32),
                 res_offset.into(),
+                workspace_offset.into(),
             ],
             &mut result,
         )
@@ -2438,6 +2441,7 @@ fn sha256_buf() {
                 Val::I32(END_OF_STANDARD_DATA as i32),
                 Val::I32(text.len() as i32),
                 res_offset.into(),
+                workspace_offset.into(),
             ],
             &mut result,
         )
@@ -2472,6 +2476,7 @@ fn sha256_int() {
 
     // The offset where the result hash will be written to
     let res_offset = 3000i32;
+    let workspace_offset = 2048i32;
 
     // Test on 0xfeedc0dedeadbeefcafed00dcafebabe
     sha256
@@ -2481,6 +2486,7 @@ fn sha256_int() {
                 Val::I64(0xcafed00dcafebabe_u64 as i64),
                 Val::I64(0xfeedc0dedeadbeef_u64 as i64),
                 res_offset.into(),
+                workspace_offset.into(),
             ],
             &mut result,
         )
@@ -2606,6 +2612,7 @@ fn hash160_buf() {
 
     // The offset where the result hash will be written to
     let res_offset = 3000i32;
+    let workspace_offset = 2048i32;
 
     // test with "Hello, World!"
     let text = b"Hello, World!";
@@ -2620,6 +2627,7 @@ fn hash160_buf() {
                 Val::I32(END_OF_STANDARD_DATA as i32),
                 Val::I32(text.len() as i32),
                 res_offset.into(),
+                workspace_offset.into(),
             ],
             &mut result,
         )
@@ -2647,6 +2655,7 @@ fn hash160_buf() {
                 Val::I32(END_OF_STANDARD_DATA as i32),
                 Val::I32(text.len() as i32),
                 res_offset.into(),
+                workspace_offset.into(),
             ],
             &mut result,
         )
@@ -2680,6 +2689,7 @@ fn hash160_int() {
 
     // The offset where the result hash will be written to
     let res_offset = 3000i32;
+    let workspace_offset = 2048i32;
 
     // Test on 0xfeedc0dedeadbeefcafed00dcafebabe
     hash160
@@ -2689,6 +2699,7 @@ fn hash160_int() {
                 Val::I64(0xcafed00dcafebabe_u64 as i64),
                 Val::I64(0xfeedc0dedeadbeef_u64 as i64),
                 res_offset.into(),
+                workspace_offset.into(),
             ],
             &mut result,
         )
@@ -3891,6 +3902,7 @@ fn sha512_buf() {
 
     // The offset where the result hash will be written to
     let res_offset = 3000i32;
+    let workspace_offset = 2048i32;
 
     // test with "Hello, World!", which requires only one pass
     let text = b"Hello, World!";
@@ -3905,6 +3917,7 @@ fn sha512_buf() {
                 Val::I32(END_OF_STANDARD_DATA as i32),
                 Val::I32(text.len() as i32),
                 res_offset.into(),
+                workspace_offset.into(),
             ],
             &mut result,
         )
@@ -3933,6 +3946,7 @@ fn sha512_buf() {
                 Val::I32(END_OF_STANDARD_DATA as i32),
                 Val::I32(text.len() as i32),
                 res_offset.into(),
+                workspace_offset.into(),
             ],
             &mut result,
         )
@@ -3962,6 +3976,7 @@ fn sha512_buf() {
                 Val::I32(END_OF_STANDARD_DATA as i32),
                 Val::I32(text.len() as i32),
                 res_offset.into(),
+                workspace_offset.into(),
             ],
             &mut result,
         )
@@ -3996,6 +4011,7 @@ fn sha512_int() {
 
     // The offset where the result hash will be written to
     let res_offset = 3000i32;
+    let workspace_offset = 2048i32;
 
     // Test on 0xfeedc0dedeadbeefcafed00dcafebabe
     sha256
@@ -4005,6 +4021,7 @@ fn sha512_int() {
                 Val::I64(0xcafed00dcafebabe_u64 as i64),
                 Val::I64(0xfeedc0dedeadbeef_u64 as i64),
                 res_offset.into(),
+                workspace_offset.into(),
             ],
             &mut result,
         )

--- a/clar2wasm/tests/standard/utils.rs
+++ b/clar2wasm/tests/standard/utils.rs
@@ -449,6 +449,7 @@ prop_compose! {
         }
 }
 
+#[allow(clippy::too_many_arguments)]
 /// Tests a Wasm hashing function `func_name` and compares its output to the output of `reference_function`.
 /// The buffers tested will be written in memory at offset `data_offset` and can have a length up to `data_max_length`.
 /// The output of the Wasm function will be written in memory on `result_offset` with length `result_length`.
@@ -460,6 +461,7 @@ pub(crate) fn test_on_buffer_hash(
     data_max_length: usize,
     result_offset: i32,
     result_length: i32,
+    workspace_offset: i32,
     reference_function: impl Fn(&[u8]) -> Vec<u8>,
 ) {
     debug_assert!(stack_pointer >= 0);
@@ -492,7 +494,7 @@ pub(crate) fn test_on_buffer_hash(
 
         fun.call(
             store.borrow_mut().deref_mut(),
-            &[offset.into(), len.into(), result_offset.into()],
+            &[offset.into(), len.into(), result_offset.into(), workspace_offset.into()],
             &mut res
         ).unwrap_or_else(|_| panic!("call to {func_name} failed"));
 
@@ -515,6 +517,7 @@ fn test_on_integer_hash(
     stack_pointer: i32,
     result_offset: i32,
     result_length: i32,
+    workspace_offset: i32,
     reference_function: impl Fn(i128) -> Vec<u8>,
 ) {
     debug_assert!(result_offset >= 0);
@@ -545,7 +548,7 @@ fn test_on_integer_hash(
 
             fun.call(
                 store.borrow_mut().deref_mut(),
-                &[n.low().into(), n.high().into(), result_offset.into()],
+                &[n.low().into(), n.high().into(), result_offset.into(), workspace_offset.into()],
                 &mut res
             ).unwrap_or_else(|_| panic!("call to {func_name} failed"));
             assert_eq!(res[0].unwrap_i32(), result_offset);
@@ -567,6 +570,7 @@ pub(crate) fn test_on_int_hash(
     stack_pointer: i32,
     result_offset: i32,
     result_length: i32,
+    workspace_offset: i32,
     reference_function: impl Fn(i128) -> Vec<u8>,
 ) {
     test_on_integer_hash(
@@ -575,6 +579,7 @@ pub(crate) fn test_on_int_hash(
         stack_pointer,
         result_offset,
         result_length,
+        workspace_offset,
         reference_function,
     )
 }
@@ -588,6 +593,7 @@ pub(crate) fn test_on_uint_hash(
     stack_pointer: i32,
     result_offset: i32,
     result_length: i32,
+    workspace_offset: i32,
     reference_function: impl Fn(i128) -> Vec<u8>,
 ) {
     test_on_integer_hash(
@@ -596,6 +602,7 @@ pub(crate) fn test_on_uint_hash(
         stack_pointer,
         result_offset,
         result_length,
+        workspace_offset,
         reference_function,
     )
 }


### PR DESCRIPTION
This PR refactors the memory management for hashing functions (sha256, sha512, and hash160) by introducing a dedicated workspace for each function.

Instead of allocating memory every time a hash is computed, each function now allocates its workspace once during initialization. The memory location for each workspace is stored and reused, improving performance and reducing allocation overhead.

Closes: #645 