### PR TITLE
Reimplementation of `try!`

### DIFF
--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -1423,7 +1423,6 @@ impl WasmGenerator {
                 }
                 last_ty = Some(ty.clone());
             }
-            eprintln!("LAST TYPE: {last_ty:?}");
             self.traverse_expr(builder, stmt)?;
         }
 

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -50,7 +50,7 @@ pub struct WasmGenerator {
     /// Map constants to an offset in the literal memory.
     pub(crate) constants: HashMap<String, u32>,
     /// The current function body block, used for early exit
-    early_return_block_id: Option<InstrSeqId>,
+    pub(crate) early_return_block_id: Option<InstrSeqId>,
     /// The type of the current function.
     pub(crate) current_function_type: Option<FixedFunction>,
     /// The types of defined data-vars

--- a/clar2wasm/src/words/bindings.rs
+++ b/clar2wasm/src/words/bindings.rs
@@ -81,6 +81,7 @@ impl ComplexWord for Let {
             expr_ty,
         )?;
 
+        // we introdue a new scope for the functions that can return a ShortResult.
         let former_scope = generator.early_return_block_id;
         let mut let_scope = builder.dangling_instr_seq(return_ty);
         let scope_id = let_scope.id();
@@ -89,9 +90,10 @@ impl ComplexWord for Let {
         // Traverse the body
         generator.traverse_statement_list(&mut let_scope, &args[1..])?;
 
+        // we link the new scope to the previous one.
         builder.instr(Block { seq: scope_id });
 
-        // Restore the named locals
+        // Restore the named locals and previous scope.
         generator.bindings = saved_locals;
         generator.early_return_block_id = former_scope;
 

--- a/clar2wasm/src/words/bindings.rs
+++ b/clar2wasm/src/words/bindings.rs
@@ -103,10 +103,8 @@ impl ComplexWord for Let {
 
 #[cfg(test)]
 mod tests {
-    use clarity::vm::{
-        errors::{Error, ShortReturnType},
-        Value,
-    };
+    use clarity::vm::errors::{Error, ShortReturnType};
+    use clarity::vm::Value;
 
     use crate::tools::{crosscheck, crosscheck_compare_only, crosscheck_expect_failure, evaluate};
 

--- a/clar2wasm/src/words/bindings.rs
+++ b/clar2wasm/src/words/bindings.rs
@@ -1,8 +1,9 @@
 use clarity::vm::{ClarityName, SymbolicExpression};
+use walrus::ir::{Block, InstrSeqType};
 
 use crate::check_args;
 use crate::cost::WordCharge;
-use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
+use crate::wasm_generator::{clar2wasm_ty, ArgumentsExt, GeneratorError, WasmGenerator};
 use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
 use crate::words::{ComplexWord, Word};
 
@@ -67,6 +68,10 @@ impl ComplexWord for Let {
             .get_expr_type(_expr)
             .ok_or_else(|| GeneratorError::TypeError("let expression should be typed".to_owned()))?
             .clone();
+
+        let return_ty =
+            InstrSeqType::new(&mut generator.module.types, &[], &clar2wasm_ty(&expr_ty));
+
         generator.set_expr_type(
             args.last().ok_or_else(|| {
                 GeneratorError::TypeError(
@@ -76,11 +81,19 @@ impl ComplexWord for Let {
             expr_ty,
         )?;
 
+        let former_scope = generator.early_return_block_id;
+        let mut let_scope = builder.dangling_instr_seq(return_ty);
+        let scope_id = let_scope.id();
+        generator.early_return_block_id = Some(scope_id);
+
         // Traverse the body
-        generator.traverse_statement_list(builder, &args[1..])?;
+        generator.traverse_statement_list(&mut let_scope, &args[1..])?;
+
+        builder.instr(Block { seq: scope_id });
 
         // Restore the named locals
         generator.bindings = saved_locals;
+        generator.early_return_block_id = former_scope;
 
         Ok(())
     }
@@ -88,7 +101,10 @@ impl ComplexWord for Let {
 
 #[cfg(test)]
 mod tests {
-    use clarity::vm::Value;
+    use clarity::vm::{
+        errors::{Error, ShortReturnType},
+        Value,
+    };
 
     use crate::tools::{crosscheck, crosscheck_compare_only, crosscheck_expect_failure, evaluate};
 
@@ -168,5 +184,78 @@ mod tests {
 
         // Custom variable name duplicate
         crosscheck_expect_failure("(let ((a 2) (a 3)) (+ a a))");
+    }
+
+    #[test]
+    fn let_with_try_ok() {
+        let snippet = r#"
+            (let
+                ( (ok-val true) (err-no u42) )
+                (try! (if true (ok ok-val) (err err-no)))
+                "result"
+            )
+        "#;
+
+        crosscheck(
+            snippet,
+            Ok(Some(
+                Value::string_ascii_from_bytes(b"result".to_vec()).unwrap(),
+            )),
+        );
+    }
+
+    #[test]
+    fn let_with_try_err() {
+        let snippet = r#"
+            (let
+                ( (ok-val true) (err-no u42) )
+                (try! (if false (ok ok-val) (err err-no)))
+                "result"
+            )
+        "#;
+
+        crosscheck(
+            snippet,
+            Err(Error::ShortReturn(ShortReturnType::ExpectedValue(
+                Value::err_uint(42),
+            ))),
+        );
+    }
+
+    #[test]
+    fn let_with_try_in_function_ok() {
+        let snippet = r#"
+            (define-private (foo)
+                (let
+                    ( (ok-val true) (err-no u42) )
+                    (try! (if true (ok ok-val) (err err-no)))
+                    (ok "result")
+                )
+            )
+            (foo)
+        "#;
+
+        crosscheck(
+            snippet,
+            Ok(Some(
+                Value::okay(Value::string_ascii_from_bytes(b"result".to_vec()).unwrap()).unwrap(),
+            )),
+        );
+    }
+
+    #[test]
+    fn let_with_try_in_function_err() {
+        let snippet = r#"
+            (define-private (foo)
+                (let
+                    ( (ok-val true) (err-no u42) )
+                    (try! (if false (ok ok-val) (err err-no)))
+                    (ok "result")
+                )
+            )
+            (foo)
+        "#;
+
+        crosscheck(snippet, Ok(Some(Value::err_uint(42))));
     }
 }

--- a/clar2wasm/src/words/conditionals.rs
+++ b/clar2wasm/src/words/conditionals.rs
@@ -235,7 +235,7 @@ impl<'a> ShortReturnable<'a> {
                     )));
                 };
                 let (expected_ok_type, _expected_err_type) = expected_resp.as_ref();
-                add_placeholder_for_clarity_type(builder, expected_ok_type);
+                add_placeholder_for_clarity_type(builder, dbg!(expected_ok_type));
                 for &l in err_value {
                     builder.local_get(l);
                 }
@@ -1792,5 +1792,22 @@ mod tests {
         ";
 
         crosscheck(snippet, Ok(Some(Value::some(Value::err_uint(1)).unwrap())));
+    }
+
+    #[test]
+    fn nested_begin_with_try() {
+        let snippet = r#"
+            (define-private (foo)
+                (begin
+                    (begin
+                        (try! (if false (ok "hello") (err u5555)))
+                    )
+                    (ok true)
+                )
+            )
+            (foo)
+        "#;
+
+        crosscheck(snippet, Ok(Some(Value::err_uint(5555))));
     }
 }

--- a/clar2wasm/src/words/conditionals.rs
+++ b/clar2wasm/src/words/conditionals.rs
@@ -1666,10 +1666,10 @@ mod tests {
     #[test]
     fn try_something_in_fn_ok() {
         let snippet = "
-        (define-public (foo) 
+        (define-public (foo)
             (ok (try! (if true (ok true) (err u3))))
         )
-        
+
         (foo)
         ";
 
@@ -1679,13 +1679,69 @@ mod tests {
     #[test]
     fn try_something_in_fn_err() {
         let snippet = "
-        (define-public (foo) 
+        (define-public (foo)
             (ok (try! (if false (ok true) (err u3))))
         )
-        
+
         (foo)
         ";
 
         crosscheck(snippet, Ok(Some(Value::err_uint(3))));
+    }
+
+    #[test]
+    fn try_reponse_true() {
+        crosscheck(
+            "(try! (if true (ok true) (err u3)))",
+            Ok(Some(Value::Bool(true))),
+        )
+    }
+
+    #[test]
+    fn try_stx_transfer() {
+        crosscheck(
+            "(try! (stx-transfer? u100 'S1G2081040G2081040G2081040G208105NK8PE5 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM))",
+            Ok(Some(Value::Bool(true))),
+        )
+    }
+
+    #[test]
+    fn try_nested_response_true() {
+        crosscheck(
+            "(try! (if true (ok (try! (if true (ok true) (err u3)))) (err false)))",
+            Ok(Some(Value::Bool(true))),
+        )
+    }
+
+    #[test]
+    fn try_begin_nested() {
+        crosscheck(
+            "(begin (try! (if true (ok (try! (if true (ok true) (err u3)))) (err false))))",
+            Ok(Some(Value::Bool(true))),
+        )
+    }
+
+    #[test]
+    fn try_reponse_inside_funtion() {
+        crosscheck(
+            "(define-public (foo) (ok (try! (if true (ok true) (err u3))))) (foo)",
+            Ok(Some(Value::okay_true())),
+        )
+    }
+
+    #[test]
+    fn try_begin_response_inside_function() {
+        crosscheck(
+            "(define-public (foo) (begin (+ 1 2) (ok (try! (if true (ok true) (err u3)))))) (foo)",
+            Ok(Some(Value::okay_true())),
+        )
+    }
+
+    #[test]
+    fn try_mint_ft() {
+        crosscheck(
+            "(define-fungible-token wasm-token) (try! (ft-mint? wasm-token u1000 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM))",
+            Ok(Some(Value::Bool(true))),
+        )
     }
 }

--- a/clar2wasm/src/words/control_flow.rs
+++ b/clar2wasm/src/words/control_flow.rs
@@ -51,6 +51,7 @@ impl ComplexWord for Begin {
             ty,
         )?;
 
+        // we introdue a new scope for the functions that can return a ShortResult
         let return_ty = InstrSeqType::new(&mut generator.module.types, &[], &wasm_ty);
         let former_scope = generator.early_return_block_id;
 
@@ -60,6 +61,7 @@ impl ComplexWord for Begin {
 
         generator.traverse_statement_list(&mut begin_scope, args)?;
 
+        // we link the new scope to the previous one.
         builder.instr(Block { seq: scope_id });
         generator.early_return_block_id = former_scope;
 

--- a/clar2wasm/src/words/control_flow.rs
+++ b/clar2wasm/src/words/control_flow.rs
@@ -1,14 +1,12 @@
 use clarity::vm::types::TypeSignature;
 use clarity::vm::{ClarityName, SymbolicExpression};
-use walrus::ir::{Block, IfElse, InstrSeqType, UnaryOp};
+use walrus::ir::{IfElse, UnaryOp};
 
 use super::{ComplexWord, Word};
 use crate::check_args;
 use crate::cost::WordCharge;
 use crate::error_mapping::ErrorMap;
-use crate::wasm_generator::{
-    clar2wasm_ty, drop_value, ArgumentsExt, GeneratorError, WasmGenerator,
-};
+use crate::wasm_generator::{drop_value, ArgumentsExt, GeneratorError, WasmGenerator};
 use crate::wasm_utils::{check_argument_count, ArgumentCountCheck};
 
 #[derive(Debug)]
@@ -38,34 +36,16 @@ impl ComplexWord for Begin {
 
         self.charge(generator, builder, 0)?;
 
-        let ty = generator
-            .get_expr_type(expr)
-            .ok_or_else(|| GeneratorError::TypeError("begin must be typed".to_owned()))?
-            .clone();
-        let wasm_ty = clar2wasm_ty(&ty);
-
         generator.set_expr_type(
             args.last().ok_or_else(|| {
                 GeneratorError::TypeError("begin must have at least one arg".to_string())
             })?,
-            ty,
+            generator
+                .get_expr_type(expr)
+                .ok_or_else(|| GeneratorError::TypeError("begin must be typed".to_owned()))?
+                .clone(),
         )?;
-
-        // we introdue a new scope for the functions that can return a ShortResult
-        let return_ty = InstrSeqType::new(&mut generator.module.types, &[], &wasm_ty);
-        let former_scope = generator.early_return_block_id;
-
-        let mut begin_scope = builder.dangling_instr_seq(return_ty);
-        let scope_id = begin_scope.id();
-        generator.early_return_block_id = Some(scope_id);
-
-        generator.traverse_statement_list(&mut begin_scope, args)?;
-
-        // we link the new scope to the previous one.
-        builder.instr(Block { seq: scope_id });
-        generator.early_return_block_id = former_scope;
-
-        Ok(())
+        generator.traverse_statement_list(builder, args)
     }
 }
 

--- a/clar2wasm/tests/wasm-generation/conditionals.rs
+++ b/clar2wasm/tests/wasm-generation/conditionals.rs
@@ -143,9 +143,9 @@ proptest! {
             .prop_flat_map(|t| (PropValue::from_type(t.clone()), PropValue::from_type(t))),
     ) {
         let snippet = format!("
-            (define-private (foo) 
+            (define-private (foo)
                 (unwrap! (if true (err {err_val}) (ok {ok_val})) {throw_val})
-            ) 
+            )
             (foo)
         ");
 
@@ -162,9 +162,9 @@ proptest! {
             .prop_flat_map(|t| (PropValue::from_type(t.clone()), PropValue::from_type(t)))
     ) {
         let snippet = format!("
-            (define-private (foo) 
+            (define-private (foo)
                 (unwrap! (if true none (some {some_val})) {throw_val})
-            ) 
+            )
             (foo)
         ");
 
@@ -184,7 +184,7 @@ proptest! {
             .prop_flat_map(|t| (PropValue::from_type(t.clone()), PropValue::from_type(t))),
     ) {
         let snippet = format!(r#"
-            (begin 
+            (begin
                 (unwrap! (some {some_val}) {throw_val})
                 {val}
             )
@@ -206,7 +206,7 @@ proptest! {
             .prop_flat_map(|t| (PropValue::from_type(t.clone()), PropValue::from_type(t))),
     ) {
         let snippet = format!(r#"
-            (begin 
+            (begin
                 (unwrap! (if true none (some {some_val})) {throw_val})
                 {val}
             )
@@ -231,7 +231,7 @@ proptest! {
             .prop_flat_map(|t| (PropValue::from_type(t.clone()), PropValue::from_type(t))),
     ) {
         let snippet = format!(r#"
-            (begin 
+            (begin
                 (unwrap! (ok {ok_val}) {throw_val})
                 {val}
             )
@@ -254,7 +254,7 @@ proptest! {
             .prop_flat_map(|t| (PropValue::from_type(t.clone()), PropValue::from_type(t))),
     ) {
         let snippet = format!(r#"
-            (begin 
+            (begin
                 (unwrap! (if true (err {err_val}) (ok {ok_val})) {throw_val})
                 {val}
             )
@@ -276,12 +276,12 @@ proptest! {
             .prop_flat_map(|t| (PropValue::from_type(t.clone()), PropValue::from_type(t))),
     ) {
         let snippet = format!("
-            (define-private (foo) 
+            (define-private (foo)
                 (begin
                     (unwrap! (if true (err {err_val}) (ok {ok_val})) {throw_val})
                     {val}
                 )
-            ) 
+            )
             (foo)
         ");
 
@@ -301,12 +301,12 @@ proptest! {
             .prop_flat_map(|t| (PropValue::from_type(t.clone()), PropValue::from_type(t)))
     ) {
         let snippet = format!("
-            (define-private (foo) 
+            (define-private (foo)
                 (begin
                     (unwrap! (if true none (some {some_val})) {throw_val})
                     {val}
                 )
-            ) 
+            )
             (foo)
         ");
 
@@ -361,9 +361,9 @@ proptest! {
             .prop_flat_map(|t| (PropValue::from_type(t.clone()), PropValue::from_type(t)))
     ) {
         let snippet = format!("
-            (define-private (foo) 
+            (define-private (foo)
                 (unwrap-err! (if true (ok {ok_val}) (err {err_val})) {throw_val})
-            ) 
+            )
             (foo)
         ");
 
@@ -381,9 +381,9 @@ proptest! {
             .prop_flat_map(|t| (PropValue::from_type(t.clone()), PropValue::from_type(t))),
     ) {
         let snippet = format!("
-            (define-private (foo) 
+            (define-private (foo)
                 (unwrap-err! (if false (ok {ok_val}) (err {err_val})) {throw_val})
-            ) 
+            )
             (foo)
         ");
 
@@ -453,12 +453,12 @@ proptest! {
             .prop_flat_map(|t| (PropValue::from_type(t.clone()), PropValue::from_type(t))),
     ) {
         let snippet = format!("
-            (define-private (foo) 
+            (define-private (foo)
                 (begin
                     (unwrap-err! (if true (ok {ok_val}) (err {err_val})) {throw_val})
                     {val}
                 )
-            ) 
+            )
             (foo)
         ");
 
@@ -479,12 +479,12 @@ proptest! {
             .prop_flat_map(|t| (PropValue::from_type(t.clone()), PropValue::from_type(t))),
     ) {
         let snippet = format!("
-            (define-private (foo) 
+            (define-private (foo)
                 (begin
                     (unwrap-err! (if false (ok {ok_val}) (err {err_val})) {throw_val})
                     {val}
                 )
-            ) 
+            )
             (foo)
         ");
 

--- a/clar2wasm/tests/wasm-generation/conditionals.rs
+++ b/clar2wasm/tests/wasm-generation/conditionals.rs
@@ -1,12 +1,8 @@
 use clar2wasm::tools::{crosscheck, crosscheck_compare_only};
 use clarity::vm::errors::{Error, ShortReturnType};
-use clarity::vm::types::{
-    ListTypeData, ResponseData, SequenceData, SequenceSubtype, TypeSignature,
-};
+use clarity::vm::types::{ListTypeData, SequenceData, SequenceSubtype, TypeSignature};
 use clarity::vm::Value;
-use proptest::prelude::any;
-use proptest::proptest;
-use proptest::strategy::{Just, Strategy};
+use proptest::prelude::*;
 
 use crate::{prop_signature, type_string, PropValue};
 


### PR DESCRIPTION
This PR reimplements different functions due to the fact that they were generating `if` with different types for the `then` branch and the `else` branch.
The functions reimplemented are `try!`, `asserts!`, `unwrap!` and `unwrap-err!`.

A new enum `ShortReturnable` was added to handle the code generation of all the short-returnable situation.

A big amount of tests were added to the proptests, to make sure that the new implementation would work in all cases. It also showed that we had a need for a typechecker workaround in the unwrapping functions.

Fixes #705 
Fixes #573