### PR TITLE
Duck-typing for function calls

### DIFF
--- a/clar2wasm/src/words/conditionals.rs
+++ b/clar2wasm/src/words/conditionals.rs
@@ -235,7 +235,7 @@ impl<'a> ShortReturnable<'a> {
                     )));
                 };
                 let (expected_ok_type, _expected_err_type) = expected_resp.as_ref();
-                add_placeholder_for_clarity_type(builder, dbg!(expected_ok_type));
+                add_placeholder_for_clarity_type(builder, expected_ok_type);
                 for &l in err_value {
                     builder.local_get(l);
                 }

--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -264,7 +264,12 @@ impl ComplexWord for Fold {
             simple.visit(generator, &mut loop_, arg_types, &result_clar_ty)?;
         } else {
             // Call user defined function
-            generator.visit_call_user_defined(&mut loop_, &result_clar_ty, func)?;
+            generator.visit_call_user_defined(
+                &mut loop_,
+                func,
+                &result_clar_ty,
+                fold_func_ty.as_ref().map(|func_ty| &func_ty.acc_ty),
+            )?;
             // since the accumulator and the return type of the function could have different types, we need to duck-type.
             if let Some(tys) = &fold_func_ty {
                 generator.duck_type(&mut loop_, &tys.return_ty, &tys.acc_ty)?;
@@ -860,7 +865,7 @@ impl ComplexWord for Map {
             }
         } else {
             // Call user defined function.
-            generator.visit_call_user_defined(&mut loop_, return_element_type, fname)?;
+            generator.visit_call_user_defined(&mut loop_, fname, return_element_type, None)?;
         }
 
         // Write the result to the output sequence.


### PR DESCRIPTION
Issue #707 showed that a function return type could be different than the expected type from the caller.

This PR adds an optional parameter to `visit_call_user_defined` which is the type that the caller expects as a result and will be used with duck typing.

This PR had to refactor a bit the algorithm of `fold` to accommodate the changes.

This PR also has a fix for `map` which didn't use the duck-typing yet (+ a test showing its necessity).

And as a bonus, I removed a forgotten `dbg` in the code.

Fixes #707 