### PR TITLE
Update CI actions to use their commit hashes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,11 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Use Rust nightly with rustfmt
-        uses: dtolnay/rust-toolchain@nightly
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
+          toolchain: nightly
           components: rustfmt
 
       - run: cargo fmt -- --config group_imports=StdExternalCrate,imports_granularity=Module --check
@@ -36,10 +37,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Use Rust stable with clippy
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           components: clippy
 
@@ -56,16 +57,15 @@ jobs:
     name: Clarity::V${{ matrix.clarity_version }} Artifacts
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Use Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
 
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
-
-      - name: Install nextest
-        uses: taiki-e/install-action@nextest
+      - name: Install cargo-llvm-cov and nextest
+        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2.78.1
+        with:
+          tool: cargo-llvm-cov, nextest
 
       - name: Create archive of test binaries
         run: |
@@ -75,14 +75,14 @@ jobs:
             --archive-file nextest-archive-v${{ matrix.clarity_version }}.tar.zst
 
       - name: Upload test binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nextest-archive-v${{ matrix.clarity_version }}
           path: nextest-archive-v${{ matrix.clarity_version }}.tar.zst
           if-no-files-found: error
 
       - name: Upload standard.wasm file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: standard-v${{ matrix.clarity_version }}.wasm
           path: ${{github.workspace}}/clar2wasm/src/standard/standard.wasm
@@ -100,25 +100,24 @@ jobs:
     name: Clarity::V${{ matrix.clarity_version }} Tests
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Use Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
 
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
-
-      - name: Install nextest
-        uses: taiki-e/install-action@nextest
+      - name: Install cargo-llvm-cov and nextest
+        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2.78.1
+        with:
+          tool: cargo-llvm-cov, nextest
 
       - name: Download standard.wasm file
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: standard-v${{ matrix.clarity_version }}.wasm
           path: ${{github.workspace}}/clar2wasm/src/standard/
 
       - name: Download archive
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nextest-archive-v${{ matrix.clarity_version }}
 
@@ -131,7 +130,7 @@ jobs:
             --output-path codecov-v${{ matrix.clarity_version }}.json
 
       - name: Upload codecov.json
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: code-coverage-v${{ matrix.clarity_version }}
           path: codecov-v${{ matrix.clarity_version }}.json
@@ -170,13 +169,13 @@ jobs:
         working-directory: ./clar2wasm
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Use Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
 
       - name: Setup wasm-tools
-        uses: bytecodealliance/actions/wasm-tools/setup@v1
+        uses: bytecodealliance/actions/wasm-tools/setup@9152e710e9f7182e4c29ad218e4f335a7b203613 # v1.1.3
 
       - name: Compile boot-contracts
         run: |

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -19,13 +19,16 @@ jobs:
       PROPTEST_CASES: 100
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
 
       - name: Use Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
 
       - name: Install nextest
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2.78.1
+        with:
+          tool: nextest
 
       - name: Run Tests
         run: |


### PR DESCRIPTION
As the title says, this simply updates the CI workflows files so that we uses commit hashes for actions. This is now required by stx-labs.