### PR TITLE
Fix overwrites in `WasmGenerator::pass_value`

### DIFF
--- a/clar2wasm/src/test_utils.rs
+++ b/clar2wasm/src/test_utils.rs
@@ -173,9 +173,9 @@ impl WasmGenerator {
         let top_level = top_level.finish(vec![], &mut self.module.funcs);
         self.module.exports.add(".top-level", top_level);
 
-        // TODO: remove magic number 20000
-        self.module.globals.get_mut(self.stack_pointer).kind =
-            walrus::GlobalKind::Local(walrus::InitExpr::Value(walrus::ir::Value::I32(20000)));
+        self.module.globals.get_mut(self.stack_pointer).kind = walrus::GlobalKind::Local(
+            walrus::InitExpr::Value(walrus::ir::Value::I32(self.literal_memory_end as i32)),
+        );
     }
 
     /// Compiles and executes the current module and returns the value on top of the stack.


### PR DESCRIPTION
Fixes #797 

There was a magic number used for the value of `stack-pointer` after `WasmGenerator::create_module`. Using the logical correct value there fixes the bug.

No test was added here, but the failing test due to this bug `clar2wasm::wasm-generation::copy::copy_value` didn’t trigger after 5000 iterations.