### PR TITLE
Fix `contract-hash?` generated proptest issue

### DIFF
--- a/clar2wasm/tests/wasm-generation/contracts.rs
+++ b/clar2wasm/tests/wasm-generation/contracts.rs
@@ -681,8 +681,9 @@ proptest! {
                 let func_name = if name.is_empty()
                     || name.len() == 1
                     || (name.starts_with('u') && name.chars().nth(1).is_some_and(|c| c.is_ascii_digit()))
+                    || clarity::vm::is_reserved(&name, &TestConfig::clarity_version())
                 {
-                    format!("func{}", idx)
+                    format!("func-{}", idx)
                 } else {
                     name
                 };


### PR DESCRIPTION
The proptest `contracts::contract_hash_returns_correct_hash_for_any_contract` was creating a few user-defined functions in a contract.

Here, the functions could clash with a reserved keyword, which would make the test fail.

This PR adds two little fixes:
- make sure we don't use a reserved keyword
- if the function name is invalid for whatever reason, the substitute name should have no chance to be a generated name too.