### PR TITLE
New function `secp256r1-verify`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
     needs: [fmt, clippy]
     strategy:
       matrix:
-        clarity_version: [1, 2, 3, 4]
+        clarity_version: [1, 2, 3, 4, 5]
 
     name: Clarity::V${{ matrix.clarity_version }} Artifacts
     steps:
@@ -96,7 +96,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clarity_version: [1, 2, 3, 4]
+        clarity_version: [1, 2, 3, 4, 5]
     name: Clarity::V${{ matrix.clarity_version }} Tests
     steps:
       - name: Checkout PR

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clarity_version: [1, 2, 3]
+        clarity_version: [1, 2, 3, 4, 5]
     name: Clarity::V${{ matrix.clarity_version }} Property Tests
     env:
       PROPTEST_CASES: 100

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#bfc6423b2a8ae7b0a96a1c0f1f5f484609f57a54"
+source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#d87bfebaa56d70b31c955ef3835712cc5bda34e9"
 dependencies = [
  "clarity-types",
  "hashbrown 0.15.5",
@@ -489,7 +489,7 @@ dependencies = [
 [[package]]
 name = "clarity-types"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#bfc6423b2a8ae7b0a96a1c0f1f5f484609f57a54"
+source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#d87bfebaa56d70b31c955ef3835712cc5bda34e9"
 dependencies = [
  "lazy_static",
  "regex",
@@ -2647,7 +2647,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#bfc6423b2a8ae7b0a96a1c0f1f5f484609f57a54"
+source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#d87bfebaa56d70b31c955ef3835712cc5bda34e9"
 dependencies = [
  "chrono",
  "curve25519-dalek",

--- a/clar2wasm/Cargo.toml
+++ b/clar2wasm/Cargo.toml
@@ -32,6 +32,7 @@ test-clarity-v1 = []
 test-clarity-v2 = []
 test-clarity-v3 = []
 test-clarity-v4 = []
+test-clarity-v5 = []
 developer-mode = []
 
 [dev-dependencies]

--- a/clar2wasm/src/error_mapping.rs
+++ b/clar2wasm/src/error_mapping.rs
@@ -6,15 +6,15 @@ use clarity::vm::errors::{
 };
 use clarity::vm::types::ResponseData;
 use clarity::vm::{ClarityVersion, Value};
-use clarity_types::types::{ASCIIData, CharType};
+use clarity_types::types::{ASCIIData, CharType, TypeSignature};
 use clarity_types::{ClarityName, ClarityTypeError};
 use walrus::InstrSeqBuilder;
 use wasmtime::{AsContextMut, Instance, Trap};
 
 use crate::wasm_generator::{GeneratorError, WasmGenerator};
 use crate::wasm_utils::{
-    get_global, read_bytes_from_wasm, read_from_wasm_indirect, read_identifier_from_wasm,
-    signature_from_string,
+    get_global, read_bytes_from_wasm, read_from_wasm, read_from_wasm_indirect,
+    read_identifier_from_wasm, signature_from_string,
 };
 
 const LOG2_ERROR_MESSAGE: &str = "log2 must be passed a positive integer";
@@ -90,6 +90,13 @@ pub enum ErrorMap {
     /// Indicates an attempt to use a function with too many arguments
     SequenceElementArityMismatch = 16,
 
+    /// Value should be a buffer of a different size
+    /// Arguments:
+    ///  - expected buffer size in $runtime-error-value-offset
+    ///  - actual buffer offset in $runtime-error-arg-offset
+    ///  - actual buffer size in $runtime-error-arg-len
+    IncorrectBufferSize = 17,
+
     /// Indicates a runtime cost overrun
     CostOverrunRuntime = 100,
 
@@ -137,6 +144,7 @@ impl From<i32> for ErrorMap {
             14 => ErrorMap::ArgumentCountAtLeast,
             15 => ErrorMap::ArgumentCountAtMost,
             16 => ErrorMap::SequenceElementArityMismatch,
+            17 => ErrorMap::IncorrectBufferSize,
             100 => ErrorMap::CostOverrunRuntime,
             101 => ErrorMap::CostOverrunReadCount,
             102 => ErrorMap::CostOverrunReadLength,
@@ -315,6 +323,37 @@ fn from_runtime_error_code(
             VmExecutionError::RuntimeCheck(
                 ClarityTypeError::SequenceElementArityMismatch { expected, found }.into(),
             )
+        }
+        ErrorMap::IncorrectBufferSize => {
+            let expected_size =
+                get_global_i32(&instance, &mut store, "runtime-error-value-offset") as u32;
+            let actual_offset = get_global_i32(&instance, &mut store, "runtime-error-arg-offset");
+            let actual_length = get_global_i32(&instance, &mut store, "runtime-error-arg-len");
+
+            let memory = instance
+                .get_memory(&mut store, "memory")
+                .unwrap_or_else(|| panic!("Could not find wasm instance memory"));
+
+            let actual_buffer = read_from_wasm(
+                memory,
+                &mut store,
+                &TypeSignature::BUFFER_MAX,
+                actual_offset,
+                actual_length,
+                *epoch_id,
+            )
+            .unwrap_or_else(|e| panic!("Could not read thrown value from memory: {e}"));
+            RuntimeCheckErrorKind::TypeValueError(
+                Box::new(TypeSignature::SequenceType(
+                    clarity_types::types::SequenceSubtype::BufferType(
+                        expected_size.try_into().unwrap_or_else(|e| {
+                            panic!("Passed an invalid size for an expected buffer error: {e}")
+                        }),
+                    ),
+                )),
+                actual_buffer.to_error_string(),
+            )
+            .into()
         }
         ErrorMap::CostOverrunRuntime => VmExecutionError::from(CostErrors::CostOverflow),
         ErrorMap::CostOverrunReadCount => VmExecutionError::from(CostErrors::CostOverflow),

--- a/clar2wasm/src/linker.rs
+++ b/clar2wasm/src/linker.rs
@@ -1,5 +1,6 @@
 use std::io::{Cursor, Write as _};
 
+use clarity::util::secp256r1::{secp256r1_verify, secp256r1_verify_digest};
 use clarity::vm::callables::{DefineType, DefinedFunction};
 use clarity::vm::clarity_wasm::{Cost, CostGlobals};
 use clarity::vm::contexts::{ExecutionState, InvocationContext};
@@ -165,6 +166,8 @@ pub fn link_host_functions(
     link_sha512_256_fn(linker)?;
     link_secp256k1_recover_fn(linker)?;
     link_secp256k1_verify_fn(linker)?;
+    link_secp256r1_verify_double_hash_fn(linker)?;
+    link_secp256r1_verify_simple_hash_fn(linker)?;
     link_principal_of_fn(linker)?;
     link_save_constant_fn(linker)?;
     link_load_constant_fn(linker)?;
@@ -5944,6 +5947,88 @@ fn link_secp256k1_verify_fn(
         })
 }
 
+fn link_secp256r1_verify_double_hash_fn(
+    linker: &mut Linker<ClarityWasmContext>,
+) -> Result<(), VmExecutionError> {
+    linker
+        .func_wrap(
+            "clarity",
+            "secp256r1_verify_double_hash",
+            |mut caller: Caller<'_, ClarityWasmContext>,
+             msg_offset: i32,
+             msg_length: i32,
+             sig_offset: i32,
+             sig_length: i32,
+             pk_offset: i32,
+             pk_length: i32| {
+                // Get the memory from the caller
+                let memory = caller
+                    .get_export("memory")
+                    .and_then(|export| export.into_memory())
+                    .ok_or(VmExecutionError::Wasm(WasmError::MemoryNotFound))?;
+
+                // Read the message bytes from the memory
+                let msg_bytes = read_bytes_from_wasm(memory, &mut caller, msg_offset, msg_length)?;
+
+                // Read the signature bytes from the memory
+                let sig_bytes = read_bytes_from_wasm(memory, &mut caller, sig_offset, sig_length)?;
+
+                // Read the public-key bytes from the memory
+                let pk_bytes = read_bytes_from_wasm(memory, &mut caller, pk_offset, pk_length)?;
+
+                Ok(secp256r1_verify(&msg_bytes, &sig_bytes, &pk_bytes).is_ok() as i32)
+            },
+        )
+        .map(|_| ())
+        .map_err(|e| {
+            VmExecutionError::Wasm(WasmError::UnableToLinkHostFunction(
+                "secp256r1_verify_double_hash".to_string(),
+                e,
+            ))
+        })
+}
+
+fn link_secp256r1_verify_simple_hash_fn(
+    linker: &mut Linker<ClarityWasmContext>,
+) -> Result<(), VmExecutionError> {
+    linker
+        .func_wrap(
+            "clarity",
+            "secp256r1_verify_simple_hash",
+            |mut caller: Caller<'_, ClarityWasmContext>,
+             msg_offset: i32,
+             msg_length: i32,
+             sig_offset: i32,
+             sig_length: i32,
+             pk_offset: i32,
+             pk_length: i32| {
+                // Get the memory from the caller
+                let memory = caller
+                    .get_export("memory")
+                    .and_then(|export| export.into_memory())
+                    .ok_or(VmExecutionError::Wasm(WasmError::MemoryNotFound))?;
+
+                // Read the message bytes from the memory
+                let msg_bytes = read_bytes_from_wasm(memory, &mut caller, msg_offset, msg_length)?;
+
+                // Read the signature bytes from the memory
+                let sig_bytes = read_bytes_from_wasm(memory, &mut caller, sig_offset, sig_length)?;
+
+                // Read the public-key bytes from the memory
+                let pk_bytes = read_bytes_from_wasm(memory, &mut caller, pk_offset, pk_length)?;
+
+                Ok(secp256r1_verify_digest(&msg_bytes, &sig_bytes, &pk_bytes).is_ok() as i32)
+            },
+        )
+        .map(|_| ())
+        .map_err(|e| {
+            VmExecutionError::Wasm(WasmError::UnableToLinkHostFunction(
+                "secp256r1_verify_simple_hash".to_string(),
+                e,
+            ))
+        })
+}
+
 /// Link host interface function, `principal_of`, into the Wasm module.
 /// This function is called for the Clarity expression, `principal-of?`.
 fn link_principal_of_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), VmExecutionError> {
@@ -7061,6 +7146,34 @@ pub fn dummy_linker(engine: &Engine) -> Result<Linker<()>, wasmtime::Error> {
          _pk_offset: i32,
          _pk_length: i32| {
             println!("secp256k1_verify");
+            Ok(0i32)
+        },
+    )?;
+
+    linker.func_wrap(
+        "clarity",
+        "secp256r1_verify_double_hash",
+        |_msg_offset: i32,
+         _msg_length: i32,
+         _sig_offset: i32,
+         _sig_length: i32,
+         _pk_offset: i32,
+         _pk_length: i32| {
+            println!("secp256r1_verify_double_hash");
+            Ok(0i32)
+        },
+    )?;
+
+    linker.func_wrap(
+        "clarity",
+        "secp256r1_verify_simple_hash",
+        |_msg_offset: i32,
+         _msg_length: i32,
+         _sig_offset: i32,
+         _sig_length: i32,
+         _pk_offset: i32,
+         _pk_length: i32| {
+            println!("secp256r1_verify_simple_hash");
             Ok(0i32)
         },
     )?;

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -315,6 +315,24 @@
                                                                  (param $pk_offset i32)
                                                                  (param $pk_length i32)
                                                                  (result i32)))
+
+    (import "clarity" "secp256r1_verify_double_hash" (func $stdlib.secp256r1_verify_double_hash 
+                                                                 (param $msg_offset i32)
+                                                                 (param $msg_length i32)
+                                                                 (param $sig_offset i32)
+                                                                 (param $sig_length i32)
+                                                                 (param $pk_offset i32)
+                                                                 (param $pk_length i32)
+                                                                 (result i32)))
+
+    (import "clarity" "secp256r1_verify_simple_hash" (func $stdlib.secp256r1_verify_simple_hash
+                                                                 (param $msg_offset i32)
+                                                                 (param $msg_length i32)
+                                                                 (param $sig_offset i32)
+                                                                 (param $sig_length i32)
+                                                                 (param $pk_offset i32)
+                                                                 (param $pk_length i32)
+                                                                 (result i32)))
     (import "clarity" "principal_of" (func $stdlib.principal_of (param $key_offset i32)
                                                                 (param $key_length i32)
                                                                 (param $principal_offset i32)

--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -510,6 +510,7 @@ impl TestConfig {
             _ if cfg!(feature = "test-clarity-v2") => ClarityVersion::Clarity2,
             _ if cfg!(feature = "test-clarity-v3") => ClarityVersion::Clarity3,
             _ if cfg!(feature = "test-clarity-v4") => ClarityVersion::Clarity4,
+            _ if cfg!(feature = "test-clarity-v5") => ClarityVersion::Clarity5,
             _ => ClarityVersion::latest(),
         }
     }

--- a/clar2wasm/src/words/mod.rs
+++ b/clar2wasm/src/words/mod.rs
@@ -34,6 +34,7 @@ pub mod principal;
 pub mod print;
 pub mod responses;
 pub mod secp256k1;
+pub mod secp256r1;
 pub mod sequences;
 pub mod stx;
 pub mod to_ascii;
@@ -115,6 +116,7 @@ pub(crate) static COMPLEX_WORDS: &[&'static dyn ComplexWord] = &[
     &responses::IsOk,
     &secp256k1::Recover,
     &secp256k1::Verify,
+    &secp256r1::Verify,
     &sequences::Append,
     &sequences::AsMaxLen,
     &sequences::Concat,

--- a/clar2wasm/src/words/secp256r1.rs
+++ b/clar2wasm/src/words/secp256r1.rs
@@ -208,7 +208,6 @@ mod tests {
     /// (*double hashing*).
     #[cfg(feature = "test-clarity-v4")]
     mod clarity_v4 {
-        use clarity::types::StacksEpochId;
         use clarity::util::hash::to_hex;
         use clarity::util::secp256r1::{Secp256r1PrivateKey, Secp256r1PublicKey};
         use clarity::vm::errors::{RuntimeCheckErrorKind, VmExecutionError};
@@ -217,22 +216,14 @@ mod tests {
         };
         use clarity::vm::Value;
 
-        use crate::tools::crosscheck_with_epoch;
-
-        // TODO Remove this
-        /// Epoch 33 is the latest epoch that still accepts Clarity 4;
-        /// the `test-clarity-v4` feature makes `crosscheck_with_epoch`
-        /// resolve the version to Clarity 4.
-        fn crosscheck_v4(snippet: &str, expected: Result<Option<Value>, VmExecutionError>) {
-            crosscheck_with_epoch(snippet, expected, StacksEpochId::Epoch33);
-        }
+        use crate::tools::crosscheck;
 
         #[test]
         fn message_too_short() {
             let short_msg = vec![0xabu8; 31];
             let sig = vec![0u8; 64];
             let pubkey = vec![0u8; 33];
-            crosscheck_v4(
+            crosscheck(
                 &format!(
                     "(secp256r1-verify 0x{} 0x{} 0x{})",
                     to_hex(&short_msg),
@@ -258,7 +249,7 @@ mod tests {
             let msg = vec![0u8; 32];
             let short_sig = vec![0u8; 63];
             let pubkey = vec![0u8; 33];
-            crosscheck_v4(
+            crosscheck(
                 &format!(
                     "(secp256r1-verify 0x{} 0x{} 0x{})",
                     to_hex(&msg),
@@ -274,7 +265,7 @@ mod tests {
             let msg = vec![0u8; 32];
             let sig = vec![0u8; 64];
             let short_pubkey = vec![0xcdu8; 32];
-            crosscheck_v4(
+            crosscheck(
                 &format!(
                     "(secp256r1-verify 0x{} 0x{} 0x{})",
                     to_hex(&msg),
@@ -300,7 +291,7 @@ mod tests {
             let msg = [0x11u8; 32];
             // `sign` double-hashes, matching the Clarity 4 verification.
             let sig = privk.sign(&msg).unwrap();
-            crosscheck_v4(
+            crosscheck(
                 &format!(
                     "(secp256r1-verify 0x{} 0x{} 0x{})",
                     to_hex(&msg),
@@ -318,7 +309,7 @@ mod tests {
             let msg = [0x11u8; 32];
             let sig = privk.sign(&msg).unwrap();
             let wrong_msg = [0x22u8; 32];
-            crosscheck_v4(
+            crosscheck(
                 &format!(
                     "(secp256r1-verify 0x{} 0x{} 0x{})",
                     to_hex(&wrong_msg),
@@ -336,7 +327,7 @@ mod tests {
             let sig = privk.sign(&msg).unwrap();
             let other_pub =
                 Secp256r1PublicKey::from_private(&Secp256r1PrivateKey::from_seed(&[2u8; 32]));
-            crosscheck_v4(
+            crosscheck(
                 &format!(
                     "(secp256r1-verify 0x{} 0x{} 0x{})",
                     to_hex(&msg),
@@ -355,7 +346,7 @@ mod tests {
             let pubk = Secp256r1PublicKey::from_private(&privk);
             let msg = [0x11u8; 32];
             let sig = privk.sign_digest(&msg).unwrap();
-            crosscheck_v4(
+            crosscheck(
                 &format!(
                     "(secp256r1-verify 0x{} 0x{} 0x{})",
                     to_hex(&msg),

--- a/clar2wasm/src/words/secp256r1.rs
+++ b/clar2wasm/src/words/secp256r1.rs
@@ -163,3 +163,363 @@ impl ComplexWord for Verify {
         Ok(())
     }
 }
+
+#[cfg(test)]
+#[cfg(not(any(
+    feature = "test-clarity-v1",
+    feature = "test-clarity-v2",
+    feature = "test-clarity-v3"
+)))]
+mod tests {
+
+    use crate::tools::evaluate;
+
+    #[test]
+    fn less_than_three_args() {
+        let result = evaluate(
+                "(secp256r1-verify \
+                 0xde5b9eb9e7c5592930eb2e30a01369c36586d872082ed8181ee83d2a0ec20f04 \
+                 0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000)",
+            );
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("expecting 3 arguments, got 2"));
+    }
+
+    #[test]
+    fn more_than_three_args() {
+        let result = evaluate(
+                "(secp256r1-verify \
+                 0xde5b9eb9e7c5592930eb2e30a01369c36586d872082ed8181ee83d2a0ec20f04 \
+                 0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 \
+                 0x000000000000000000000000000000000000000000000000000000000000000000 \
+                 0x000000000000000000000000000000000000000000000000000000000000000000)",
+            );
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("expecting 3 arguments, got 4"));
+    }
+
+    /// Clarity 4: the message hash is SHA256-hashed again before verification
+    /// (*double hashing*).
+    #[cfg(feature = "test-clarity-v4")]
+    mod clarity_v4 {
+        use clarity::types::StacksEpochId;
+        use clarity::util::hash::to_hex;
+        use clarity::util::secp256r1::{Secp256r1PrivateKey, Secp256r1PublicKey};
+        use clarity::vm::errors::{RuntimeCheckErrorKind, VmExecutionError};
+        use clarity::vm::types::{
+            BuffData, BufferLength, SequenceData, SequenceSubtype, TypeSignature,
+        };
+        use clarity::vm::Value;
+
+        use crate::tools::crosscheck_with_epoch;
+
+        // TODO Remove this
+        /// Epoch 33 is the latest epoch that still accepts Clarity 4;
+        /// the `test-clarity-v4` feature makes `crosscheck_with_epoch`
+        /// resolve the version to Clarity 4.
+        fn crosscheck_v4(snippet: &str, expected: Result<Option<Value>, VmExecutionError>) {
+            crosscheck_with_epoch(snippet, expected, StacksEpochId::Epoch33);
+        }
+
+        #[test]
+        fn message_too_short() {
+            let short_msg = vec![0xabu8; 31];
+            let sig = vec![0u8; 64];
+            let pubkey = vec![0u8; 33];
+            crosscheck_v4(
+                &format!(
+                    "(secp256r1-verify 0x{} 0x{} 0x{})",
+                    to_hex(&short_msg),
+                    to_hex(&sig),
+                    to_hex(&pubkey)
+                ),
+                Err(VmExecutionError::RuntimeCheck(
+                    RuntimeCheckErrorKind::TypeValueError(
+                        Box::new(TypeSignature::SequenceType(SequenceSubtype::BufferType(
+                            BufferLength::try_from(32_u32).unwrap(),
+                        ))),
+                        Value::Sequence(SequenceData::Buffer(BuffData { data: short_msg }))
+                            .to_error_string(),
+                    ),
+                )),
+            );
+        }
+
+        #[test]
+        fn signature_too_short() {
+            // A signature that is shorter than 64 bytes is not a runtime error:
+            // the word returns `false`.
+            let msg = vec![0u8; 32];
+            let short_sig = vec![0u8; 63];
+            let pubkey = vec![0u8; 33];
+            crosscheck_v4(
+                &format!(
+                    "(secp256r1-verify 0x{} 0x{} 0x{})",
+                    to_hex(&msg),
+                    to_hex(&short_sig),
+                    to_hex(&pubkey)
+                ),
+                Ok(Some(Value::Bool(false))),
+            );
+        }
+
+        #[test]
+        fn public_key_too_short() {
+            let msg = vec![0u8; 32];
+            let sig = vec![0u8; 64];
+            let short_pubkey = vec![0xcdu8; 32];
+            crosscheck_v4(
+                &format!(
+                    "(secp256r1-verify 0x{} 0x{} 0x{})",
+                    to_hex(&msg),
+                    to_hex(&sig),
+                    to_hex(&short_pubkey)
+                ),
+                Err(VmExecutionError::RuntimeCheck(
+                    RuntimeCheckErrorKind::TypeValueError(
+                        Box::new(TypeSignature::SequenceType(SequenceSubtype::BufferType(
+                            BufferLength::try_from(33_u32).unwrap(),
+                        ))),
+                        Value::Sequence(SequenceData::Buffer(BuffData { data: short_pubkey }))
+                            .to_error_string(),
+                    ),
+                )),
+            );
+        }
+
+        #[test]
+        fn valid_signature() {
+            let privk = Secp256r1PrivateKey::from_seed(&[1u8; 32]);
+            let pubk = Secp256r1PublicKey::from_private(&privk);
+            let msg = [0x11u8; 32];
+            // `sign` double-hashes, matching the Clarity 4 verification.
+            let sig = privk.sign(&msg).unwrap();
+            crosscheck_v4(
+                &format!(
+                    "(secp256r1-verify 0x{} 0x{} 0x{})",
+                    to_hex(&msg),
+                    to_hex(&sig.0),
+                    to_hex(&pubk.to_bytes_compressed())
+                ),
+                Ok(Some(Value::Bool(true))),
+            );
+        }
+
+        #[test]
+        fn wrong_message() {
+            let privk = Secp256r1PrivateKey::from_seed(&[1u8; 32]);
+            let pubk = Secp256r1PublicKey::from_private(&privk);
+            let msg = [0x11u8; 32];
+            let sig = privk.sign(&msg).unwrap();
+            let wrong_msg = [0x22u8; 32];
+            crosscheck_v4(
+                &format!(
+                    "(secp256r1-verify 0x{} 0x{} 0x{})",
+                    to_hex(&wrong_msg),
+                    to_hex(&sig.0),
+                    to_hex(&pubk.to_bytes_compressed())
+                ),
+                Ok(Some(Value::Bool(false))),
+            );
+        }
+
+        #[test]
+        fn wrong_key() {
+            let privk = Secp256r1PrivateKey::from_seed(&[1u8; 32]);
+            let msg = [0x11u8; 32];
+            let sig = privk.sign(&msg).unwrap();
+            let other_pub =
+                Secp256r1PublicKey::from_private(&Secp256r1PrivateKey::from_seed(&[2u8; 32]));
+            crosscheck_v4(
+                &format!(
+                    "(secp256r1-verify 0x{} 0x{} 0x{})",
+                    to_hex(&msg),
+                    to_hex(&sig.0),
+                    to_hex(&other_pub.to_bytes_compressed())
+                ),
+                Ok(Some(Value::Bool(false))),
+            );
+        }
+
+        #[test]
+        fn simple_hash_signature_is_rejected() {
+            // A signature produced for the simple-hashing scheme (`sign_digest`)
+            // must not verify under the double-hashing scheme.
+            let privk = Secp256r1PrivateKey::from_seed(&[1u8; 32]);
+            let pubk = Secp256r1PublicKey::from_private(&privk);
+            let msg = [0x11u8; 32];
+            let sig = privk.sign_digest(&msg).unwrap();
+            crosscheck_v4(
+                &format!(
+                    "(secp256r1-verify 0x{} 0x{} 0x{})",
+                    to_hex(&msg),
+                    to_hex(&sig.0),
+                    to_hex(&pubk.to_bytes_compressed())
+                ),
+                Ok(Some(Value::Bool(false))),
+            );
+        }
+    }
+
+    #[cfg(not(any(
+        feature = "test-clarity-v1",
+        feature = "test-clarity-v2",
+        feature = "test-clarity-v3",
+        feature = "test-clarity-v4"
+    )))]
+    mod clarity_ge_v5 {
+        use clarity::util::hash::to_hex;
+        use clarity::util::secp256r1::{Secp256r1PrivateKey, Secp256r1PublicKey};
+        use clarity::vm::errors::{RuntimeCheckErrorKind, VmExecutionError};
+        use clarity::vm::types::{
+            BuffData, BufferLength, SequenceData, SequenceSubtype, TypeSignature,
+        };
+        use clarity::vm::Value;
+
+        use crate::tools::crosscheck;
+
+        #[test]
+        fn message_too_short() {
+            let short_msg = vec![0xabu8; 31];
+            let sig = vec![0u8; 64];
+            let pubkey = vec![0u8; 33];
+            crosscheck(
+                &format!(
+                    "(secp256r1-verify 0x{} 0x{} 0x{})",
+                    to_hex(&short_msg),
+                    to_hex(&sig),
+                    to_hex(&pubkey)
+                ),
+                Err(VmExecutionError::RuntimeCheck(
+                    RuntimeCheckErrorKind::TypeValueError(
+                        Box::new(TypeSignature::SequenceType(SequenceSubtype::BufferType(
+                            BufferLength::try_from(32_u32).unwrap(),
+                        ))),
+                        Value::Sequence(SequenceData::Buffer(BuffData { data: short_msg }))
+                            .to_error_string(),
+                    ),
+                )),
+            );
+        }
+
+        #[test]
+        fn signature_too_short() {
+            // A signature that is shorter than 64 bytes is not a runtime error:
+            // the word returns `false`.
+            let msg = vec![0u8; 32];
+            let short_sig = vec![0u8; 63];
+            let pubkey = vec![0u8; 33];
+            crosscheck(
+                &format!(
+                    "(secp256r1-verify 0x{} 0x{} 0x{})",
+                    to_hex(&msg),
+                    to_hex(&short_sig),
+                    to_hex(&pubkey)
+                ),
+                Ok(Some(Value::Bool(false))),
+            );
+        }
+
+        #[test]
+        fn public_key_too_short() {
+            let msg = vec![0u8; 32];
+            let sig = vec![0u8; 64];
+            let short_pubkey = vec![0xcdu8; 32];
+            crosscheck(
+                &format!(
+                    "(secp256r1-verify 0x{} 0x{} 0x{})",
+                    to_hex(&msg),
+                    to_hex(&sig),
+                    to_hex(&short_pubkey)
+                ),
+                Err(VmExecutionError::RuntimeCheck(
+                    RuntimeCheckErrorKind::TypeValueError(
+                        Box::new(TypeSignature::SequenceType(SequenceSubtype::BufferType(
+                            BufferLength::try_from(33_u32).unwrap(),
+                        ))),
+                        Value::Sequence(SequenceData::Buffer(BuffData { data: short_pubkey }))
+                            .to_error_string(),
+                    ),
+                )),
+            );
+        }
+
+        #[test]
+        fn valid_signature() {
+            let privk = Secp256r1PrivateKey::from_seed(&[1u8; 32]);
+            let pubk = Secp256r1PublicKey::from_private(&privk);
+            let msg = [0x11u8; 32];
+            let sig = privk.sign_digest(&msg).unwrap();
+            crosscheck(
+                &format!(
+                    "(secp256r1-verify 0x{} 0x{} 0x{})",
+                    to_hex(&msg),
+                    to_hex(&sig.0),
+                    to_hex(&pubk.to_bytes_compressed())
+                ),
+                Ok(Some(Value::Bool(true))),
+            );
+        }
+
+        #[test]
+        fn wrong_message() {
+            let privk = Secp256r1PrivateKey::from_seed(&[1u8; 32]);
+            let pubk = Secp256r1PublicKey::from_private(&privk);
+            let msg = [0x11u8; 32];
+            let sig = privk.sign_digest(&msg).unwrap();
+            let wrong_msg = [0x22u8; 32];
+            crosscheck(
+                &format!(
+                    "(secp256r1-verify 0x{} 0x{} 0x{})",
+                    to_hex(&wrong_msg),
+                    to_hex(&sig.0),
+                    to_hex(&pubk.to_bytes_compressed())
+                ),
+                Ok(Some(Value::Bool(false))),
+            );
+        }
+
+        #[test]
+        fn wrong_key() {
+            let privk = Secp256r1PrivateKey::from_seed(&[1u8; 32]);
+            let msg = [0x11u8; 32];
+            let sig = privk.sign_digest(&msg).unwrap();
+            let other_pub =
+                Secp256r1PublicKey::from_private(&Secp256r1PrivateKey::from_seed(&[2u8; 32]));
+            crosscheck(
+                &format!(
+                    "(secp256r1-verify 0x{} 0x{} 0x{})",
+                    to_hex(&msg),
+                    to_hex(&sig.0),
+                    to_hex(&other_pub.to_bytes_compressed())
+                ),
+                Ok(Some(Value::Bool(false))),
+            );
+        }
+
+        #[test]
+        fn double_hash_signature_is_rejected() {
+            // A signature produced for the double-hashing scheme (`sign`) must
+            // not verify under the simple-hashing scheme.
+            let privk = Secp256r1PrivateKey::from_seed(&[1u8; 32]);
+            let pubk = Secp256r1PublicKey::from_private(&privk);
+            let msg = [0x11u8; 32];
+            let sig = privk.sign(&msg).unwrap();
+            crosscheck(
+                &format!(
+                    "(secp256r1-verify 0x{} 0x{} 0x{})",
+                    to_hex(&msg),
+                    to_hex(&sig.0),
+                    to_hex(&pubk.to_bytes_compressed())
+                ),
+                Ok(Some(Value::Bool(false))),
+            );
+        }
+    }
+}

--- a/clar2wasm/src/words/secp256r1.rs
+++ b/clar2wasm/src/words/secp256r1.rs
@@ -1,0 +1,165 @@
+use clarity_types::ClarityName;
+use walrus::ir::{BinaryOp, Block};
+use walrus::ValType;
+
+use crate::check_args;
+use crate::error_mapping::ErrorMap;
+use crate::wasm_generator::GeneratorError;
+use crate::wasm_utils::get_global;
+use crate::words::{ComplexWord, Word};
+
+#[derive(Debug)]
+pub struct Verify;
+
+impl Word for Verify {
+    fn name(&self) -> clarity_types::ClarityName {
+        ClarityName::from_literal("secp256r1-verify")
+    }
+}
+
+impl ComplexWord for Verify {
+    fn traverse(
+        &self,
+        generator: &mut crate::wasm_generator::WasmGenerator,
+        builder: &mut walrus::InstrSeqBuilder,
+        _expr: &clarity::vm::SymbolicExpression,
+        args: &[clarity::vm::SymbolicExpression],
+    ) -> Result<(), GeneratorError> {
+        check_args!(
+            generator,
+            builder,
+            3,
+            args.len(),
+            crate::wasm_utils::ArgumentCountCheck::Exact
+        );
+
+        let [message_hash, signature, public_key] = args else {
+            unreachable!()
+        };
+
+        let verify_function = generator.func_by_name(
+            if generator
+                .contract_analysis
+                .clarity_version
+                .uses_secp256r1_double_hashing()
+            {
+                "stdlib.secp256r1_verify_double_hash"
+            } else {
+                "stdlib.secp256r1_verify_simple_hash"
+            },
+        );
+
+        let outer_block_id = {
+            let mut outer_block = builder.dangling_instr_seq(ValType::I32);
+            let outer_block_id = outer_block.id();
+
+            let expected_buffer_size = generator.borrow_local(ValType::I32);
+            let actual_buffer_offset = generator.borrow_local(ValType::I32);
+            let actual_buffer_size = generator.borrow_local(ValType::I32);
+
+            let inner_block_id = {
+                let mut inner_block = outer_block.dangling_instr_seq(None);
+                let inner_block_id = inner_block.id();
+
+                // handling message hash
+                generator.traverse_expr(&mut inner_block, message_hash)?;
+                inner_block
+                    .local_set(*actual_buffer_size)
+                    .local_set(*actual_buffer_offset);
+                inner_block.i32_const(32).local_set(*expected_buffer_size);
+                inner_block
+                    .local_get(*expected_buffer_size)
+                    .local_get(*actual_buffer_size)
+                    .binop(BinaryOp::I32Ne)
+                    .br_if(inner_block_id);
+                inner_block
+                    .local_get(*actual_buffer_offset)
+                    .local_get(*actual_buffer_size);
+
+                // handling signature
+                generator.traverse_expr(&mut inner_block, signature)?;
+                inner_block
+                    .local_set(*actual_buffer_size)
+                    .local_set(*actual_buffer_offset);
+                inner_block.i32_const(64).local_set(*expected_buffer_size);
+                inner_block
+                    .local_get(*expected_buffer_size)
+                    .local_get(*actual_buffer_size)
+                    .binop(BinaryOp::I32LtU)
+                    .br_if(inner_block_id);
+                // if signature size is different from 64, it's an automatic false result
+                inner_block
+                    .local_get(*expected_buffer_size)
+                    .local_get(*actual_buffer_size)
+                    .binop(BinaryOp::I32Ne)
+                    .if_else(
+                        None,
+                        |then| {
+                            // we push a false
+                            then.i32_const(0);
+                            // we branch to the end of the computation: branching
+                            // to the (i32-typed) outer block keeps the false we
+                            // just pushed and unwinds the message hash offset and
+                            // size still sitting on the stack.
+                            then.br(outer_block_id);
+                        },
+                        |_else| {},
+                    );
+                inner_block
+                    .local_get(*actual_buffer_offset)
+                    .local_get(*actual_buffer_size);
+
+                // handling public key
+                generator.traverse_expr(&mut inner_block, public_key)?;
+                inner_block
+                    .local_set(*actual_buffer_size)
+                    .local_set(*actual_buffer_offset);
+                inner_block.i32_const(33).local_set(*expected_buffer_size);
+                inner_block
+                    .local_get(*expected_buffer_size)
+                    .local_get(*actual_buffer_size)
+                    .binop(BinaryOp::I32Ne)
+                    .br_if(inner_block_id);
+                inner_block
+                    .local_get(*actual_buffer_offset)
+                    .local_get(*actual_buffer_size);
+
+                // calling the secp256r1 verify function
+                inner_block.call(verify_function);
+
+                // we can now go to the end of the computation
+                inner_block.br(outer_block_id);
+
+                inner_block_id
+            };
+
+            outer_block.instr(Block {
+                seq: inner_block_id,
+            });
+
+            // if we arrive here, we have to throw a runtime error.
+            outer_block
+                .local_get(*expected_buffer_size)
+                .global_set(get_global(&generator.module, "runtime-error-value-offset")?);
+            outer_block
+                .local_get(*actual_buffer_offset)
+                .global_set(get_global(&generator.module, "runtime-error-arg-offset")?);
+            outer_block
+                .local_get(*actual_buffer_size)
+                .global_set(get_global(&generator.module, "runtime-error-arg-len")?);
+            outer_block
+                .i32_const(ErrorMap::IncorrectBufferSize as i32)
+                .call(generator.func_by_name("stdlib.runtime-error"));
+
+            outer_block.unreachable();
+
+            outer_block_id
+        };
+
+        builder.instr(Block {
+            seq: outer_block_id,
+        });
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Here is the new function `secp256r1-verify`. It is implemented both with the double-hash for Clarity 4 and the simple hash for Clarity 5.

Nothing special in this PR, just the implementation of a new word.
Still, a little opinionated choice here, for the runtime error this function could throw. The interpreter returns a `TypeValueError` (which makes no sense, a buffer value with a smaller size can still be of the correct type). I decided to create a dedicated runtime error for wasm, `IncorrectBufferSize`, because the original error requires a lot of memory when thrown (we need the expected type). Here we only need the expected size, since we already know we have a buffer.

Closes #811 

This PR also adds the required changes in CI to test Clarity 5 features.

This is a draft:

- ~~We still need to be able to test for Clarity 4 (for now, we have a hack for it) #814~~ DONE
- ~~We could have a few proptests, modeled on the `secp256k1-verify` ones~~ (not needed, the function should be tested in the clarity dependency)
- ~~We need to duplicate the new linked functions in stacks-core~~ here https://github.com/stacks-network/stacks-core/pull/7473
- ~~For the CI, I forgot to add Clarity 5 tests to the scheduled runs~~ DONE