### PR TITLE
fix: align with is-equal cost with interpreter

### DIFF
--- a/clar2wasm/src/cost.rs
+++ b/clar2wasm/src/cost.rs
@@ -1427,27 +1427,27 @@ mod word {
     });
     decl_tests!("index_of_list", "(index-of (list 1 2 3) 2)", {
         1 => CostMeter { runtime: 7000, read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
-        2 => CostMeter { runtime: 485,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
+        2 => CostMeter { runtime: 556,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
         3 => CostMeter { runtime: 490,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
     });
     decl_tests!("index_of_string_utf8", r#"(index-of u"hello" u"l")"#, {
         1 => CostMeter { runtime: 3000, read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
-        2 => CostMeter { runtime: 245,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
+        2 => CostMeter { runtime: 259,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
         3 => CostMeter { runtime: 227,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
     });
     decl_tests!("index_of_buff", r#"(index-of 0x1234567890 0x34)"#, {
         1 => CostMeter { runtime: 3000, read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
-        2 => CostMeter { runtime: 245,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
+        2 => CostMeter { runtime: 259,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
         3 => CostMeter { runtime: 227,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
     });
     decl_tests!("is_eq_signed_int", "(is-eq 1 1)", {
         1 => CostMeter { runtime: 3000, read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
-        2 => CostMeter { runtime: 186,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
+        2 => CostMeter { runtime: 410,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
         3 => CostMeter { runtime: 185,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
     });
     decl_tests!("is_eq_unsigned_int", "(is-eq u1 u1)", {
         1 => CostMeter { runtime: 3000, read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
-        2 => CostMeter { runtime: 186,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
+        2 => CostMeter { runtime: 410,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
         3 => CostMeter { runtime: 185,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
     });
     decl_tests!("is_eq_bool", "(is-eq true true)", {
@@ -1457,42 +1457,42 @@ mod word {
     });
     decl_tests!("is_eq_principal", "(is-eq 'ST1HTBVD3JG9C05J7HBJTHGR0GGW7KXW28M5JS8QE 'ST1HTBVD3JG9C05J7HBJTHGR0GGW7KXW28M5JS8QE)", {
         1 => CostMeter { runtime: 3000, read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
-        2 => CostMeter { runtime: 186,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
+        2 => CostMeter { runtime: 480,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
         3 => CostMeter { runtime: 195,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
     });
     decl_tests!("is_eq_buffer", "(is-eq 0x68656c6c6f21 0x68656c6c6f21)", {
         1 => CostMeter { runtime: 3000, read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
-        2 => CostMeter { runtime: 186,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
+        2 => CostMeter { runtime: 326,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
         3 => CostMeter { runtime: 173,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
     });
     decl_tests!("is_eq_ascii_string", "(is-eq \"This is an ASCII string\" \"This is an ASCII string\")", {
         1 => CostMeter { runtime: 3000, read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
-        2 => CostMeter { runtime: 186,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
+        2 => CostMeter { runtime: 564,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
         3 => CostMeter { runtime: 207,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
     });
     decl_tests!("is_eq_utf8_string", "(is-eq u\"And this is an UTF-8 string \\u{1f601}\" u\"And this is an UTF-8 string \\u{1f601}\")", {
         1 => CostMeter { runtime: 3000, read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
-        2 => CostMeter { runtime: 186,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
+        2 => CostMeter { runtime: 690,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
         3 => CostMeter { runtime: 225,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
     });
     decl_tests!("is_eq_list", "(is-eq (list 1 2 3) (list 1 2 3))", {
         1 => CostMeter { runtime: 11000, read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
-        2 => CostMeter { runtime: 666,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
+        2 => CostMeter { runtime: 1436,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
         3 => CostMeter { runtime: 675,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
     });
     decl_tests!("is_eq_optional", "(is-eq (some u5) (some u5))", {
         1 => CostMeter { runtime: 5000, read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
-        2 => CostMeter { runtime: 646,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
+        2 => CostMeter { runtime: 884,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
         3 => CostMeter { runtime: 585,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
     });
     decl_tests!("is_eq_tuple", "(is-eq {field1: 1, field2: (list 1 2 3)} {field1: 1, field2: (list 1 2 3)})", {
         1 => CostMeter { runtime: 17000, read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
-        2 => CostMeter { runtime: 2912,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
+        2 => CostMeter { runtime: 4186,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
         3 => CostMeter { runtime: 4539,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
     });
     decl_tests!("is_eq_error", "(is-eq (err u5) (err u5))", {
         1 => CostMeter { runtime: 5000, read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
-        2 => CostMeter { runtime: 646,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
+        2 => CostMeter { runtime: 884,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
         3 => CostMeter { runtime: 585,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
     });
     decl_tests!("map_definition", "(define-map squares { x: int } { y: int })", {
@@ -1609,7 +1609,7 @@ mod word {
                           (if (is-eq char 0x00) 0x00 0x01)) \
                         (map zero-or-one 0x000102)", {
         1 => CostMeter { runtime: 16000, read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
-        2 => CostMeter { runtime: 8102,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
+        2 => CostMeter { runtime: 8312,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
         3 => CostMeter { runtime: 7654,  read_count: 0, read_length: 0, write_count: 0, write_length: 0 },
     });
     decl_tests!("replace_at", "(replace-at? 0x00112233 u2 0x44)", {

--- a/clar2wasm/src/words/equal.rs
+++ b/clar2wasm/src/words/equal.rs
@@ -32,7 +32,7 @@ impl ComplexWord for IsEq {
         let serialization_size_sum = generator.module.locals.add(ValType::I32);
 
         check_args!(generator, builder, 1, args_len, ArgumentCountCheck::AtLeast);
-        if generator.contract_analysis.epoch <= StacksEpochId::Epoch2_05 {
+        if generator.contract_analysis.epoch < StacksEpochId::Epoch2_05 {
             self.charge(generator, builder, args_len as u32)?;
         }
 
@@ -53,7 +53,7 @@ impl ComplexWord for IsEq {
         for operand in args.iter() {
             generator.traverse_expr(builder, operand)?;
             // STACK: [operand]
-            if generator.contract_analysis.epoch > StacksEpochId::Epoch2_05 {
+            if generator.contract_analysis.epoch >= StacksEpochId::Epoch2_05 {
                 generator.serialization_size(builder, &ty)?;
                 // STACK: [operand, serialization_size]
                 builder
@@ -65,7 +65,7 @@ impl ComplexWord for IsEq {
         }
         // STACK: [operand1, ..., operandN]
 
-        if generator.contract_analysis.epoch > StacksEpochId::Epoch2_05 {
+        if generator.contract_analysis.epoch >= StacksEpochId::Epoch2_05 {
             self.charge(generator, builder, serialization_size_sum)?;
         }
 

--- a/clar2wasm/src/words/index_of.rs
+++ b/clar2wasm/src/words/index_of.rs
@@ -37,7 +37,7 @@ impl ComplexWord for IndexOf {
         let serialization_size = generator.module.locals.add(ValType::I32);
         check_args!(generator, builder, 2, args.len(), ArgumentCountCheck::Exact);
 
-        if generator.contract_analysis.epoch <= StacksEpochId::Epoch2_05 {
+        if generator.contract_analysis.epoch < StacksEpochId::Epoch2_05 {
             self.charge(generator, builder, args.len() as u32)?;
         }
 
@@ -65,7 +65,7 @@ impl ComplexWord for IndexOf {
             })?
             .clone();
 
-        if generator.contract_analysis.epoch > StacksEpochId::Epoch2_05 {
+        if generator.contract_analysis.epoch >= StacksEpochId::Epoch2_05 {
             generator.serialization_size(builder, &item_ty)?;
             // STACK: [item, item_serialization_size]
 
@@ -84,7 +84,7 @@ impl ComplexWord for IndexOf {
         // Get type of the Sequence element.
         let elem_ty = generator.get_sequence_element_type(seq)?;
 
-        if generator.contract_analysis.epoch > StacksEpochId::Epoch2_05 {
+        if generator.contract_analysis.epoch >= StacksEpochId::Epoch2_05 {
             let seq_type = generator
                 .get_expr_type(seq)
                 .ok_or_else(|| {


### PR DESCRIPTION
This PR contributes to #758 and follows from PR #761 where the motivation behind changing the cost of the operations can be found.

In #776 I learned that we actually do not want to use the serialization cost for epochs pre 2.05. This fixes the first implementation in equals.

I also fixed the version on which we charge with number of arguments vs serialization size. we do the later starting from 2.05 INCLUDED

