### PR TITLE
`get-block-info?` missing property `vrf-seed`

### DIFF
--- a/clar2wasm/src/words/blockinfo.rs
+++ b/clar2wasm/src/words/blockinfo.rs
@@ -802,11 +802,17 @@ mod tests {
         assert_eq!(result, Some(Value::some(Value::UInt(0)).unwrap()));
     }
 
+    #[test]
+    fn get_block_info_vrf_seed() {
         let mut env = TestEnvironment::new(
             clarity::types::StacksEpochId::Epoch25,
+            clarity::vm::ClarityVersion::Clarity2,
+        );
         env.advance_chain_tip(1);
         let result = env
             .evaluate("(get-block-info? vrf-seed u0)")
+            .expect("Failed to init contract.");
+        assert_eq!(
             result,
             Some(Value::some(Value::buff_from([0; 32].to_vec()).unwrap()).unwrap())
         );

--- a/clar2wasm/src/words/blockinfo.rs
+++ b/clar2wasm/src/words/blockinfo.rs
@@ -81,6 +81,9 @@ impl ComplexWord for GetBlockInfo {
                     generator.func_by_name("stdlib.get_block_info_miner_spend_winner_property"),
                 );
             }
+            "vrf-seed" => {
+                builder.call(generator.func_by_name("stdlib.get_block_info_vrf_seed_property"));
+            }
             _ => {
                 return Err(GeneratorError::InternalError(format!(
                     "{self:?} does not have a property of type {}",

--- a/clar2wasm/src/words/blockinfo.rs
+++ b/clar2wasm/src/words/blockinfo.rs
@@ -802,6 +802,16 @@ mod tests {
         assert_eq!(result, Some(Value::some(Value::UInt(0)).unwrap()));
     }
 
+        let mut env = TestEnvironment::new(
+            clarity::types::StacksEpochId::Epoch25,
+        env.advance_chain_tip(1);
+        let result = env
+            .evaluate("(get-block-info? vrf-seed u0)")
+            result,
+            Some(Value::some(Value::buff_from([0; 32].to_vec()).unwrap()).unwrap())
+        );
+    }
+
     #[test]
     fn get_burn_block_info_less_than_two_args() {
         let result = evaluate("(get-burn-block-info? id-header-hash)");


### PR DESCRIPTION
This PR adds `vrf-seed` property to the `get-block-info?` function.

fixes: #670 & #687 