### PR TITLE
Duck-typing Part II : Filter Reloaded

### DIFF
--- a/clar2wasm/src/duck_type.rs
+++ b/clar2wasm/src/duck_type.rs
@@ -10,16 +10,21 @@ use crate::wasm_utils::get_type_in_memory_size;
 impl WasmGenerator {
     /// Converts the representation of a Value on top of the stack from a type to another type. The Value keeps the
     /// same value in the end, only its representation in locals and memory differs.
+    /// This is a no-op if both types are identical.
     ///
     /// The original and target types should be "somewhat compatible" and validated by the typechecker
     /// for this function to succeed.
-    #[allow(dead_code)]
     pub(crate) fn duck_type(
         &mut self,
         builder: &mut InstrSeqBuilder,
         og_ty: &TypeSignature,
         target_ty: &TypeSignature,
     ) -> Result<(), GeneratorError> {
+        // This is a no-op if both types are identical
+        if og_ty == target_ty {
+            return Ok(());
+        }
+
         let former_stack_pointer = {
             let needed_workspace = dt_needed_workspace(target_ty);
             (needed_workspace > 0).then(|| {

--- a/clar2wasm/src/lib.rs
+++ b/clar2wasm/src/lib.rs
@@ -163,40 +163,6 @@ fn typechecker_workaround(ast: &ContractAST, contract_analysis: &mut ContractAna
             .and_then(|first| first.match_atom())
             .map(|atom| atom.as_str())
         {
-            Some("filter") => {
-                let Some(func_name) = expr.match_list().and_then(|l| l[1].match_atom()) else {
-                    continue;
-                };
-
-                let entry_type = match contract_analysis
-                    .get_private_function(func_name.as_str())
-                    .or(contract_analysis.get_read_only_function_type(func_name.as_str()))
-                {
-                    Some(clarity::vm::types::FunctionType::Fixed(FixedFunction {
-                        args, ..
-                    })) => args[0].signature.clone(),
-                    _ => continue,
-                };
-                let max_len = match contract_analysis
-                    .type_map
-                    .as_ref()
-                    .and_then(|ty| ty.get_type(expr))
-                {
-                    Some(TypeSignature::SequenceType(SequenceSubtype::ListType(l))) => {
-                        l.get_max_len()
-                    }
-                    _ => continue,
-                };
-                match (
-                    ListTypeData::new_list(entry_type, max_len),
-                    contract_analysis.type_map.as_mut(),
-                ) {
-                    (Ok(list_type), Some(tmap)) => {
-                        tmap.overwrite_type(expr, TypeSignature::from(list_type))
-                    }
-                    _ => continue,
-                }
-            }
             Some("fold") => {
                 // in the case of fold we need to override the type of the argument list
 

--- a/clar2wasm/src/words/conditionals.rs
+++ b/clar2wasm/src/words/conditionals.rs
@@ -1034,7 +1034,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "See issue #488"]
     fn filter_result_read_only_double_workaround() {
         let snippet = "
 (define-read-only (is-even? (x int))
@@ -1062,6 +1061,21 @@ mod tests {
 )
 (filter is-dash 0x612d62)",
             Ok(Some(Value::buff_from_byte(0x2d))),
+        );
+    }
+
+    #[test]
+    fn filter_with_different_types_for_predicates() {
+        crosscheck(
+            "
+            (define-private (foo (a (response int bool))) (and (is-ok a) (< (unwrap-panic a) 100)))
+            (define-private (bar (a (response int uint))) (and (is-ok a) (> (unwrap-panic a) 42)))
+
+            (filter bar (filter foo (list (ok 1) (ok 50))))
+        ",
+            Ok(Some(
+                Value::cons_list_unsanitized(vec![Value::okay(Value::Int(50)).unwrap()]).unwrap(),
+            )),
         );
     }
 

--- a/clar2wasm/src/words/conditionals.rs
+++ b/clar2wasm/src/words/conditionals.rs
@@ -205,8 +205,9 @@ impl ComplexWord for Filter {
         args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
         check_args!(generator, builder, 2, args.len(), ArgumentCountCheck::Exact);
-
         self.charge(generator, builder, 0)?;
+
+        let memory = generator.get_memory()?;
 
         let discriminator = args.get_name(0)?;
         let sequence = args.get_expr(1)?;
@@ -232,29 +233,13 @@ impl ComplexWord for Filter {
         // Setup neccesary locals for the operations.
         let input_len = generator.module.locals.add(ValType::I32);
         let input_offset = generator.module.locals.add(ValType::I32);
-        let input_end = generator.module.locals.add(ValType::I32);
         let output_len = generator.module.locals.add(ValType::I32);
 
-        builder
-            // [ input_offset, input_len ]
-            .local_set(input_len)
-            // [ input_offset ]
-            .local_tee(input_offset)
-            // [ input_offset ]
-            .local_get(input_len)
-            // [ input_offset, input_len ]
-            .binop(ir::BinaryOp::I32Add)
-            // [ input_end ]
-            .local_set(input_end);
-        // [ ]
-        // now we have an empty stack, and three initialized locals
+        // save list (offset, length) to locals
+        builder.local_set(input_len).local_set(input_offset);
 
-        // reserve space for the length of the output list
+        // reserve space for the output list
         let (output_offset, _) = generator.create_call_stack_local(builder, &ty, false, true);
-
-        let memory = generator.get_memory()?;
-
-        let mut loop_result = Ok(());
 
         let mut loop_ = builder.dangling_instr_seq(None);
         let loop_id = loop_.id();
@@ -278,83 +263,56 @@ impl ComplexWord for Filter {
             }
         };
 
-        // Stack now contains the value read from memory, note that this can be multiple values in case of
-        // sequences.
-
-        // [ Value ]
-
-        // call the discriminator
-
         if let Some(simple) = words::lookup_simple(discriminator) {
             // Call simple builtin
-            loop_result = simple.visit(
+            simple.visit(
                 generator,
                 &mut loop_,
                 &[TypeSignature::BoolType],
                 &TypeSignature::BoolType,
-            );
+            )?;
         } else {
             // user defined
             loop_.call(generator.func_by_name(discriminator.as_str()));
         }
         // [ Discriminator result (bool) ]
 
-        let mut success_branch = loop_.dangling_instr_seq(None);
-        let succ_id = success_branch.id();
+        loop_.if_else(
+            None,
+            |then| {
+                // copy value to result sequence
+                then.local_get(output_offset)
+                    .local_get(output_len)
+                    .binop(ir::BinaryOp::I32Add)
+                    .local_get(input_offset)
+                    .i32_const(elem_size)
+                    .memory_copy(memory, memory);
 
-        // on success, increment length and copy value
-        // memory.copy takes source, destination and size in push order
-        // (reverse on stack)
-
-        success_branch
-            // []
-            .local_get(output_offset)
-            // [ output_ofs ]
-            .local_get(output_len)
-            // [ output_ofs, output_len ]
-            .binop(ir::BinaryOp::I32Add)
-            // [ output_write_pos ]
-            .local_get(input_offset)
-            // [ output_write_pos, input_offset ]
-            .i32_const(elem_size)
-            // [ output_write_pos, input_offset, element_size ]
-            .memory_copy(memory, memory)
-            // [  ]
-            .local_get(output_len)
-            // [ output_len ]
-            .i32_const(elem_size)
-            // [ output_len, elem_size ]
-            .binop(ir::BinaryOp::I32Add)
-            // [ new_output_len ]
-            .local_set(output_len);
-        // [  ]
-
-        // fail branch is a no-op (FIXME there is most certainly a better way to do this)
-
-        let fail_branch = loop_.dangling_instr_seq(None);
-        let fail_id = fail_branch.id();
-
-        loop_.instr(ir::IfElse {
-            consequent: succ_id,
-            alternative: fail_id,
-        });
+                // increment the size of result sequence
+                then.local_get(output_len)
+                    .i32_const(elem_size)
+                    .binop(ir::BinaryOp::I32Add)
+                    .local_set(output_len);
+            },
+            |_else| {},
+        );
 
         // increment offset, leaving the new offset on the stack for the end check
         loop_
             .local_get(input_offset)
             .i32_const(elem_size)
             .binop(ir::BinaryOp::I32Add)
-            .local_tee(input_offset);
+            .local_set(input_offset);
 
         // Loop if we haven't reached the end of the sequence
         loop_
-            .local_get(input_end)
-            .binop(ir::BinaryOp::I32LtU)
+            .local_get(input_len)
+            .i32_const(elem_size)
+            .binop(ir::BinaryOp::I32Sub)
+            .local_tee(input_len)
             .br_if(loop_id);
 
         builder.instr(Loop { seq: loop_id });
-
-        loop_result?;
 
         builder.local_get(output_offset);
         builder.local_get(output_len);


### PR DESCRIPTION
This PR adds the duck-typing in `filter`.

This PR comes with 

- a small refactoring of `filter`'s `visit`
- adding the duck-typing part where we use the predicate on the value
- removing the dreadful `typechecker_workaround` part for filter
- de-ignoring the test `filter_result_read_only_double_workaround` that depended on #488
- adding the test from #608

Fixes #488 
Fixes #608

Will come next the usage of duck-typing in `fold` so that we can definitely remove `typechecker_workaround` and next will come proptests to harden the duck-typing algorithm (mostly on lists which are still untested).