### PR TITLE
Fix NameAlreadyUsed runtime errors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,10 +124,13 @@ jobs:
       - name: Run tests and output coverage
         shell: bash
         run: |
+          # --extract-overwrite: tolerate target/llvm-cov-target/target pre-existing
+          # (created during cargo-llvm-cov's clean/metadata phase before nextest extracts).
           cargo llvm-cov nextest \
             --archive-file nextest-archive-v${{ matrix.clarity_version }}.tar.zst \
             --codecov \
-            --output-path codecov-v${{ matrix.clarity_version }}.json
+            --output-path codecov-v${{ matrix.clarity_version }}.json \
+            --extract-overwrite
 
       - name: Upload codecov.json
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/clar2wasm/src/error_mapping.rs
+++ b/clar2wasm/src/error_mapping.rs
@@ -445,6 +445,9 @@ pub(crate) fn generate_name_already_used_error(
         .i32_const(ErrorMap::NameAlreadyUsed as i32)
         .call(generator.func_by_name("stdlib.runtime-error"));
 
+    // prevents type errors in the generated binary
+    builder.unreachable();
+
     Ok(())
 }
 

--- a/clar2wasm/src/error_mapping.rs
+++ b/clar2wasm/src/error_mapping.rs
@@ -447,3 +447,37 @@ pub(crate) fn generate_name_already_used_error(
 
     Ok(())
 }
+
+impl WasmGenerator {
+    pub(crate) fn is_already_used_name(&self, name: &ClarityName) -> bool {
+        trait HasClarityName {
+            fn has_key(&self, name: &ClarityName) -> bool;
+        }
+
+        impl<V> HasClarityName for std::collections::BTreeMap<ClarityName, V> {
+            fn has_key(&self, name: &ClarityName) -> bool {
+                self.contains_key(name)
+            }
+        }
+
+        impl HasClarityName for std::collections::BTreeSet<ClarityName> {
+            fn has_key(&self, name: &ClarityName) -> bool {
+                self.contains(name)
+            }
+        }
+
+        let ca = &self.contract_analysis;
+        let define_maps: [&dyn HasClarityName; _] = [
+            &ca.variable_types,
+            &ca.persisted_variable_types,
+            &ca.map_types,
+            &ca.fungible_tokens,
+            &ca.non_fungible_tokens,
+            &ca.defined_traits,
+        ];
+
+        self.is_reserved_name(name)
+            || self.defined_functions.contains(name.as_str())
+            || define_maps.into_iter().any(|hk| hk.has_key(name))
+    }
+}

--- a/clar2wasm/src/error_mapping.rs
+++ b/clar2wasm/src/error_mapping.rs
@@ -3,10 +3,15 @@ use clarity::vm::costs::CostErrors;
 use clarity::vm::errors::{CheckErrors, Error, RuntimeErrorType, ShortReturnType, WasmError};
 use clarity::vm::types::ResponseData;
 use clarity::vm::{ClarityVersion, Value};
+use clarity_types::types::{ASCIIData, CharType};
+use clarity_types::ClarityName;
+use walrus::InstrSeqBuilder;
 use wasmtime::{AsContextMut, Instance, Trap};
 
+use crate::wasm_generator::{GeneratorError, WasmGenerator};
 use crate::wasm_utils::{
-    read_bytes_from_wasm, read_from_wasm_indirect, read_identifier_from_wasm, signature_from_string,
+    get_global, read_bytes_from_wasm, read_from_wasm_indirect, read_identifier_from_wasm,
+    signature_from_string,
 };
 
 const LOG2_ERROR_MESSAGE: &str = "log2 must be passed a positive integer";
@@ -420,4 +425,25 @@ fn get_runtime_error_arg_lengths(
     .unwrap_or_else(|e| panic!("Could not recover arg_lengths: {e}"));
 
     extract_expected_and_got(&arg_lengths)
+}
+
+pub(crate) fn generate_name_already_used_error(
+    generator: &mut WasmGenerator,
+    builder: &mut InstrSeqBuilder,
+    name: &ClarityName,
+) -> Result<(), GeneratorError> {
+    let (arg_name_offset, arg_name_len) =
+        generator.add_clarity_string_literal(&CharType::ASCII(ASCIIData {
+            data: name.as_bytes().to_vec(),
+        }))?;
+
+    builder
+        .i32_const(arg_name_offset as i32)
+        .global_set(get_global(&generator.module, "runtime-error-arg-offset")?)
+        .i32_const(arg_name_len as i32)
+        .global_set(get_global(&generator.module, "runtime-error-arg-len")?)
+        .i32_const(ErrorMap::NameAlreadyUsed as i32)
+        .call(generator.func_by_name("stdlib.runtime-error"));
+
+    Ok(())
 }

--- a/clar2wasm/src/error_mapping.rs
+++ b/clar2wasm/src/error_mapping.rs
@@ -452,6 +452,10 @@ pub(crate) fn generate_name_already_used_error(
 }
 
 impl WasmGenerator {
+    /// Returns `true` if `name` is already claimed by another contract-level definition.
+    ///
+    /// Mirrors the interpreter's `ContractContext::is_name_used` so the compiler can emit a
+    /// `NameAlreadyUsed` runtime error for collisions the analyzer's `check_name_used` misses.
     pub(crate) fn is_already_used_name(&self, name: &ClarityName) -> bool {
         trait HasClarityName {
             fn has_key(&self, name: &ClarityName) -> bool;

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -2147,38 +2147,6 @@ impl WasmGenerator {
                     .find_map(|arg| (&arg.name == arg_name).then_some(&arg.signature))
             })
     }
-
-    pub(crate) fn is_already_used_name(&self, name: &ClarityName) -> bool {
-        let ca = &self.contract_analysis;
-        let define_maps: [&dyn HasClarityName; _] = [
-            &ca.variable_types,
-            &ca.persisted_variable_types,
-            &ca.map_types,
-            &ca.fungible_tokens,
-            &ca.non_fungible_tokens,
-            &ca.defined_traits,
-        ];
-
-        self.is_reserved_name(name)
-            || self.defined_functions.contains(name.as_str())
-            || define_maps.into_iter().any(|hk| hk.has_key(name))
-    }
-}
-
-pub(crate) trait HasClarityName {
-    fn has_key(&self, name: &ClarityName) -> bool;
-}
-
-impl<V> HasClarityName for BTreeMap<ClarityName, V> {
-    fn has_key(&self, name: &ClarityName) -> bool {
-        self.contains_key(name)
-    }
-}
-
-impl HasClarityName for std::collections::BTreeSet<ClarityName> {
-    fn has_key(&self, name: &ClarityName) -> bool {
-        self.contains(name)
-    }
 }
 
 /// Returns true if a composed type has an inner in-memory type.

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -2147,6 +2147,60 @@ impl WasmGenerator {
                     .find_map(|arg| (&arg.name == arg_name).then_some(&arg.signature))
             })
     }
+
+    pub(crate) fn is_already_used_name(
+        &self,
+        name: &ClarityName,
+        current_define: &dyn HasClarityName,
+    ) -> Result<bool, GeneratorError> {
+        let ca = &self.contract_analysis;
+        let mut define_maps: Vec<&dyn HasClarityName> = vec![
+            &ca.private_function_types,
+            &ca.public_function_types,
+            &ca.read_only_function_types,
+            &ca.variable_types,
+            &ca.persisted_variable_types,
+            &ca.map_types,
+            &ca.fungible_tokens,
+            &ca.non_fungible_tokens,
+            &ca.defined_traits,
+        ];
+        match define_maps.iter().position(|&hk| {
+            std::ptr::eq(
+                hk as *const dyn HasClarityName as *const (),
+                current_define as *const dyn HasClarityName as *const (),
+            )
+        }) {
+            Some(p) => {
+                define_maps.swap_remove(p);
+            }
+            None => {
+                return Err(GeneratorError::InternalError(
+                    "Invalid HasKey collection used in is_already_used_name".to_owned(),
+                ))
+            }
+        }
+
+        Ok(self.is_reserved_name(name)
+            || self.defined_functions.contains(name.as_str())
+            || define_maps.into_iter().any(|hk| hk.has_key(name)))
+    }
+}
+
+pub(crate) trait HasClarityName {
+    fn has_key(&self, name: &ClarityName) -> bool;
+}
+
+impl<V> HasClarityName for BTreeMap<ClarityName, V> {
+    fn has_key(&self, name: &ClarityName) -> bool {
+        self.contains_key(name)
+    }
+}
+
+impl HasClarityName for std::collections::BTreeSet<ClarityName> {
+    fn has_key(&self, name: &ClarityName) -> bool {
+        self.contains(name)
+    }
 }
 
 /// Returns true if a composed type has an inner in-memory type.

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -2148,16 +2148,9 @@ impl WasmGenerator {
             })
     }
 
-    pub(crate) fn is_already_used_name(
-        &self,
-        name: &ClarityName,
-        current_define: &dyn HasClarityName,
-    ) -> Result<bool, GeneratorError> {
+    pub(crate) fn is_already_used_name(&self, name: &ClarityName) -> bool {
         let ca = &self.contract_analysis;
-        let mut define_maps: Vec<&dyn HasClarityName> = vec![
-            &ca.private_function_types,
-            &ca.public_function_types,
-            &ca.read_only_function_types,
+        let define_maps: [&dyn HasClarityName; _] = [
             &ca.variable_types,
             &ca.persisted_variable_types,
             &ca.map_types,
@@ -2165,25 +2158,10 @@ impl WasmGenerator {
             &ca.non_fungible_tokens,
             &ca.defined_traits,
         ];
-        match define_maps.iter().position(|&hk| {
-            std::ptr::eq(
-                hk as *const dyn HasClarityName as *const (),
-                current_define as *const dyn HasClarityName as *const (),
-            )
-        }) {
-            Some(p) => {
-                define_maps.swap_remove(p);
-            }
-            None => {
-                return Err(GeneratorError::InternalError(
-                    "Invalid HasKey collection used in is_already_used_name".to_owned(),
-                ))
-            }
-        }
 
-        Ok(self.is_reserved_name(name)
+        self.is_reserved_name(name)
             || self.defined_functions.contains(name.as_str())
-            || define_maps.into_iter().any(|hk| hk.has_key(name)))
+            || define_maps.into_iter().any(|hk| hk.has_key(name))
     }
 }
 

--- a/clar2wasm/src/words/bindings.rs
+++ b/clar2wasm/src/words/bindings.rs
@@ -1,10 +1,10 @@
 use clarity::vm::{ClarityName, SymbolicExpression};
 
-use crate::check_args;
 use crate::cost::WordCharge;
 use crate::wasm_generator::{ArgumentsExt, GeneratorError, WasmGenerator};
 use crate::wasm_utils::ArgumentCountCheck;
 use crate::words::{ComplexWord, Word};
+use crate::{check_args, error_mapping};
 
 #[derive(Debug)]
 pub struct Let;
@@ -40,10 +40,8 @@ impl ComplexWord for Let {
             let name = pair.get_name(0)?;
             let value = pair.get_expr(1)?;
             // make sure name does not collide with builtin symbols
-            if generator.is_reserved_name(name) {
-                return Err(GeneratorError::InternalError(format!(
-                    "Name already used {name:?}"
-                )));
+            if generator.is_already_used_name(name) {
+                error_mapping::generate_name_already_used_error(generator, builder, name)?;
             }
 
             // Traverse the value

--- a/clar2wasm/src/words/bindings.rs
+++ b/clar2wasm/src/words/bindings.rs
@@ -89,7 +89,7 @@ impl ComplexWord for Let {
 
 #[cfg(test)]
 mod tests {
-    use clarity::vm::errors::{Error, ShortReturnType};
+    use clarity::vm::errors::{CheckErrors, Error, ShortReturnType};
     use clarity::vm::Value;
 
     use crate::tools::{crosscheck, crosscheck_compare_only, crosscheck_expect_failure, evaluate};
@@ -142,6 +142,56 @@ mod tests {
     test))";
 
         crosscheck_expect_failure(&format!("{ERR} (test)"));
+    }
+
+    #[test]
+    fn let_binding_collides_with_readonly_defined_later() {
+        crosscheck(
+            "
+                (define-public (caller) (let ((dup u0)) (ok dup)))
+                (define-read-only (dup) (ok u1))
+                (caller)
+            ",
+            Err(Error::Unchecked(CheckErrors::NameAlreadyUsed(
+                "dup".to_owned(),
+            ))),
+        );
+    }
+
+    #[test]
+    fn let_binding_collides_with_readonly_defined_before() {
+        crosscheck(
+            "
+                (define-read-only (dup) (ok u1))
+                (define-public (caller) (let ((dup u0)) (ok dup)))
+                (caller)
+            ",
+            Err(Error::Unchecked(CheckErrors::NameAlreadyUsed(
+                "dup".to_owned(),
+            ))),
+        );
+    }
+
+    #[test]
+    fn let_binding_colliding_with_readonly_deploys_when_uninvoked_later() {
+        crosscheck(
+            "
+                (define-public (caller) (let ((dup u0)) (ok dup)))
+                (define-read-only (dup) (ok u1))
+            ",
+            Ok(None),
+        );
+    }
+
+    #[test]
+    fn let_binding_colliding_with_readonly_deploys_when_uninvoked_before() {
+        crosscheck(
+            "
+                (define-read-only (dup) (ok u1))
+                (define-public (caller) (let ((dup u0)) (ok dup)))
+            ",
+            Ok(None),
+        );
     }
 
     #[test]

--- a/clar2wasm/src/words/bindings.rs
+++ b/clar2wasm/src/words/bindings.rs
@@ -41,7 +41,7 @@ impl ComplexWord for Let {
             let value = pair.get_expr(1)?;
             // make sure name does not collide with builtin symbols
             if generator.is_already_used_name(name) {
-                error_mapping::generate_name_already_used_error(generator, builder, name)?;
+                return error_mapping::generate_name_already_used_error(generator, builder, name);
             }
 
             // Traverse the value

--- a/clar2wasm/src/words/functions.rs
+++ b/clar2wasm/src/words/functions.rs
@@ -31,9 +31,7 @@ impl ComplexWord for DefinePrivateFunction {
         // Handling function name collision.
         // Detects duplicate names and generates
         // appropriate WebAssembly instructions to report the error.
-        if generator
-            .is_already_used_name(name, &generator.contract_analysis.private_function_types)?
-        {
+        if generator.is_already_used_name(name) {
             return error_mapping::generate_name_already_used_error(generator, builder, name);
         }
 
@@ -84,9 +82,7 @@ impl ComplexWord for DefineReadonlyFunction {
         // Handling function name collision.
         // Detects duplicate names and generates
         // appropriate WebAssembly instructions to report the error.
-        if generator
-            .is_already_used_name(name, &generator.contract_analysis.read_only_function_types)?
-        {
+        if generator.is_already_used_name(name) {
             return error_mapping::generate_name_already_used_error(generator, builder, name);
         }
 
@@ -127,9 +123,7 @@ impl ComplexWord for DefinePublicFunction {
         // Handling function name collision.
         // Detects duplicate names and generates
         // appropriate WebAssembly instructions to report the error.
-        if generator
-            .is_already_used_name(name, &generator.contract_analysis.public_function_types)?
-        {
+        if generator.is_already_used_name(name) {
             return error_mapping::generate_name_already_used_error(generator, builder, name);
         }
 

--- a/clar2wasm/src/words/functions.rs
+++ b/clar2wasm/src/words/functions.rs
@@ -560,6 +560,32 @@ mod tests {
     }
 
     #[test]
+    fn define_private_after_read_only_same_name() {
+        crosscheck(
+            r#"
+                (define-read-only (dup) (ok u1))
+                (define-private (dup) u2)
+            "#,
+            Err(Error::Unchecked(CheckErrors::NameAlreadyUsed(
+                "dup".to_string(),
+            ))),
+        )
+    }
+
+    #[test]
+    fn define_public_after_read_only_same_name() {
+        crosscheck(
+            r#"
+                (define-read-only (dup) (ok u1))
+                (define-public (dup) (ok u2))
+            "#,
+            Err(Error::Unchecked(CheckErrors::NameAlreadyUsed(
+                "dup".to_string(),
+            ))),
+        )
+    }
+
+    #[test]
     fn private_function_direct_call() {
         crosscheck(
             r#"

--- a/clar2wasm/src/words/functions.rs
+++ b/clar2wasm/src/words/functions.rs
@@ -516,6 +516,84 @@ mod tests {
     }
 
     #[test]
+    fn define_constant_after_read_only_same_name() {
+        crosscheck(
+            r#"
+                (define-constant dup u2)
+                (define-read-only (dup) (ok u1))
+            "#,
+            Err(Error::Unchecked(CheckErrors::NameAlreadyUsed(
+                "dup".to_string(),
+            ))),
+        )
+    }
+
+    #[test]
+    fn define_data_var_after_read_only_same_name() {
+        crosscheck(
+            r#"
+                (define-data-var dup uint u2)
+                (define-read-only (dup) (ok u1))
+            "#,
+            Err(Error::Unchecked(CheckErrors::NameAlreadyUsed(
+                "dup".to_string(),
+            ))),
+        )
+    }
+
+    #[test]
+    fn define_map_after_read_only_same_name() {
+        crosscheck(
+            r#"
+                (define-map dup uint uint)
+                (define-read-only (dup) (ok u1))
+            "#,
+            Err(Error::Unchecked(CheckErrors::NameAlreadyUsed(
+                "dup".to_string(),
+            ))),
+        )
+    }
+
+    #[test]
+    fn define_ft_after_read_only_same_name() {
+        crosscheck(
+            r#"
+                (define-fungible-token dup)
+                (define-read-only (dup) (ok u1))
+            "#,
+            Err(Error::Unchecked(CheckErrors::NameAlreadyUsed(
+                "dup".to_string(),
+            ))),
+        )
+    }
+
+    #[test]
+    fn define_nft_after_read_only_same_name() {
+        crosscheck(
+            r#"
+                (define-read-only (dup) (ok u1))
+                (define-non-fungible-token dup uint)
+            "#,
+            Err(Error::Unchecked(CheckErrors::NameAlreadyUsed(
+                "dup".to_string(),
+            ))),
+        )
+    }
+
+    #[test]
+    fn define_trait_after_read_only_same_name() {
+        crosscheck(
+            r#"
+                (define-trait dup ((f () (response uint uint))))
+                (define-read-only (dup) (ok u1))
+            "#,
+            Err(Error::Unchecked(CheckErrors::NameAlreadyUsed(
+                "dup".to_string(),
+            ))),
+        )
+    }
+
+    #[test]
     fn private_function_direct_call() {
         crosscheck(
             r#"

--- a/clar2wasm/src/words/functions.rs
+++ b/clar2wasm/src/words/functions.rs
@@ -498,6 +498,24 @@ mod tests {
     }
 
     #[test]
+    fn define_after_define_same_name() {
+        let def_type = ["read_only", "public", "private"];
+        for (def1, def2) in def_type.iter().zip(def_type) {
+            crosscheck(
+                &format!(
+                    r#"
+                        (define-{def1} (dup) (ok u1))
+                        (define-{def2} (dup) (ok u2))
+                    "#
+                ),
+                Err(Error::Unchecked(CheckErrors::NameAlreadyUsed(
+                    "dup".to_string(),
+                ))),
+            )
+        }
+    }
+
+    #[test]
     fn private_function_direct_call() {
         crosscheck(
             r#"

--- a/clar2wasm/src/words/functions.rs
+++ b/clar2wasm/src/words/functions.rs
@@ -1,13 +1,8 @@
-use clarity::vm::types::{ASCIIData, CharType};
-use clarity::vm::{ClarityName, SymbolicExpression};
-
 use super::{ComplexWord, Word};
-use crate::check_args;
-use crate::error_mapping::ErrorMap;
-use crate::wasm_generator::{
-    get_global, ArgumentsExt, FunctionKind, GeneratorError, WasmGenerator,
-};
+use crate::wasm_generator::{ArgumentsExt, FunctionKind, GeneratorError, WasmGenerator};
 use crate::wasm_utils::ArgumentCountCheck;
+use crate::{check_args, error_mapping};
+use clarity::vm::{ClarityName, SymbolicExpression};
 
 #[derive(Debug)]
 pub struct DefinePrivateFunction;
@@ -32,11 +27,14 @@ impl ComplexWord for DefinePrivateFunction {
             return Err(GeneratorError::NotImplemented);
         };
         let name = signature.get_name(0)?;
-        // Making sure name is not reserved
-        if generator.is_reserved_name(name) {
-            return Err(GeneratorError::InternalError(format!(
-                "Name already used {name:?}"
-            )));
+
+        // Handling function name collision.
+        // Detects duplicate names and generates
+        // appropriate WebAssembly instructions to report the error.
+        if generator
+            .is_already_used_name(name, &generator.contract_analysis.private_function_types)?
+        {
+            return error_mapping::generate_name_already_used_error(generator, builder, name);
         }
 
         let body = args.get_expr(1)?;
@@ -86,21 +84,10 @@ impl ComplexWord for DefineReadonlyFunction {
         // Handling function name collision.
         // Detects duplicate names and generates
         // appropriate WebAssembly instructions to report the error.
-        if generator.defined_functions.contains(&name.to_string()) {
-            let (arg_name_offset, arg_name_len) =
-                generator.add_clarity_string_literal(&CharType::ASCII(ASCIIData {
-                    data: name.as_bytes().to_vec(),
-                }))?;
-
-            builder
-                .i32_const(arg_name_offset as i32)
-                .global_set(get_global(&generator.module, "runtime-error-arg-offset")?)
-                .i32_const(arg_name_len as i32)
-                .global_set(get_global(&generator.module, "runtime-error-arg-len")?)
-                .i32_const(ErrorMap::NameAlreadyUsed as i32)
-                .call(generator.func_by_name("stdlib.runtime-error"));
-
-            return Ok(());
+        if generator
+            .is_already_used_name(name, &generator.contract_analysis.read_only_function_types)?
+        {
+            return error_mapping::generate_name_already_used_error(generator, builder, name);
         }
 
         let body = args.get_expr(1)?;
@@ -136,11 +123,14 @@ impl ComplexWord for DefinePublicFunction {
             return Err(GeneratorError::NotImplemented);
         };
         let name = signature.get_name(0)?;
-        // Making sure name is not reserved
-        if generator.is_reserved_name(name) {
-            return Err(GeneratorError::InternalError(format!(
-                "Name already used {name:?}"
-            )));
+
+        // Handling function name collision.
+        // Detects duplicate names and generates
+        // appropriate WebAssembly instructions to report the error.
+        if generator
+            .is_already_used_name(name, &generator.contract_analysis.public_function_types)?
+        {
+            return error_mapping::generate_name_already_used_error(generator, builder, name);
         }
 
         let body = args.get_expr(1)?;

--- a/clar2wasm/src/words/functions.rs
+++ b/clar2wasm/src/words/functions.rs
@@ -1,8 +1,9 @@
+use clarity::vm::{ClarityName, SymbolicExpression};
+
 use super::{ComplexWord, Word};
 use crate::wasm_generator::{ArgumentsExt, FunctionKind, GeneratorError, WasmGenerator};
 use crate::wasm_utils::ArgumentCountCheck;
 use crate::{check_args, error_mapping};
-use clarity::vm::{ClarityName, SymbolicExpression};
 
 #[derive(Debug)]
 pub struct DefinePrivateFunction;

--- a/clar2wasm/src/words/functions.rs
+++ b/clar2wasm/src/words/functions.rs
@@ -498,29 +498,11 @@ mod tests {
     }
 
     #[test]
-    fn define_after_define_same_name() {
-        let def_type = ["read_only", "public", "private"];
-        for (def1, def2) in def_type.iter().zip(def_type) {
-            crosscheck(
-                &format!(
-                    r#"
-                        (define-{def1} (dup) (ok u1))
-                        (define-{def2} (dup) (ok u2))
-                    "#
-                ),
-                Err(Error::Unchecked(CheckErrors::NameAlreadyUsed(
-                    "dup".to_string(),
-                ))),
-            )
-        }
-    }
-
-    #[test]
     fn define_constant_after_read_only_same_name() {
         crosscheck(
             r#"
-                (define-constant dup u2)
                 (define-read-only (dup) (ok u1))
+                (define-constant dup u2)
             "#,
             Err(Error::Unchecked(CheckErrors::NameAlreadyUsed(
                 "dup".to_string(),
@@ -532,8 +514,8 @@ mod tests {
     fn define_data_var_after_read_only_same_name() {
         crosscheck(
             r#"
-                (define-data-var dup uint u2)
                 (define-read-only (dup) (ok u1))
+                (define-data-var dup uint u2)
             "#,
             Err(Error::Unchecked(CheckErrors::NameAlreadyUsed(
                 "dup".to_string(),
@@ -545,8 +527,8 @@ mod tests {
     fn define_map_after_read_only_same_name() {
         crosscheck(
             r#"
-                (define-map dup uint uint)
                 (define-read-only (dup) (ok u1))
+                (define-map dup uint uint)
             "#,
             Err(Error::Unchecked(CheckErrors::NameAlreadyUsed(
                 "dup".to_string(),
@@ -558,8 +540,8 @@ mod tests {
     fn define_ft_after_read_only_same_name() {
         crosscheck(
             r#"
-                (define-fungible-token dup)
                 (define-read-only (dup) (ok u1))
+                (define-fungible-token dup)
             "#,
             Err(Error::Unchecked(CheckErrors::NameAlreadyUsed(
                 "dup".to_string(),
@@ -584,8 +566,8 @@ mod tests {
     fn define_trait_after_read_only_same_name() {
         crosscheck(
             r#"
-                (define-trait dup ((f () (response uint uint))))
                 (define-read-only (dup) (ok u1))
+                (define-trait dup ((f () (response uint uint))))
             "#,
             Err(Error::Unchecked(CheckErrors::NameAlreadyUsed(
                 "dup".to_string(),


### PR DESCRIPTION
There are cases where the static analysis doesn’t find a `NameAlreadyUsed` error and this one is found at deployment.
For the compiler, this means that this kind of errors should generate a `runtime-error`.

The cases where it happens are:

- If a read-only function has the same name as a trait, constant, data-var, nft or ft and they are defined before.
- if a binding in a `let` expression has the same name as a function.

This PR adds a check to find those cases, a function to generate a runtime-error, and tests.

Fixes #655 