### PR TITLE
allow call to some private functions

### DIFF
--- a/clar2wasm/src/words/functions.rs
+++ b/clar2wasm/src/words/functions.rs
@@ -41,7 +41,13 @@ impl ComplexWord for DefinePrivateFunction {
 
         let body = args.get_expr(1)?;
 
-        generator.traverse_define_function(builder, name, body, FunctionKind::Private)?;
+        // Certain special contracts, such as PoX and signer contracts, invoke private functions directly within the contract.
+        // Additionally, development tools may call private functions during contract testing.
+        // Therefore, to support these use cases, private functions must also be exported by the WebAssembly module.
+        let function_id =
+            generator.traverse_define_function(builder, name, body, FunctionKind::Private)?;
+        generator.module.exports.add(name.as_str(), function_id);
+
         Ok(())
     }
 }

--- a/clar2wasm/src/words/functions.rs
+++ b/clar2wasm/src/words/functions.rs
@@ -493,4 +493,17 @@ mod tests {
             ))),
         )
     }
+
+    #[test]
+    fn private_function_direct_call() {
+        crosscheck(
+            r#"
+              (define-constant BAR 42)
+              (define-public (get-bar) (ok BAR))
+              (define-private (im-a-private-func) (get-bar))
+              (im-a-private-func)
+            "#,
+            evaluate("(ok 42)"),
+        )
+    }
 }

--- a/clar2wasm/tests/contracts/private-call.clar
+++ b/clar2wasm/tests/contracts/private-call.clar
@@ -1,0 +1,6 @@
+(define-constant BAR 42)
+
+(define-public (get-bar)
+    (ok BAR))
+
+(define-private (im-a-private-func) (get-bar))

--- a/clar2wasm/tests/lib_tests.rs
+++ b/clar2wasm/tests/lib_tests.rs
@@ -4205,3 +4205,13 @@ test_contract_call_response!(
         assert_eq!(*response.data, Value::Int(42));
     }
 );
+
+test_contract_call_response!(
+    test_private_call,
+    "private-call",
+    "im-a-private-func",
+    |response: ResponseData| {
+        assert!(response.committed);
+        assert_eq!(*response.data, Value::Int(42));
+    }
+);


### PR DESCRIPTION
Certain special contracts, such as PoX and signer contracts, invoke private functions directly within the contract.
To support these use cases, private functions must also be exported by the WebAssembly module.