### PR TITLE
Duck typing: making it work for lists

### DIFF
--- a/clar2wasm/src/duck_type.rs
+++ b/clar2wasm/src/duck_type.rs
@@ -246,6 +246,7 @@ fn dt_needed_workspace(ty: &TypeSignature) -> u32 {
         }
         TypeSignature::TupleType(tup) => tup.get_type_map().values().map(dt_needed_workspace).sum(),
         TypeSignature::SequenceType(SequenceSubtype::ListType(_)) => {
+            // we need the full capacity for a list in memory except for its actual offset and length which will be on the stack
             get_type_in_memory_size(ty, true) as u32 - 8
         }
         _ => 0,


### PR DESCRIPTION
Despite what I said earlier, it was absolutely possible to test lists directly in unit tests for the duck typing. 

This PR adds the needed framework for that, two tests and multiple bug fixes in the code.

I also intended to remove the `ensure_workspace` since it could lead to bugs in case of `contract-call?`'s, but I was interrupted by #678 . This issue needs to be solved so that I can see how we will make the final usage of the duck typing and I can decide how to adapt it to pre-allocate a workspace.