### PR TITLE
Fixes for `append` and `replace-at?`

### DIFF
--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -1865,6 +1865,19 @@ mod tests {
     }
 
     #[test]
+    fn append_with_as_max_len() {
+        crosscheck(
+            "
+                (define-data-var lst (list 20 int) (list))
+                (as-max-len? (append (var-get lst) 42) u20)
+            ",
+            Ok(Some(
+                Value::some(Value::cons_list_unsanitized(vec![Value::Int(42)]).unwrap()).unwrap(),
+            )),
+        )
+    }
+
+    #[test]
     fn test_fold_sub() {
         crosscheck(
             r#"

--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -2511,6 +2511,20 @@ mod tests {
         use super::*;
 
         #[test]
+        fn replace_at_with_as_max_len() {
+            crosscheck(
+                "
+                (define-data-var lst (list 20 int) (list 1))
+                (as-max-len? (unwrap-panic (replace-at? (var-get lst) u0 42)) u20)
+            ",
+                Ok(Some(
+                    Value::some(Value::cons_list_unsanitized(vec![Value::Int(42)]).unwrap())
+                        .unwrap(),
+                )),
+            )
+        }
+
+        #[test]
         fn test_map_mixed() {
             crosscheck(
                 r#"

--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -1892,14 +1892,14 @@ mod tests {
     }
 
     #[test]
-    fn append_with_as_max_len() {
+    fn append_with_different_length_and_max_length() {
         crosscheck(
             "
                 (define-data-var lst (list 20 int) (list))
-                (as-max-len? (append (var-get lst) 42) u20)
+                (append (var-get lst) 42)
             ",
             Ok(Some(
-                Value::some(Value::cons_list_unsanitized(vec![Value::Int(42)]).unwrap()).unwrap(),
+                Value::cons_list_unsanitized(vec![Value::Int(42)]).unwrap(),
             )),
         )
     }
@@ -2524,11 +2524,11 @@ mod tests {
         use super::*;
 
         #[test]
-        fn replace_at_with_as_max_len() {
+        fn replace_at_with_different_length_and_max_length() {
             crosscheck(
                 "
                 (define-data-var lst (list 20 int) (list 1))
-                (as-max-len? (unwrap-panic (replace-at? (var-get lst) u0 42)) u20)
+                (replace-at? (var-get lst) u0 42)
             ",
                 Ok(Some(
                     Value::some(Value::cons_list_unsanitized(vec![Value::Int(42)]).unwrap())


### PR DESCRIPTION
While working on #678 , I noticed the problem didn't come from the implementation of `fold`, but from `append`. 

`append` used the maximum length from the type as the result length instead of using the actual length of the list.

A quick look in the rest of the file and I noticed that `replace-at?` suffered the same issue.

This PR fixes those two functions and adapt the cost tracker with the changes on their algorithms.

Closes #678