### PR TITLE
New function to compute the size of a serialized value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,7 @@ dependencies = [
  "assert_fs",
  "chrono",
  "clap",
+ "clar2wasm",
  "clarity",
  "criterion",
  "hex",

--- a/clar2wasm/Cargo.toml
+++ b/clar2wasm/Cargo.toml
@@ -27,8 +27,10 @@ pb = []
 test-clarity-v1 = []
 test-clarity-v2 = []
 test-clarity-v3 = []
+developer-mode = []
 
 [dev-dependencies]
+clar2wasm = {path = ".", features = ["developer-mode"]}
 criterion = "0.5"
 proptest = "1.2.0"
 num-integer = { version = "0.1.45", default-features = false }

--- a/clar2wasm/src/lib.rs
+++ b/clar2wasm/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate lazy_static;
-
 use clarity::types::StacksEpochId;
 use clarity::vm::analysis::{run_analysis, AnalysisDatabase, ContractAnalysis};
 use clarity::vm::ast::{build_ast_with_diagnostics, ContractAST};
@@ -27,6 +25,9 @@ pub mod tools;
 mod debug_msg;
 pub mod duck_type;
 mod error_mapping;
+
+#[cfg(feature = "developer-mode")]
+pub mod test_utils;
 
 // FIXME: This is copied from stacks-blockchain
 // Block limit in Stacks 2.1

--- a/clar2wasm/src/serialize.rs
+++ b/clar2wasm/src/serialize.rs
@@ -1254,3 +1254,53 @@ impl WasmGenerator {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use clarity::vm::{
+        types::{TupleData, TupleTypeSignature, TypeSignature},
+        Value,
+    };
+
+    use crate::wasm_generator::WasmGenerator;
+
+    fn test_serialization_size(value: Value, ty: TypeSignature) {
+        let mut gen = WasmGenerator::empty();
+
+        // since `serialization_size` push on the stack the value and the size,
+        // we'll expect a tuple {a: value, b: size}
+        let return_ty: TypeSignature = TupleTypeSignature::try_from(vec![
+            ("a".into(), ty.clone()),
+            ("b".into(), TypeSignature::UIntType),
+        ])
+        .unwrap()
+        .into();
+
+        gen.create_module(&return_ty, |gen, builder| {
+            gen.pass_value(builder, &value, &ty)
+                .expect("failed to write instructions for original value");
+
+            gen.serialization_size(builder, &ty)
+                .expect("failed to write serialization size instructions");
+
+            // we need to extend the u32 we get for the size into a uint
+            builder
+                .unop(walrus::ir::UnaryOp::I64ExtendUI32)
+                .i64_const(0);
+        });
+
+        let res = gen.execute_module(&return_ty);
+
+        let expected_size = value
+            .serialized_size()
+            .expect("could not compute serialized size");
+        let expected = TupleData::from_data(vec![
+            ("a".into(), value),
+            ("b".into(), Value::UInt(expected_size as u128)),
+        ])
+        .unwrap()
+        .into();
+
+        assert_eq!(res, expected);
+    }
+}

--- a/clar2wasm/src/serialize.rs
+++ b/clar2wasm/src/serialize.rs
@@ -1262,10 +1262,10 @@ impl WasmGenerator {
 
 #[cfg(test)]
 mod tests {
-    use clarity::vm::{
-        types::{PrincipalData, SequenceSubtype, TupleData, TupleTypeSignature, TypeSignature},
-        Value,
+    use clarity::vm::types::{
+        PrincipalData, SequenceSubtype, TupleData, TupleTypeSignature, TypeSignature,
     };
+    use clarity::vm::Value;
 
     use crate::wasm_generator::WasmGenerator;
 

--- a/clar2wasm/src/serialize.rs
+++ b/clar2wasm/src/serialize.rs
@@ -1254,7 +1254,11 @@ impl WasmGenerator {
                     builder.binop(BinaryOp::I32Add);
                 }
             }
-            _ => unimplemented!(),
+            _ => {
+                return Err(GeneratorError::TypeError(format!(
+                    "Unserializable type found for serialization size computation: {ty}"
+                )))
+            }
         }
         Ok(())
     }

--- a/clar2wasm/src/test_utils.rs
+++ b/clar2wasm/src/test_utils.rs
@@ -15,6 +15,7 @@ use crate::wasm_generator::{
 use crate::wasm_utils::{placeholder_for_type, wasm_to_clarity_value};
 
 impl WasmGenerator {
+    /// Creates an empty WasmGenerator.
     pub fn empty() -> Self {
         let empty_analysis = ContractAnalysis::new(
             QualifiedContractIdentifier::transient(),
@@ -27,6 +28,7 @@ impl WasmGenerator {
             .expect("failed to build WasmGenerator for empty contract")
     }
 
+    /// Adds the instructions to have a value of some type on top of the stack.
     pub fn pass_value(
         &mut self,
         builder: &mut InstrSeqBuilder,
@@ -147,6 +149,9 @@ impl WasmGenerator {
         }
     }
 
+    /// Creates a module containing a `.top-level` function which will contain the instructions
+    /// passed in the closure `add_instruction`. This closure takes as argument the current
+    /// generator and the current builder.
     pub fn create_module(
         &mut self,
         return_ty: &TypeSignature,
@@ -165,9 +170,9 @@ impl WasmGenerator {
             walrus::GlobalKind::Local(walrus::InitExpr::Value(walrus::ir::Value::I32(20000)));
     }
 
+    /// Compiles and executes the current module and returns the value on top of the stack.
+    /// If the value isn't of the type passed as a parameter, the function panics.
     pub fn execute_module(&mut self, return_ty: &TypeSignature) -> Value {
-        std::fs::write("debug.wasm", self.module.emit_wasm()).unwrap();
-
         let engine = Engine::default();
         let mut store = Store::new(&engine, ());
         let linker = dummy_linker(&engine).expect("failed to create linker");

--- a/clar2wasm/src/test_utils.rs
+++ b/clar2wasm/src/test_utils.rs
@@ -1,0 +1,210 @@
+use clarity::types::StacksEpochId;
+use clarity::vm::analysis::ContractAnalysis;
+use clarity::vm::costs::LimitedCostTracker;
+use clarity::vm::types::{
+    QualifiedContractIdentifier, SequenceData, SequenceSubtype, TypeSignature,
+};
+use clarity::vm::{ClarityVersion, Value};
+use walrus::{FunctionBuilder, InstrSeqBuilder};
+use wasmtime::{Engine, Module, Store};
+
+use crate::linker::dummy_linker;
+use crate::wasm_generator::{
+    add_placeholder_for_clarity_type, clar2wasm_ty, GeneratorError, WasmGenerator,
+};
+use crate::wasm_utils::{placeholder_for_type, wasm_to_clarity_value};
+
+impl WasmGenerator {
+    pub fn empty() -> Self {
+        let empty_analysis = ContractAnalysis::new(
+            QualifiedContractIdentifier::transient(),
+            vec![],
+            LimitedCostTracker::Free,
+            StacksEpochId::latest(),
+            ClarityVersion::latest(),
+        );
+        WasmGenerator::new(empty_analysis)
+            .expect("failed to build WasmGenerator for empty contract")
+    }
+
+    pub fn pass_value(
+        &mut self,
+        builder: &mut InstrSeqBuilder,
+        value: &Value,
+        ty: &TypeSignature,
+    ) -> Result<(), GeneratorError> {
+        match value {
+            Value::Bool(b) => {
+                builder.i32_const(*b as i32);
+                Ok(())
+            }
+            Value::Int(i) => {
+                builder.i64_const((i & 0xFFFFFFFFFFFFFFFF) as i64);
+                builder.i64_const(((i >> 64) & 0xFFFFFFFFFFFFFFFF) as i64);
+                Ok(())
+            }
+            Value::UInt(u) => {
+                builder.i64_const((u & 0xFFFFFFFFFFFFFFFF) as i64);
+                builder.i64_const(((u >> 64) & 0xFFFFFFFFFFFFFFFF) as i64);
+                Ok(())
+            }
+            Value::Sequence(SequenceData::String(s)) => {
+                let (offset, len) = self.add_clarity_string_literal(s)?;
+                builder.i32_const(offset as i32);
+                builder.i32_const(len as i32);
+                Ok(())
+            }
+            Value::Principal(_) | Value::Sequence(SequenceData::Buffer(_)) => {
+                let (offset, len) = self.add_literal(value)?;
+                builder.i32_const(offset as i32);
+                builder.i32_const(len as i32);
+                Ok(())
+            }
+            Value::Optional(opt) => {
+                let TypeSignature::OptionalType(inner_ty) = ty else {
+                    return Err(GeneratorError::InternalError(
+                        "Mismatched value/type".to_owned(),
+                    ));
+                };
+                match &opt.data {
+                    Some(inner) => {
+                        builder.i32_const(1);
+                        self.pass_value(builder, inner, inner_ty)?;
+                    }
+                    None => {
+                        builder.i32_const(0);
+                        add_placeholder_for_clarity_type(builder, inner_ty);
+                    }
+                }
+                Ok(())
+            }
+            Value::Response(resp) => {
+                let TypeSignature::ResponseType(resp_ty) = ty else {
+                    return Err(GeneratorError::InternalError(
+                        "Mismatched value/type".to_owned(),
+                    ));
+                };
+                builder.i32_const(resp.committed as i32);
+                if resp.committed {
+                    self.pass_value(builder, &resp.data, &resp_ty.0)?;
+                    add_placeholder_for_clarity_type(builder, &resp_ty.1);
+                } else {
+                    add_placeholder_for_clarity_type(builder, &resp_ty.0);
+                    self.pass_value(builder, &resp.data, &resp_ty.1)?;
+                }
+                Ok(())
+            }
+            Value::Tuple(tuple) => {
+                let TypeSignature::TupleType(tuple_ty) = ty else {
+                    return Err(GeneratorError::InternalError(
+                        "Mismatched value/type".to_owned(),
+                    ));
+                };
+                for (elem, elem_ty) in tuple
+                    .data_map
+                    .values()
+                    .zip(tuple_ty.get_type_map().values())
+                {
+                    self.pass_value(builder, elem, elem_ty)?;
+                }
+                Ok(())
+            }
+            Value::Sequence(SequenceData::List(list)) => {
+                let TypeSignature::SequenceType(SequenceSubtype::ListType(ltd)) = ty else {
+                    return Err(GeneratorError::InternalError(
+                        "Mismatched value/type".to_owned(),
+                    ));
+                };
+                let offset = self.module.locals.add(walrus::ValType::I32);
+
+                for value in list.data.iter().rev() {
+                    self.pass_value(builder, value, ltd.get_list_item_type())?;
+                }
+
+                builder.global_get(self.stack_pointer).local_set(offset);
+                let mut length = 0;
+                for _ in 0..list.data.len() {
+                    let written =
+                        self.write_to_memory(builder, offset, 0, ltd.get_list_item_type())?;
+                    builder
+                        .local_get(offset)
+                        .i32_const(written as i32)
+                        .binop(walrus::ir::BinaryOp::I32Add)
+                        .local_set(offset);
+                    length += written;
+                }
+
+                // the offset is already on the stack
+                builder
+                    .global_get(self.stack_pointer)
+                    .i32_const(length as i32);
+
+                builder.local_get(offset).global_set(self.stack_pointer);
+                Ok(())
+            }
+            #[allow(clippy::unimplemented)]
+            Value::CallableContract(_) => unimplemented!("We can already test principals"),
+        }
+    }
+
+    pub fn create_module(
+        &mut self,
+        return_ty: &TypeSignature,
+        mut add_instructions: impl FnMut(&mut Self, &mut InstrSeqBuilder),
+    ) {
+        let return_ty = clar2wasm_ty(return_ty);
+        let mut top_level = FunctionBuilder::new(&mut self.module.types, &[], &return_ty);
+
+        add_instructions(self, &mut top_level.func_body());
+
+        let top_level = top_level.finish(vec![], &mut self.module.funcs);
+        self.module.exports.add(".top-level", top_level);
+
+        // TODO: remove magic number 20000
+        self.module.globals.get_mut(self.stack_pointer).kind =
+            walrus::GlobalKind::Local(walrus::InitExpr::Value(walrus::ir::Value::I32(20000)));
+    }
+
+    pub fn execute_module(&mut self, return_ty: &TypeSignature) -> Value {
+        std::fs::write("debug.wasm", self.module.emit_wasm()).unwrap();
+
+        let engine = Engine::default();
+        let mut store = Store::new(&engine, ());
+        let linker = dummy_linker(&engine).expect("failed to create linker");
+        let module =
+            Module::new(&engine, self.module.emit_wasm()).expect("failed to create module");
+        let instance = linker
+            .instantiate(&mut store, &module)
+            .expect("failed to instanciate module");
+
+        let top_level = instance
+            .get_func(&mut store, ".top-level")
+            .expect("cannot find .top-level function");
+
+        let mut result: Vec<_> = top_level
+            .ty(&mut store)
+            .results()
+            .map(placeholder_for_type)
+            .collect();
+
+        top_level
+            .call(&mut store, &[], &mut result)
+            .expect("couldn't call .top-level");
+
+        let memory = instance
+            .get_memory(&mut store, "memory")
+            .expect("couldn't find memory");
+
+        wasm_to_clarity_value(
+            return_ty,
+            0,
+            &result,
+            memory,
+            &mut store,
+            StacksEpochId::latest(),
+        )
+        .expect("error in execution")
+        .0
+        .expect("no value computed???")
+    }
+}

--- a/clar2wasm/src/test_utils.rs
+++ b/clar2wasm/src/test_utils.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
 use clarity::types::StacksEpochId;
 use clarity::vm::analysis::ContractAnalysis;
 use clarity::vm::costs::LimitedCostTracker;

--- a/clar2wasm/tests/wasm-generation/main.rs
+++ b/clar2wasm/tests/wasm-generation/main.rs
@@ -23,6 +23,7 @@ pub mod regression;
 pub mod response;
 pub mod secp256k1;
 pub mod sequences;
+pub mod serialization_size;
 pub mod stx;
 pub mod tokens;
 pub mod traits;

--- a/clar2wasm/tests/wasm-generation/serialization_size.rs
+++ b/clar2wasm/tests/wasm-generation/serialization_size.rs
@@ -1,0 +1,57 @@
+use clar2wasm::wasm_generator::WasmGenerator;
+use clarity::vm::{
+    types::{TupleData, TupleTypeSignature, TypeSignature},
+    Value,
+};
+use proptest::prelude::*;
+
+use crate::{prop_signature, PropValue};
+
+proptest! {
+    #![proptest_config(super::runtime_config())]
+
+    #[test]
+    fn compare_serialization_size(
+        (ty, value) in prop_signature()
+            .prop_ind_flat_map2(|ty| PropValue::from_type(ty).prop_map_into())
+            .no_shrink()
+    ) {
+        let mut gen = WasmGenerator::empty();
+
+        // since `serialization_size` push on the stack the value and the size,
+        // we'll expect a tuple {a: value, b: size}
+        let return_ty: TypeSignature = TupleTypeSignature::try_from(vec![
+            ("a".into(), ty.clone()),
+            ("b".into(), TypeSignature::UIntType),
+        ])
+        .unwrap()
+        .into();
+
+        gen.create_module(&return_ty, |gen, builder| {
+            gen.pass_value(builder, &value, &ty)
+                .expect("failed to write instructions for original value");
+
+            gen.serialization_size(builder, &ty)
+                .expect("failed to write serialization size instructions");
+
+            // we need to extend the u32 we get for the size into a uint
+            builder
+                .unop(walrus::ir::UnaryOp::I64ExtendUI32)
+                .i64_const(0);
+        });
+
+        let res = gen.execute_module(&return_ty);
+
+        let expected_size = value
+            .serialized_size()
+            .expect("could not compute serialized size");
+        let expected = TupleData::from_data(vec![
+            ("a".into(), value),
+            ("b".into(), Value::UInt(expected_size as u128)),
+        ])
+        .unwrap()
+        .into();
+
+        assert_eq!(res, expected);
+    }
+}

--- a/clar2wasm/tests/wasm-generation/serialization_size.rs
+++ b/clar2wasm/tests/wasm-generation/serialization_size.rs
@@ -1,8 +1,6 @@
 use clar2wasm::wasm_generator::WasmGenerator;
-use clarity::vm::{
-    types::{TupleData, TupleTypeSignature, TypeSignature},
-    Value,
-};
+use clarity::vm::types::{TupleData, TupleTypeSignature, TypeSignature};
+use clarity::vm::Value;
 use proptest::prelude::*;
 
 use crate::{prop_signature, PropValue};


### PR DESCRIPTION
This PR adds a function `serialization_size` to compute the size of a serialized value.
@ureeves needs this for some cost values in the cost tracker implementation.

There is some reorganization of code here also, so that I could use the methods created to test the duck typing for the serialization size's testing as well.