### PR TITLE
Chore: clippy 1.89

### DIFF
--- a/clar2wasm/Cargo.toml
+++ b/clar2wasm/Cargo.toml
@@ -59,3 +59,6 @@ path = "src/bin/crosscheck.rs"
 [[bench]]
 name = "comparison"
 harness = false
+
+[lints.clippy]
+result_large_err = "allow"


### PR DESCRIPTION
The new lint "result_large_err" gave a lot of warnings due to stacks-core error types.

Here is a copy-paste of the comment I wrote on slack about it:
```
Hi people of Clarity-Wasm,
With the new version of Rust come the new clippy warnings. In this case it's massive: they added a check for [LLLLAAARRRGGGGEEEE error variants in `Result`](https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err) and the errors we are pulling from stack-core are all flagged by this lint.
Problem is: we cannot just box the errors and call it a day, since we implement some traits where the methods need to return those large variants.
I propose we just add a flag to ignore this lint and let the people who deal with stacks-core clippyness fix it for us.
The alternative is the create a struct such as struct ClarityError(Box<clarity::vm::errors::Error>) and use these wherever we can and add #[allow(...)] for the places where we can't use it.
I strongly would prefer to ignore it. Would everyone be okay with this, or should we fix it internally?
```

This PR ignores the new lint by adding a new section in _Cargo.toml_ .