### PR TITLE
FIx `NameAlreadyUsed` bug

### DIFF
--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
 use std::rc::Rc;
 
@@ -60,6 +60,8 @@ pub struct WasmGenerator {
     pub(crate) nft_types: HashMap<ClarityName, TypeSignature>,
     /// The (offsets, lengths) of trait IDs
     pub(crate) used_traits: HashMap<TraitIdentifier, (u32, u32)>,
+    /// The names of defined functions
+    pub(crate) defined_functions: HashSet<String>,
 
     /// The locals for the current function.
     pub(crate) bindings: Bindings,
@@ -341,6 +343,7 @@ impl WasmGenerator {
             local_pool: Rc::new(RefCell::new(HashMap::new())),
             nft_types: HashMap::new(),
             used_traits: HashMap::new(),
+            defined_functions: HashSet::new(),
         })
     }
 

--- a/clar2wasm/src/words/functions.rs
+++ b/clar2wasm/src/words/functions.rs
@@ -525,9 +525,7 @@ mod tests {
 (define-read-only (get-counter) (ok true))
         "#;
         let mut env = TestEnvironment::new(StacksEpochId::Epoch25, ClarityVersion::Clarity2);
-        env.init_contract_with_snippet("foo", foo)
-            .unwrap();
-        env.init_contract_with_snippet("bar", bar)
-            .unwrap();
+        env.init_contract_with_snippet("foo", foo).unwrap();
+        env.init_contract_with_snippet("bar", bar).unwrap();
     }
 }

--- a/clar2wasm/src/words/functions.rs
+++ b/clar2wasm/src/words/functions.rs
@@ -511,7 +511,7 @@ mod tests {
     }
 
     #[test]
-    fn false_duplicate_function_name() {
+    fn test_no_cross_contract_function_name_collision() {
         let foo = r#"
 (define-data-var counter uint u0)
 


### PR DESCRIPTION
This PR adds a `defined_functions` HashSet to prevent false duplicate name errors in `literal_memory`.

The issue was caused by `contract-call?`, which was saving the name of the function it calls into `literal_memory`. As a result, if the contract also defines a function with the same name, the compiler would wrongly throw a `NameAlreadyUsed` error.

Closes: #712 